### PR TITLE
fix(heartbeat): align render-path ts_skew with publish path

### DIFF
--- a/dmp/server/http_api.py
+++ b/dmp/server/http_api.py
@@ -333,9 +333,7 @@ class _DMPHttpHandler(BaseHTTPRequestHandler):
         merged: dict = {}
         for r in rows:
             try:
-                rec = HeartbeatRecord.parse_and_verify(
-                    r.wire, ts_skew_seconds=10**9
-                )
+                rec = HeartbeatRecord.parse_and_verify(r.wire, ts_skew_seconds=10**9)
             except Exception:
                 continue
             if rec is None:

--- a/dmp/server/http_api.py
+++ b/dmp/server/http_api.py
@@ -321,10 +321,21 @@ class _DMPHttpHandler(BaseHTTPRequestHandler):
         rows = store.list_recent(limit=limit)
 
         # (operator_spk, endpoint) -> DirectoryRow, keeping the highest ts.
+        # ts_skew_seconds=10**9 matches the seen-graph publish path
+        # in heartbeat_worker._publish_seen_graph: store.list_recent
+        # already filtered on `exp > now`, so any wire we're rendering
+        # is by construction unexpired. Without the override, the
+        # default 300s skew rejected peer wires whose `ts` was more
+        # than 5 minutes ago — a node with a slower harvest cadence
+        # than 5 min would render an empty peer list (or only its
+        # own self-row, since the self-row is synthesized below) even
+        # though _dnsmesh-seen.<zone> showed the full peer set.
         merged: dict = {}
         for r in rows:
             try:
-                rec = HeartbeatRecord.parse_and_verify(r.wire)
+                rec = HeartbeatRecord.parse_and_verify(
+                    r.wire, ts_skew_seconds=10**9
+                )
             except Exception:
                 continue
             if rec is None:


### PR DESCRIPTION
## Bug

Live observation: \`https://dnsmesh.io/\` rendered "Recent peers (1)" (its own self-row only), while \`https://dnsmesh.pro/\` rendered "Recent peers (2)" (self + dnsmesh.io). Both nodes' \`_dnsmesh-seen.<zone>\` RRsets actually carried both peers verified.

So the asymmetry was display-side timing luck, not a real seen-graph difference.

## Cause

\`dmp/server/http_api.py:327\` called \`HeartbeatRecord.parse_and_verify(wire)\` with the default \`ts_skew_seconds=300\`. The publish path (\`heartbeat_worker._publish_seen_graph\`) already uses \`ts_skew_seconds=10**9\` because \`store.list_recent\` has filtered on \`exp > now\` — any wire surfacing through that path is by construction unexpired.

Result: a node whose harvest of a peer was more than 5 minutes ago renders an empty peer table (or only its synthesized self-row) even though the peer is live in the SeenStore and being republished in the seen-graph RRset.

## Fix

One-line equivalent: pass \`ts_skew_seconds=10**9\` on the render path so the read-side accepts any unexpired wire. The wire's security property is the Ed25519 signature + the \`exp\` field — both still enforced.

## Verification

- Existing \`tests/test_landing*\` and heartbeat tests: 119 passed, 0 failed.
- After deploy, \`dnsmesh.io\` should render 2 peers (self + dnsmesh.pro) consistently.

## Deploy note

The live nodes pick this up via \`docker pull && docker compose up -d\` (or whatever orchestration the operator uses). No data migration; the fix is render-path-only.

## Bigger picture

This is one of three issues found while investigating why the directory aggregator returned empty:

1. **(this PR)** render-path skew rejection — display bug, fixed here.
2. **#8 / fix/seeds-served-zones** — \`directory/seeds.txt\` pointed at \`dnsmesh.io\`/\`dnsmesh.pro\` (apex) instead of \`dmp.dnsmesh.io\`/\`dmp.dnsmesh.pro\` (served zones).
3. **Operator action** — \`dmp.<apex>\` subzone is not delegated at the registrar (DigitalOcean) so public resolvers can't reach the heartbeat. Walked through in \`docs/deployment/dns-delegation.md\`.

Once all three land, the public directory at \`/DNSMeshProtocol/directory/\` will populate with both reference nodes.