### PR TITLE
fix(directory): point seeds at dmp.<apex> served zones

### DIFF
--- a/directory/seeds.txt
+++ b/directory/seeds.txt
@@ -23,5 +23,5 @@
 # this repo just gives the project a public "first directory" so a
 # fresh operator has somewhere to look immediately.
 
-dnsmesh.io
-dnsmesh.pro
+dmp.dnsmesh.io
+dmp.dnsmesh.pro


### PR DESCRIPTION
The public reference nodes publish heartbeats under
\`dmp.dnsmesh.io\` and \`dmp.dnsmesh.pro\` (their \`DMP_DOMAIN\`),
not the apex domains. The seeds.txt entries pointed at the bare
apex, so the aggregator queried \`_dnsmesh-heartbeat.dnsmesh.io\`
(empty) instead of \`_dnsmesh-heartbeat.dmp.dnsmesh.io\` (where
the wire actually lives).

Verified the wire path works when queried directly against the
node IPs:

\`\`\`
_dnsmesh-heartbeat.dmp.dnsmesh.io  → 1 signed HeartbeatRecord wire
_dnsmesh-heartbeat.dmp.dnsmesh.pro → 1 signed HeartbeatRecord wire
\`\`\`

This fix is necessary but not sufficient. Public resolvers also
need the \`dmp.<apex>\` subzone delegated at each registrar
(NS-with-glue records pointing at the node IP) before they can
find these records via the recursive chain. Until delegation
lands, the aggregator gets empty responses even with the correct
seed names. Delegation is operator-side; see
[\`docs/deployment/dns-delegation.md\`](https://github.com/oscarvalenzuelab/DNSMeshProtocol/blob/main/docs/deployment/dns-delegation.md).