### PR TITLE
docs: link the public node directory from README + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Curious what a node currently publishes:
 dig _dnsmesh-heartbeat.dmp.dnsmesh.io TXT +short
 ```
 
+A live, signature-verified directory of every DMP node currently
+advertising itself on the public DNS chain:
+**[https://ovalenzuela.com/DNSMeshProtocol/directory/](https://ovalenzuela.com/DNSMeshProtocol/directory/)**.
+Rebuilt every 30 minutes by an aggregator that queries
+`_dnsmesh-heartbeat.<seed>` + `_dnsmesh-seen.<seed>` from a
+federated seed list (`directory/seeds.txt`); anyone can run their
+own aggregator off the same data.
+
 Full walkthrough with troubleshooting in
 [Getting Started](https://oscarvalenzuelab.github.io/DNSMeshProtocol/getting-started).
 

--- a/docs/deployment/heartbeat.md
+++ b/docs/deployment/heartbeat.md
@@ -37,6 +37,15 @@ re-exports at `GET /v1/nodes/seen` so any aggregator (including
 a central directory website) can union the public state
 deterministically.
 
+The canonical project-hosted directory rendered off this signed
+P2P data is at
+[https://ovalenzuela.com/DNSMeshProtocol/directory/](https://ovalenzuela.com/DNSMeshProtocol/directory/),
+refreshed every 30 minutes by a workflow running
+[`examples/directory_aggregator.py`](https://github.com/oscarvalenzuelab/DNSMeshProtocol/blob/main/examples/directory_aggregator.py)
+against [`directory/seeds.txt`](https://github.com/oscarvalenzuelab/DNSMeshProtocol/blob/main/directory/seeds.txt).
+For a node to appear there, get listed in any node's seen-graph
+that's reachable from a seed (or PR a new seed yourself).
+
 If you don't want to be listed in any public directory: don't
 enable heartbeat. The feature is fully opt-in and nothing on the
 protocol's critical path depends on it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,13 @@ Self-hosting gets the same capabilities via
 `deploy/native-ubuntu/install.sh`. Both modes interoperate over DNS;
 the public node is a reference, not a dependency.
 
+A live, signature-verified directory of nodes currently advertising
+on the public DNS chain lives at
+[`/directory/`]({{ site.baseurl }}/directory/) — rebuilt every 30
+minutes from `directory/seeds.txt`. The aggregator is open source
+and federated; anyone can run their own off the same signed P2P
+data ([reference implementation](https://github.com/oscarvalenzuelab/DNSMeshProtocol/blob/main/examples/directory_aggregator.py)).
+
 ---
 
 ## What it is


### PR DESCRIPTION
Adds a discoverable pointer to [https://ovalenzuela.com/DNSMeshProtocol/directory/](https://ovalenzuela.com/DNSMeshProtocol/directory/) from:

- **README.md** — "Try it" section, after the `dig` example.
- **docs/index.md** — "Use dnsmesh.io as your starting point" section.
- **docs/deployment/heartbeat.md** — heartbeat-layer overview.

The directory page itself has been live for a while; this just makes it discoverable via the entry surfaces instead of relying on URL guessing.