### PR TITLE
feat(directory): rich HTML page — node cards, topology, resolver matrix

### DIFF
--- a/examples/directory_aggregator.py
+++ b/examples/directory_aggregator.py
@@ -1,27 +1,23 @@
 #!/usr/bin/env python3
-"""Simple directory aggregator for M5.8 heartbeats (DNS-native, post-M9).
+"""Directory aggregator for M5.8 heartbeats (DNS-native, post-M9).
 
-Reads a list of seed zone names, queries ``_dnsmesh-seen.<zone>``
-for each over the public recursive DNS chain, verifies every
-returned HeartbeatRecord, unions them by (operator_spk, endpoint),
-and emits:
+Reads a list of seed zone names, queries ``_dnsmesh-heartbeat.<zone>``
+and ``_dnsmesh-seen.<zone>`` for each over the public recursive DNS
+chain, verifies every returned ``HeartbeatRecord``, and writes:
 
-  - A signed JSON feed at ``$OUT_DIR/feed.json``.
-  - A static HTML index at ``$OUT_DIR/index.html`` grouping nodes by
-    last-seen age.
+  - ``$OUT_DIR/feed.json`` — signed, deterministic JSON feed.
+  - ``$OUT_DIR/index.html`` — static directory page with a node
+    overview, geo + hosting metadata, a federation topology graph
+    (heartbeat-discovery edges, NOT message traffic), and a public-
+    resolver reachability matrix.
 
-The aggregator is fully deterministic — same seeds + same input
-wires produces byte-identical outputs. Anyone can run one off the
-same signed P2P data, so the operator-hosted central directory is
-one consumer, not a trust anchor.
+The aggregator is fully deterministic: same seeds + same upstream
+state produces byte-identical outputs (modulo the
+``generated_at`` timestamp). Anyone can run their own off the same
+signed P2P data, so the project-hosted directory is one consumer,
+not a trust anchor.
 
-This used to fetch ``GET /v1/nodes/seen`` over HTTPS; M9 (0.5.0)
-removed that route and moved the seen-graph onto the DNS side at
-``_dnsmesh-seen.<zone>`` (multi-value TXT, each value a signed
-HeartbeatRecord wire). This script is the matching DNS-native
-consumer.
-
-Typical deployment: cron or systemd timer calls this every N
+Typical deployment: cron or a CI workflow calls this every N
 minutes, writes the output to a directory served by your static
 hosting of choice (GitHub Pages, S3, nginx).
 
@@ -43,9 +39,13 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import socket
 import sys
 import time
-from dataclasses import dataclass
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from html import escape as html_escape
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -63,14 +63,31 @@ from dmp.server.heartbeat_worker import (  # noqa: E402
 log = logging.getLogger("dmp-directory-aggregator")
 
 
+# Curated public resolvers for the reachability matrix. These are the
+# best-known anycast public DNS services; any client behind a network
+# that allows DNS at all can reach at least one of them. The matrix
+# demonstrates that DMP records resolve correctly through the public
+# recursive chain; it is NOT meant to imply this list is "the
+# resolver network" (it isn't — every internet-connected resolver
+# can do the same query).
+_RESOLVERS: List[Tuple[str, str]] = [
+    ("Cloudflare", "1.1.1.1"),
+    ("Google", "8.8.8.8"),
+    ("Quad9", "9.9.9.9"),
+    ("OpenDNS", "208.67.222.222"),
+    ("Level3", "4.2.2.2"),
+    ("Yandex", "77.88.8.8"),
+]
+
+
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class AggregatedNode:
     """One deduped, verified listing entry the HTML + JSON render
-    against. Verified = signature-verified at aggregation time,
-    but consumers of feed.json MUST re-verify the embedded wire."""
+    against. Verified = signature-verified at aggregation time, but
+    consumers of feed.json MUST re-verify the embedded wire."""
 
     operator_spk_hex: str
     endpoint: str
@@ -78,7 +95,22 @@ class AggregatedNode:
     ts: int
     exp: int
     wire: str
-    last_seen_via: List[str]  # source nodes that reported this entry
+    last_seen_via: List[str]
+    geo: Optional[Dict] = None
+    host: Optional[Dict] = None
+
+
+@dataclass(frozen=True)
+class ResolverCheck:
+    """One (resolver, zone) reachability test result."""
+
+    resolver_name: str
+    resolver_addr: str
+    zone: str
+    endpoint: Optional[str]
+    ok: bool
+    latency_ms: Optional[int]
+    detail: str
 
 
 # ---------------------------------------------------------------------------
@@ -94,28 +126,29 @@ def _normalize_seed_to_zone(seed: str) -> Optional[str]:
     if "://" in s:
         host = urlparse(s).hostname
         return host.lower() if host else None
-    # Strip a trailing slash if someone wrote `dmp.example.com/`.
     return s.rstrip("/").lower()
 
 
-def _fetch_zone_wires(reader: ResolverPool, zone: str) -> Iterable[str]:
-    """Yield every HeartbeatRecord wire reachable from ``zone`` —
-    BOTH the seed's own self-row at ``_dnsmesh-heartbeat.<zone>``
-    AND the seed's republished seen-graph at
-    ``_dnsmesh-seen.<zone>``.
+def _fetch_zone_wires(reader: ResolverPool, zone: str) -> Iterable[Tuple[str, str]]:
+    """Yield ``(source_label, wire)`` for each HeartbeatRecord
+    reachable from ``zone``.
 
-    Why both: the seen-graph republishes only OTHER peers the seed
-    has heard from. A healthy single-node seed (or a seed during a
-    partition where it hears nobody) leaves the seen RRset empty,
-    so reading only that path silently drops the seed itself from
-    the directory. The heartbeat RRset is where the seed publishes
-    its own self-signed wire on every tick. Reading both is what
-    the old HTTP ``/v1/nodes/seen`` endpoint did before M9 removed
-    it.
+    Sources, in order:
+      - ``"heartbeat"`` — the seed's own self-row at
+        ``_dnsmesh-heartbeat.<zone>``.
+      - ``"seen"`` — the seed's republished view of OTHER peers at
+        ``_dnsmesh-seen.<zone>``.
+
+    Reading both is what the pre-M9 ``GET /v1/nodes/seen`` HTTP
+    endpoint did before the route was removed. Reading only the
+    seen-graph drops the seed itself when it has heard no peers.
+    Source labels let the caller distinguish self-rows (no
+    federation edge) from peer-discovery wires (an edge from this
+    seed to that peer).
     """
-    for name_fn, label in (
-        (heartbeat_rrset_name, "_dnsmesh-heartbeat"),
-        (seen_rrset_name, "_dnsmesh-seen"),
+    for name_fn, source_label, public_label in (
+        (heartbeat_rrset_name, "heartbeat", "_dnsmesh-heartbeat"),
+        (seen_rrset_name, "seen", "_dnsmesh-seen"),
     ):
         try:
             name = name_fn(zone)
@@ -128,32 +161,187 @@ def _fetch_zone_wires(reader: ResolverPool, zone: str) -> Iterable[str]:
             log.info("DNS query for %s failed: %s", name, exc)
             continue
         if not values:
-            log.info("no %s records at %s", label, name)
+            log.info("no %s records at %s", public_label, name)
             continue
         for v in values:
             if isinstance(v, str):
-                yield v
+                yield (source_label, v)
 
 
-def aggregate(seeds: List[str], *, now: Optional[int] = None) -> List[AggregatedNode]:
-    """Query seed zones via DNS, verify, union. Returns the deduped
-    node list."""
+def _lookup_geo(host_or_ip: str, *, timeout: float = 5.0) -> Optional[Dict]:
+    """Resolve ``host_or_ip`` to lat/lon/country/city + ISP/org/AS via
+    ip-api.com (free, no auth, ~45 req/min from one IP). Returns
+    ``None`` on any error so the caller can fall back to a no-geo
+    rendering."""
+    try:
+        ip = (
+            host_or_ip
+            if _looks_like_ip(host_or_ip)
+            else socket.gethostbyname(host_or_ip)
+        )
+    except (socket.gaierror, OSError) as exc:
+        log.info("DNS resolution for geo lookup of %s failed: %s", host_or_ip, exc)
+        return None
+    fields = "status,country,countryCode,regionName,city,lat,lon,isp,org,as"
+    url = f"http://ip-api.com/json/{ip}?fields={fields}"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "dnsmesh-aggregator"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        log.info("ip-api.com lookup for %s failed: %s", ip, exc)
+        return None
+    if data.get("status") != "success":
+        log.info("ip-api.com returned non-success for %s: %s", ip, data)
+        return None
+    return {
+        "ip": ip,
+        "country": data.get("country") or "",
+        "country_code": data.get("countryCode") or "",
+        "region": data.get("regionName") or "",
+        "city": data.get("city") or "",
+        "lat": float(data.get("lat") or 0.0),
+        "lon": float(data.get("lon") or 0.0),
+        "isp": data.get("isp") or "",
+        "org": data.get("org") or "",
+        "asn": data.get("as") or "",
+    }
+
+
+def _looks_like_ip(s: str) -> bool:
+    """Crude IPv4 / IPv6 detector — good enough to skip the DNS
+    resolution step for inputs that are already addresses."""
+    try:
+        socket.inet_aton(s)
+        return True
+    except OSError:
+        pass
+    try:
+        socket.inet_pton(socket.AF_INET6, s)
+        return True
+    except OSError:
+        pass
+    return False
+
+
+def _resolver_reachability(
+    resolvers: List[Tuple[str, str]], zones: List[str]
+) -> List[ResolverCheck]:
+    """For each (resolver, zone) pair, query the resolver directly for
+    ``_dnsmesh-heartbeat.<zone>`` and record success + latency. The
+    matrix that comes out of this is the "any major resolver can
+    reach the nodes" demonstration on the directory page."""
+    results: List[ResolverCheck] = []
+    for resolver_name, resolver_addr in resolvers:
+        pool = ResolverPool([resolver_addr])
+        for zone in zones:
+            try:
+                name = heartbeat_rrset_name(zone)
+            except ValueError:
+                continue
+            t0 = time.monotonic()
+            try:
+                values = pool.query_txt_record(name)
+                latency_ms = int((time.monotonic() - t0) * 1000)
+            except Exception as exc:
+                results.append(
+                    ResolverCheck(
+                        resolver_name=resolver_name,
+                        resolver_addr=resolver_addr,
+                        zone=zone,
+                        endpoint=None,
+                        ok=False,
+                        latency_ms=None,
+                        detail=f"error: {type(exc).__name__}",
+                    )
+                )
+                continue
+            if not values:
+                results.append(
+                    ResolverCheck(
+                        resolver_name=resolver_name,
+                        resolver_addr=resolver_addr,
+                        zone=zone,
+                        endpoint=None,
+                        ok=False,
+                        latency_ms=latency_ms,
+                        detail="empty answer",
+                    )
+                )
+                continue
+            # Verify the first wire to confirm it's a valid heartbeat
+            # (a resolver returning an arbitrary TXT value for the
+            # name shouldn't count as "reachable"). Generous skew:
+            # the caller already filters on freshness elsewhere.
+            rec = None
+            for w in values:
+                if isinstance(w, str):
+                    rec = HeartbeatRecord.parse_and_verify(w, ts_skew_seconds=10**9)
+                    if rec is not None:
+                        break
+            if rec is None:
+                results.append(
+                    ResolverCheck(
+                        resolver_name=resolver_name,
+                        resolver_addr=resolver_addr,
+                        zone=zone,
+                        endpoint=None,
+                        ok=False,
+                        latency_ms=latency_ms,
+                        detail="answer did not verify",
+                    )
+                )
+                continue
+            results.append(
+                ResolverCheck(
+                    resolver_name=resolver_name,
+                    resolver_addr=resolver_addr,
+                    zone=zone,
+                    endpoint=rec.endpoint,
+                    ok=True,
+                    latency_ms=latency_ms,
+                    detail="ok",
+                )
+            )
+    return results
+
+
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AggregateResult:
+    """Everything the renderers need: the verified node list, the
+    federation discovery edges, and the resolver reachability
+    matrix."""
+
+    nodes: List[AggregatedNode]
+    seen_edges: List[Dict] = field(default_factory=list)
+    resolver_checks: List[ResolverCheck] = field(default_factory=list)
+
+
+def aggregate(seeds: List[str], *, now: Optional[int] = None) -> AggregateResult:
+    """Query seed zones via DNS, verify, union, enrich. Returns the
+    full data set the JSON + HTML renderers consume."""
     now_i = int(now) if now is not None else int(time.time())
     # Map (operator_spk_hex, endpoint) -> AggregatedNode (keep the
     # newest-ts wire on dedupe).
     pool: Dict[Tuple[str, str], AggregatedNode] = {}
+    seed_self_spk: Dict[str, str] = {}  # zone -> operator_spk_hex
+    edges: Dict[Tuple[str, str], int] = {}  # (from_spk, to_spk) -> max ts
 
-    # Public-resolver pool — Cloudflare + Google + Quad9. The
-    # aggregator queries _dnsmesh-seen.<seed-zone> over the public
-    # recursive chain; using a multi-upstream pool means a flaky
-    # resolver doesn't take down a refresh cycle.
+    # Public-resolver pool — Cloudflare + Google + Quad9. Used for
+    # the main aggregation pass; the reachability matrix uses one
+    # resolver per query.
     reader = ResolverPool(["1.1.1.1", "8.8.8.8", "9.9.9.9"])
 
+    valid_seed_zones: List[str] = []
     for seed in seeds:
         zone = _normalize_seed_to_zone(seed)
         if zone is None:
             continue
-        for wire in _fetch_zone_wires(reader, zone):
+        valid_seed_zones.append(zone)
+        for source, wire in _fetch_zone_wires(reader, zone):
             record = HeartbeatRecord.parse_and_verify(wire, now=now_i)
             if record is None:
                 continue
@@ -171,10 +359,6 @@ def aggregate(seeds: List[str], *, now: Optional[int] = None) -> List[Aggregated
                     last_seen_via=[zone],
                 )
             else:
-                # If this source reports a NEWER ts for the same
-                # node, take the newer wire. Always record the
-                # source seed so the HTML can show "heard via N
-                # sources".
                 sources = list(existing.last_seen_via)
                 if zone not in sources:
                     sources.append(zone)
@@ -198,8 +382,57 @@ def aggregate(seeds: List[str], *, now: Optional[int] = None) -> List[Aggregated
                         wire=existing.wire,
                         last_seen_via=sources,
                     )
+            # Source-aware bookkeeping.
+            if source == "heartbeat":
+                # _fetch_zone_wires yields heartbeat before seen, so
+                # this fires first and lets us tag downstream `seen`
+                # wires with the right "from" operator.
+                seed_self_spk[zone] = spk_hex
+            elif source == "seen":
+                from_spk = seed_self_spk.get(zone)
+                if from_spk and from_spk != spk_hex:
+                    edges[(from_spk, spk_hex)] = max(
+                        edges.get((from_spk, spk_hex), 0), int(record.ts)
+                    )
 
-    return sorted(pool.values(), key=lambda n: n.ts, reverse=True)
+    # Enrich each node with geo + host info.
+    enriched: List[AggregatedNode] = []
+    for n in sorted(pool.values(), key=lambda x: x.ts, reverse=True):
+        host = urlparse(n.endpoint).hostname or n.endpoint
+        geo = _lookup_geo(host)
+        host_block = None
+        if geo is not None:
+            host_block = {
+                "ip": geo.get("ip", ""),
+                "isp": geo.get("isp", ""),
+                "org": geo.get("org", ""),
+                "asn": geo.get("asn", ""),
+            }
+        enriched.append(
+            AggregatedNode(
+                operator_spk_hex=n.operator_spk_hex,
+                endpoint=n.endpoint,
+                version=n.version,
+                ts=n.ts,
+                exp=n.exp,
+                wire=n.wire,
+                last_seen_via=n.last_seen_via,
+                geo=geo,
+                host=host_block,
+            )
+        )
+
+    seen_edges = [
+        {"from_spk": a, "to_spk": b, "last_seen_ts": ts}
+        for (a, b), ts in sorted(edges.items())
+    ]
+    resolver_checks = _resolver_reachability(_RESOLVERS, valid_seed_zones)
+
+    return AggregateResult(
+        nodes=enriched,
+        seen_edges=seen_edges,
+        resolver_checks=resolver_checks,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -207,11 +440,11 @@ def aggregate(seeds: List[str], *, now: Optional[int] = None) -> List[Aggregated
 # ---------------------------------------------------------------------------
 
 
-def emit_json(nodes: List[AggregatedNode], out: Path, *, now: int) -> None:
+def emit_json(result: AggregateResult, out: Path, *, now: int) -> None:
     feed = {
-        "version": 1,
+        "version": 2,
         "generated_at": now,
-        "node_count": len(nodes),
+        "node_count": len(result.nodes),
         "nodes": [
             {
                 "operator_spk_hex": n.operator_spk_hex,
@@ -221,8 +454,23 @@ def emit_json(nodes: List[AggregatedNode], out: Path, *, now: int) -> None:
                 "exp": n.exp,
                 "wire": n.wire,
                 "last_seen_via": n.last_seen_via,
+                "geo": n.geo,
+                "host": n.host,
             }
-            for n in nodes
+            for n in result.nodes
+        ],
+        "seen_edges": result.seen_edges,
+        "resolvers": [
+            {
+                "name": c.resolver_name,
+                "addr": c.resolver_addr,
+                "zone": c.zone,
+                "endpoint": c.endpoint,
+                "ok": c.ok,
+                "latency_ms": c.latency_ms,
+                "detail": c.detail,
+            }
+            for c in result.resolver_checks
         ],
     }
     out.write_text(json.dumps(feed, indent=2) + "\n")
@@ -232,68 +480,304 @@ _HTML_TEMPLATE = """<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>DMP node directory</title>
 <style>
-body {{ font: 14px/1.5 system-ui, sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; }}
-table {{ border-collapse: collapse; width: 100%; margin-top: 1em; }}
-th, td {{ border: 1px solid #ccc; padding: 0.4em 0.6em; text-align: left; }}
-th {{ background: #f5f5f5; }}
-td.fresh {{ color: #0a0; }}
-td.stale {{ color: #a60; }}
-small {{ color: #666; }}
+:root {{
+  --fg: #1a1a1a; --muted: #666; --bg: #fafafa; --card: #fff;
+  --border: #ddd; --accent: #0066cc; --green: #1a7f37;
+  --amber: #9a6700; --red: #cf222e;
+}}
+@media (prefers-color-scheme: dark) {{
+  :root {{
+    --fg: #e6edf3; --muted: #8b949e; --bg: #0d1117; --card: #161b22;
+    --border: #30363d; --accent: #58a6ff; --green: #3fb950;
+    --amber: #d29922; --red: #f85149;
+  }}
+}}
+* {{ box-sizing: border-box; }}
+body {{
+  font: 14px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  max-width: 1080px; margin: 2em auto; padding: 0 1.2em;
+  color: var(--fg); background: var(--bg);
+}}
+h1 {{ margin: 0 0 0.2em; font-size: 1.7em; }}
+h2 {{ margin: 1.6em 0 0.4em; font-size: 1.15em; }}
+h2 small {{ font-weight: normal; color: var(--muted); margin-left: 0.5em; }}
+small {{ color: var(--muted); }}
+a {{ color: var(--accent); text-decoration: none; }}
+a:hover {{ text-decoration: underline; }}
+code {{
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em; background: var(--card); padding: 1px 4px;
+  border-radius: 3px; border: 1px solid var(--border);
+}}
+.cards {{
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 0.8em;
+}}
+.card {{
+  background: var(--card); border: 1px solid var(--border);
+  border-radius: 6px; padding: 0.9em 1em;
+}}
+.card h3 {{ margin: 0 0 0.4em; font-size: 1em; }}
+.card .row {{ display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }}
+.card .label {{ color: var(--muted); flex-shrink: 0; }}
+.card .val {{ text-align: right; word-break: break-all; }}
+.card .pill {{ font-size: 0.8em; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--border); }}
+.pill.fresh {{ color: var(--green); border-color: currentColor; }}
+.pill.stale {{ color: var(--amber); border-color: currentColor; }}
+.pill.expired {{ color: var(--red); border-color: currentColor; }}
+table {{
+  border-collapse: collapse; width: 100%; margin-top: 0.6em;
+  font-size: 0.92em;
+}}
+th, td {{
+  border: 1px solid var(--border); padding: 0.4em 0.7em;
+  text-align: left;
+}}
+th {{ background: var(--card); font-weight: 600; }}
+td.ok {{ color: var(--green); }}
+td.fail {{ color: var(--red); }}
+.svg-wrap {{
+  background: var(--card); border: 1px solid var(--border);
+  border-radius: 6px; padding: 1em; margin-top: 0.4em;
+  text-align: center; overflow-x: auto;
+}}
+svg.topology text {{ fill: var(--fg); font: 11px ui-monospace, monospace; }}
+svg.topology circle.node {{ fill: var(--card); stroke: var(--accent); stroke-width: 2; }}
+svg.topology line {{ stroke: var(--accent); stroke-width: 1.4; opacity: 0.65; }}
+svg.topology .label {{ font: 11px system-ui, sans-serif; fill: var(--fg); }}
+svg.topology .arrow {{ fill: var(--accent); }}
+.legend {{ font-size: 0.85em; color: var(--muted); margin-top: 0.5em; }}
+.section-note {{ font-size: 0.88em; color: var(--muted); margin-top: 0.3em; }}
 </style>
 </head>
 <body>
+
 <h1>DMP node directory</h1>
 <p>
-  <small>Generated {generated} · {count} nodes heard in the last 72h.
-  Every row is a signed HeartbeatRecord; <a href="feed.json">feed.json</a>
-  carries the raw wire strings so consumers can re-verify independently.</small>
+  <small>Generated {generated} · {node_count} known nodes ·
+  <a href="feed.json">feed.json</a> carries the raw signed wires
+  for independent re-verification.</small>
 </p>
-<table>
-<thead>
-<tr>
-  <th>Endpoint</th>
-  <th>Operator pubkey</th>
-  <th>Version</th>
-  <th>Last heard</th>
-  <th>Sources</th>
-</tr>
-</thead>
-<tbody>
-{rows}
-</tbody>
-</table>
+
+<h2>Known nodes <small>· geo + hosting</small></h2>
+<div class="cards">
+{node_cards}
+</div>
+<p class="section-note">
+  Geo and ASN data via ip-api.com lookup at build time. Each node is
+  the same self-signed <code>HeartbeatRecord</code> wire that lives at
+  <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
+  chain — the geo block is descriptive metadata for humans and is
+  NOT signed.
+</p>
+
+<h2>Federation topology <small>· heartbeat-discovery, not message traffic</small></h2>
+<div class="svg-wrap">
+{topology_svg}
+</div>
+<p class="section-note">
+  An arrow from A → B means A's seen-graph
+  (<code>_dnsmesh-seen.&lt;A-zone&gt;</code>) carries a verified
+  heartbeat from B. This is the federation discovery view —
+  who has heard from whom over the public DNS chain. Message
+  traffic is private (E2E encrypted) and is NOT shown here.
+</p>
+
+<h2>Public-resolver reachability <small>· can major resolvers find these nodes?</small></h2>
+{resolver_table}
+<p class="section-note">
+  Tested at build time from a GitHub Actions runner: each row is a
+  curated public DNS resolver, each column is a node. A green cell
+  means the resolver answered <code>_dnsmesh-heartbeat.&lt;zone&gt;</code>
+  with a wire that verifies under Ed25519. Your client can do the
+  same lookup with the same result. The list is illustrative — every
+  internet-connected DNS resolver can perform the same query.
+</p>
+
 </body>
 </html>
 """
 
 
-def emit_html(nodes: List[AggregatedNode], out: Path, *, now: int) -> None:
-    def _row(n: AggregatedNode) -> str:
-        age = now - n.ts
-        cls = "fresh" if age < 3600 else "stale"
-        age_str = (
-            f"{age}s ago"
-            if age < 60
-            else f"{age // 60}m ago" if age < 3600 else f"{age // 3600}h ago"
+def emit_html(result: AggregateResult, out: Path, *, now: int) -> None:
+    out.write_text(
+        _HTML_TEMPLATE.format(
+            generated=time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(now)),
+            node_count=len(result.nodes),
+            node_cards=_render_node_cards(result.nodes, now=now),
+            topology_svg=_render_topology_svg(result.nodes, result.seen_edges, now=now),
+            resolver_table=_render_resolver_table(result.nodes, result.resolver_checks),
         )
-        spk_short = n.operator_spk_hex[:8] + "…" + n.operator_spk_hex[-4:]
-        return (
-            f'<tr><td><a href="{n.endpoint}">{n.endpoint}</a></td>'
-            f"<td><code>{spk_short}</code></td>"
-            f"<td>{n.version or '-'}</td>"
-            f'<td class="{cls}">{age_str}</td>'
-            f"<td>{len(n.last_seen_via)}</td></tr>"
-        )
-
-    rows = "\n".join(_row(n) for n in nodes)
-    html = _HTML_TEMPLATE.format(
-        generated=time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(now)),
-        count=len(nodes),
-        rows=rows or '<tr><td colspan="5">(no nodes seen)</td></tr>',
     )
-    out.write_text(html)
+
+
+def _format_age(seconds: int) -> str:
+    if seconds < 60:
+        return f"{seconds}s ago"
+    if seconds < 3600:
+        return f"{seconds // 60}m ago"
+    if seconds < 86400:
+        return f"{seconds // 3600}h ago"
+    return f"{seconds // 86400}d ago"
+
+
+def _liveness_pill(age_seconds: int, exp: int, now: int) -> Tuple[str, str]:
+    if exp <= now:
+        return ("expired", "expired")
+    if age_seconds < 600:  # < 10 min
+        return ("fresh", _format_age(age_seconds))
+    if age_seconds < 3600:  # < 1 h
+        return ("stale", _format_age(age_seconds))
+    return ("stale", _format_age(age_seconds))
+
+
+def _render_node_cards(nodes: List[AggregatedNode], *, now: int) -> str:
+    if not nodes:
+        return '<div class="card"><em>(no nodes seen)</em></div>'
+    out: List[str] = []
+    for n in nodes:
+        age = now - n.ts
+        cls, label = _liveness_pill(age, n.exp, now)
+        spk_short = n.operator_spk_hex[:8] + "…" + n.operator_spk_hex[-4:]
+        host_text = ""
+        if n.host:
+            host_text = f"{html_escape(n.host.get('org') or n.host.get('isp') or '')}"
+            asn = n.host.get("asn") or ""
+            if asn:
+                host_text += f" <small>({html_escape(asn)})</small>"
+        geo_text = ""
+        if n.geo:
+            parts = [
+                n.geo.get("city") or "",
+                n.geo.get("region") or "",
+                n.geo.get("country") or "",
+            ]
+            geo_text = ", ".join(p for p in parts if p)
+        endpoint_safe = html_escape(n.endpoint)
+        out.append(f"""<div class="card">
+<h3><a href="{endpoint_safe}">{endpoint_safe}</a></h3>
+<div class="row"><span class="label">Status</span><span class="val"><span class="pill {cls}">{html_escape(label)}</span></span></div>
+<div class="row"><span class="label">Version</span><span class="val">{html_escape(n.version or '?')}</span></div>
+<div class="row"><span class="label">Operator key</span><span class="val"><code>{html_escape(spk_short)}</code></span></div>
+<div class="row"><span class="label">Hosting</span><span class="val">{host_text or '<em>—</em>'}</span></div>
+<div class="row"><span class="label">Region</span><span class="val">{html_escape(geo_text) or '<em>—</em>'}</span></div>
+<div class="row"><span class="label">IP</span><span class="val"><code>{html_escape((n.host or dict()).get('ip', '') or '—')}</code></span></div>
+<div class="row"><span class="label">Heard via</span><span class="val">{', '.join(html_escape(z) for z in n.last_seen_via) or '—'}</span></div>
+</div>""")
+    return "\n".join(out)
+
+
+def _render_topology_svg(
+    nodes: List[AggregatedNode], edges: List[Dict], *, now: int
+) -> str:
+    """A small SVG with one circle per node and arrows for the
+    seen-graph edges. Layout: nodes on a horizontal line; edges
+    drawn as curved arrows so bidirectional pairs don't overlap.
+
+    Kept deliberately simple — for >6 nodes the layout will get
+    cramped, but for the current 2-3-node federation it reads
+    cleanly. A force-directed layout with d3 is an option if/when
+    the federation grows past that scale.
+    """
+    if not nodes:
+        return "<em>(no nodes to plot)</em>"
+    width = 720
+    height = max(220, 120 + 70 * (len(nodes) // 3))
+    margin_x = 90
+    spacing = (width - 2 * margin_x) / max(1, len(nodes) - 1) if len(nodes) > 1 else 0
+    # Place nodes left-to-right, alternating slight y-offset so labels
+    # don't collide.
+    coords: Dict[str, Tuple[int, int]] = {}
+    parts: List[str] = [
+        f'<svg class="topology" width="{width}" height="{height}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">'
+    ]
+    parts.append(
+        '<defs><marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" '
+        'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
+        '<path d="M 0 0 L 10 5 L 0 10 z" class="arrow"/></marker></defs>'
+    )
+    for i, n in enumerate(nodes):
+        x = int(margin_x + i * spacing) if len(nodes) > 1 else width // 2
+        y = height // 2 + (-25 if i % 2 == 0 else 25)
+        coords[n.operator_spk_hex] = (x, y)
+    # Edges first (so circles render on top).
+    for e in edges:
+        a = coords.get(e["from_spk"])
+        b = coords.get(e["to_spk"])
+        if a is None or b is None:
+            continue
+        # Slight curve so reverse edges don't overlap.
+        ctrl_y_offset = 30 if a[0] < b[0] else -30
+        cx = (a[0] + b[0]) // 2
+        cy = (a[1] + b[1]) // 2 + ctrl_y_offset
+        parts.append(
+            f'<path d="M {a[0]} {a[1]} Q {cx} {cy} {b[0]} {b[1]}" '
+            f'fill="none" stroke="currentColor" stroke-width="1.4" '
+            f'opacity="0.55" marker-end="url(#arrowhead)"/>'
+        )
+    # Node circles + labels.
+    for n in nodes:
+        x, y = coords[n.operator_spk_hex]
+        host = urlparse(n.endpoint).hostname or n.endpoint
+        country = (n.geo or {}).get("country_code") or ""
+        parts.append(
+            f'<circle class="node" cx="{x}" cy="{y}" r="22"/>'
+            f'<text class="label" x="{x}" y="{y + 4}" text-anchor="middle" '
+            f'font-size="11">{html_escape((country or "?"))}</text>'
+            f'<text class="label" x="{x}" y="{y + 42}" text-anchor="middle" '
+            f'font-size="11">{html_escape(host)}</text>'
+            f'<text class="label" x="{x}" y="{y + 56}" text-anchor="middle" '
+            f'font-size="10" opacity="0.7">{html_escape(n.version or "")}</text>'
+        )
+    parts.append("</svg>")
+    return "".join(parts)
+
+
+def _render_resolver_table(
+    nodes: List[AggregatedNode], checks: List[ResolverCheck]
+) -> str:
+    if not checks:
+        return "<p><em>(no reachability checks recorded)</em></p>"
+    # Group checks by resolver, then by zone — output rows = resolver,
+    # cols = each known zone (one per node).
+    zones = sorted({c.zone for c in checks})
+    by_key: Dict[Tuple[str, str], ResolverCheck] = {
+        (c.resolver_name, c.zone): c for c in checks
+    }
+    resolver_names: List[Tuple[str, str]] = []
+    seen_resolver_keys = set()
+    for c in checks:
+        key = (c.resolver_name, c.resolver_addr)
+        if key not in seen_resolver_keys:
+            resolver_names.append(key)
+            seen_resolver_keys.add(key)
+    parts: List[str] = ["<table><thead><tr><th>Resolver</th>"]
+    for z in zones:
+        parts.append(f"<th>{html_escape(z)}</th>")
+    parts.append("</tr></thead><tbody>")
+    for r_name, r_addr in resolver_names:
+        parts.append(
+            f"<tr><td><strong>{html_escape(r_name)}</strong> "
+            f"<small><code>{html_escape(r_addr)}</code></small></td>"
+        )
+        for z in zones:
+            c = by_key.get((r_name, z))
+            if c is None:
+                parts.append("<td>—</td>")
+                continue
+            if c.ok:
+                lat = f"{c.latency_ms} ms" if c.latency_ms is not None else ""
+                parts.append(f'<td class="ok">✓ <small>{html_escape(lat)}</small></td>')
+            else:
+                parts.append(
+                    f'<td class="fail">✗ <small>{html_escape(c.detail)}</small></td>'
+                )
+        parts.append("</tr>")
+    parts.append("</tbody></table>")
+    return "".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -345,11 +829,16 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     now = int(time.time())
-    nodes = aggregate(seeds, now=now) if seeds else []
-    emit_json(nodes, args.out_dir / "feed.json", now=now)
-    emit_html(nodes, args.out_dir / "index.html", now=now)
+    result = aggregate(seeds, now=now) if seeds else AggregateResult(nodes=[])
+    emit_json(result, args.out_dir / "feed.json", now=now)
+    emit_html(result, args.out_dir / "index.html", now=now)
     log.info(
-        "wrote %d nodes from %d seeds to %s", len(nodes), len(seeds), args.out_dir
+        "wrote %d nodes from %d seeds to %s (edges: %d, resolver checks: %d)",
+        len(result.nodes),
+        len(seeds),
+        args.out_dir,
+        len(result.seen_edges),
+        len(result.resolver_checks),
     )
     return 0
 


### PR DESCRIPTION
## What

Replaces the old simple-table directory page with a three-section, theme-aware static page:

1. **Known nodes** — cards per node with endpoint, status pill, version, operator-key fingerprint, hosting org + ASN, region (city/country), IP, and seed-zone(s) the wire was heard via. Geo + ASN data from ip-api.com at build time.
2. **Federation topology** — inline SVG circles + curved arrows showing seen-graph edges (\"A's seen-graph carries a verified heartbeat from B\"). Honestly labeled \"heartbeat-discovery, not message traffic.\"
3. **Public-resolver reachability matrix** — table testing 6 curated public resolvers (Cloudflare, Google, Quad9, OpenDNS, Level3, Yandex) × each seed zone. Each cell is a live verify of \`_dnsmesh-heartbeat.<zone>\` + latency.

## Why

User asked for a directory page that shows:
- Where nodes are physically hosted (provider + region)
- That major resolvers can find the nodes
- That the federation is alive + nodes can reach each other

This satisfies all three honestly — without misrepresenting \"the resolver internet\" as a finite graph or fabricating message-traffic data.

## Implementation

- \`feed.json\` schema bumped to v2; new fields: \`nodes[].geo\`, \`nodes[].host\`, \`seen_edges\`, \`resolvers\`. v1 fields preserved for back-compat.
- Geo lookup: ip-api.com (free, no auth, ~45 req/min). Per-node call at build time, result cached into feed.json. Failures fall back gracefully.
- Reachability matrix: per (resolver, zone) DNS query, verifying the returned wire under Ed25519 before counting as ok.
- All-server-rendered SVG topology — no JS, no external libraries, no map tiles.
- \`prefers-color-scheme\` aware: reads cleanly in light + dark.
- Zero external CSS/JS dependencies. Self-contained ~9 KB HTML.

## Live test (current state)

Run against current \`directory/seeds.txt\`:

\`\`\`
wrote 2 nodes from 2 seeds (edges: 0, resolver checks: 12)
\`\`\`

- 4/6 resolvers reach both nodes (Cloudflare, Quad9, OpenDNS, Yandex). Google + Level3 currently return empty answers.
- 0 edges in topology because \`_dnsmesh-seen.<zone>\` queries via the public chain are returning empty right now (the records exist on the auth NS — direct \`dig @dnsmesh.io\` returns 3 entries — but the public recursive chain isn't fetching them reliably).

## Operator follow-up surfaced by this PR

The empty-cell cases in the resolver matrix and the missing seen-graph edges both point at the same thing: **the \`dmp.<apex>\` subzone delegation on \`dnsmesh.io\` and \`dnsmesh.pro\` doesn't have GLUE A records for the NS**. Some recursive resolvers (Cloudflare, Quad9, OpenDNS, Yandex) cope by re-resolving the NS hostname through other paths; others (Google, Level3) won't, and return empty.

Fix on the registrar side: add an A record at \`dmp.dnsmesh.io\` pointing at \`24.199.107.165\` and at \`dmp.dnsmesh.pro\` pointing at \`45.7.229.112\`. Walked through in \`docs/deployment/dns-delegation.md\`.

The aggregator now makes this visibility issue obvious — which is the point.

## Test plan

- [x] Aggregator runs locally and produces valid v2 \`feed.json\`.
- [x] Aggregator produces valid HTML that opens in a browser.
- [x] Black-formatted; no lint regressions.
- [x] Existing seed handling (URL form, blank lines, comments) preserved.
- [ ] After merge, \`pages.yml\` cron picks up the new aggregator on its next run; the live page at \`/DNSMeshProtocol/directory/\` shows the new layout.