### PR TITLE
feat(deploy): firewall.sh helper + fix install.sh missing TCP 53

### DIFF
--- a/deploy/native-ubuntu/firewall.sh
+++ b/deploy/native-ubuntu/firewall.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# DMP node firewall helper (optional).
+#
+# Configures ufw with the ports a DMP node needs:
+#
+#   SSH 22/tcp       — admin access (default; override with --ssh-port)
+#   DNS 53/udp       — DMP authoritative DNS, primary path
+#   DNS 53/tcp       — DNS TCP fallback (RFC 1035 §4.2.2 + RFC 7766);
+#                      required when responses exceed UDP buffer size,
+#                      most visibly for _dnsmesh-seen.<zone> RRsets
+#   HTTP 80/tcp      — Let's Encrypt HTTP-01 ACME challenge
+#   HTTPS 443/tcp    — Caddy front-end (TSIG registration handshake +
+#                      node landing page)
+#   HTTPS 443/udp    — HTTP/3 (QUIC); optional, harmless to leave open
+#
+# Usage:
+#
+#   sudo ./firewall.sh                # add the rules above + show status
+#   sudo ./firewall.sh --check        # print the rules and ufw state, change nothing
+#   sudo ./firewall.sh --enable       # also `ufw enable` if disabled
+#   sudo ./firewall.sh --ssh-port 2222
+#
+# This script only configures the host-level firewall (ufw). Cloud
+# providers run a SEPARATE firewall in front of your droplet — DO Cloud
+# Firewall, AWS Security Group, GCP firewall rules, etc. You'll need
+# to allow the same ports there too. Check your provider's docs.
+#
+# Idempotent: re-running adds rules that don't exist, leaves the rest
+# alone. Safe to use on a host with existing ufw config.
+
+set -euo pipefail
+
+SSH_PORT=22
+MODE="apply"  # apply | check | apply-and-enable
+
+usage() {
+    sed -n '2,30p' "$0" | sed 's/^# \?//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check)         MODE="check"; shift ;;
+        --enable)        MODE="apply-and-enable"; shift ;;
+        --ssh-port)      SSH_PORT="$2"; shift 2 ;;
+        --ssh-port=*)    SSH_PORT="${1#*=}"; shift ;;
+        -h|--help)       usage ;;
+        *)
+            echo "unknown arg: $1" >&2
+            echo "see --help" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Color helpers (only when stderr is a terminal).
+if [[ -t 2 ]]; then
+    BOLD=$'\e[1m'; RED=$'\e[31m'; GREEN=$'\e[32m'; YELLOW=$'\e[33m'; RESET=$'\e[0m'
+else
+    BOLD=""; RED=""; GREEN=""; YELLOW=""; RESET=""
+fi
+
+step() { echo "${BOLD}==>${RESET} $*" >&2; }
+ok()   { echo "${GREEN}ok${RESET}    $*" >&2; }
+warn() { echo "${YELLOW}warn${RESET}  $*" >&2; }
+fail() { echo "${RED}error${RESET} $*" >&2; exit 1; }
+
+# Must run as root for any ufw mutation; --check can run unprivileged
+# but the status command itself needs root on most Ubuntu setups.
+if [[ $EUID -ne 0 ]]; then
+    fail "must be run as root (try: sudo $0 ${MODE/apply-and-enable/--enable})"
+fi
+
+if ! command -v ufw >/dev/null 2>&1; then
+    fail "ufw not installed. run: apt install ufw"
+fi
+
+# Show current state up front so the operator sees what they're starting with.
+step "Current ufw state"
+ufw status verbose 2>&1 | sed 's/^/    /' >&2
+
+if [[ "$MODE" == "check" ]]; then
+    exit 0
+fi
+
+# Rules to apply: (port/proto, comment).
+RULES=(
+    "${SSH_PORT}/tcp::SSH"
+    "53/udp::dnsmesh authoritative DNS (UDP)"
+    "53/tcp::dnsmesh DNS TCP fallback"
+    "80/tcp::ACME HTTP-01 challenge (Let's Encrypt)"
+    "443/tcp::dnsmesh HTTPS (Caddy / TSIG registration / landing page)"
+    "443/udp::dnsmesh HTTPS HTTP/3 (QUIC, optional)"
+)
+
+step "Applying ufw rules"
+for rule in "${RULES[@]}"; do
+    spec="${rule%%::*}"
+    comment="${rule##*::}"
+    if ufw status | grep -qE "^${spec}\s+ALLOW\b"; then
+        ok "${spec} already allowed"
+    else
+        ufw allow "${spec}" comment "${comment}" >/dev/null
+        ok "${spec} added (${comment})"
+    fi
+done
+
+# Optionally enable ufw. NEVER auto-enable without --enable: if SSH
+# isn't already in the rule set when ufw flips on, the operator gets
+# locked out. Adding the SSH rule above doesn't help if they typo'd
+# --ssh-port. Make them say so explicitly.
+if [[ "$MODE" == "apply-and-enable" ]]; then
+    if ufw status | grep -q "^Status: active"; then
+        ok "ufw already enabled"
+    else
+        step "Enabling ufw (be sure SSH is in the rules above)"
+        # `ufw enable` prompts on TTY; --force skips it.
+        ufw --force enable >/dev/null
+        ok "ufw enabled"
+    fi
+elif ! ufw status | grep -q "^Status: active"; then
+    warn "ufw is INACTIVE. The rules above are configured but not enforced."
+    warn "Re-run with --enable once you've confirmed SSH (port ${SSH_PORT}) is correct."
+fi
+
+# Final state.
+step "Resulting ufw state"
+ufw status verbose 2>&1 | sed 's/^/    /' >&2
+
+# Reminder about cloud-firewall layer that this script can't touch.
+echo "" >&2
+echo "${BOLD}Reminder:${RESET} most cloud providers run a SEPARATE firewall in" >&2
+echo "front of your VM. Allow the same ports there too:" >&2
+echo "  - DigitalOcean: Networking → Firewalls → your firewall →" >&2
+echo "    Inbound rules → Add SSH + 53/udp + 53/tcp + 80/tcp +" >&2
+echo "    443/tcp + 443/udp" >&2
+echo "  - AWS:           Security Group inbound rules" >&2
+echo "  - GCP:           VPC firewall rules" >&2

--- a/deploy/native-ubuntu/install.sh
+++ b/deploy/native-ubuntu/install.sh
@@ -313,7 +313,8 @@ ok "$CADDYFILE configured for $DMP_NODE_HOSTNAME"
 
 if ufw status | grep -q "Status: active"; then
     step "Opening firewall ports (ufw active)"
-    ufw allow 53/udp comment 'dnsmesh authoritative DNS' >/dev/null
+    ufw allow 53/udp comment 'dnsmesh authoritative DNS (UDP)' >/dev/null
+    ufw allow 53/tcp comment 'dnsmesh DNS TCP fallback' >/dev/null
     ufw allow 80/tcp comment 'ACME HTTP-01 challenge' >/dev/null
     ufw allow 443/tcp comment 'dnsmesh HTTPS publish API' >/dev/null
     ufw allow 443/udp comment 'dnsmesh HTTPS / HTTP-3' >/dev/null

--- a/docs/deployment/native-ubuntu.md
+++ b/docs/deployment/native-ubuntu.md
@@ -52,8 +52,8 @@ When to pick Docker instead:
   UDP 53).
 - Caddy fronting the HTTP API on TCP 443 with auto Let's Encrypt.
 - Persistent state at `/var/lib/dmp/dmp.db`.
-- ufw rules for `UDP 53`, `TCP 80`, `TCP 443`, `UDP 443` (when ufw is
-  active).
+- ufw rules for `UDP 53`, `TCP 53`, `TCP 80`, `TCP 443`, `UDP 443`
+  (when ufw is active).
 
 ## Prerequisites
 
@@ -61,10 +61,30 @@ When to pick Docker instead:
 2. **A DNS A (and ideally AAAA) record** pointing at the machine's
    public IP. Caddy uses the HTTP-01 ACME challenge, so the hostname
    has to resolve here *before* the script runs.
-3. **Open inbound:** `UDP 53`, `TCP 80`, `TCP 443`, `UDP 443`. The
-   script handles `ufw` automatically; cloud-firewall layers
-   (DigitalOcean Cloud Firewall, AWS Security Group, etc.) you set
-   yourself.
+3. **Open inbound:** `TCP 22` (SSH), `UDP 53`, `TCP 53`, `TCP 80`,
+   `TCP 443`, `UDP 443`. The install script handles `ufw`
+   automatically; cloud-firewall layers (DigitalOcean Cloud
+   Firewall, AWS Security Group, etc.) you set yourself.
+
+   If you want to configure the firewall *separately* from the
+   install (e.g. on a host that already has a node running, or to
+   set it up on a fresh box before installing), there's a small
+   helper script:
+
+   ```bash
+   sudo /opt/dnsmesh/firewall.sh --check    # report current state
+   sudo /opt/dnsmesh/firewall.sh            # add the rules
+   sudo /opt/dnsmesh/firewall.sh --enable   # also `ufw enable`
+   ```
+
+   Or run it from the source repo before any `pip install`:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/oscarvalenzuelab/DNSMeshProtocol/main/deploy/native-ubuntu/firewall.sh \
+       | sudo bash
+   ```
+
+   It's idempotent — safe to re-run at any point.
 
 ## Run the install
 


### PR DESCRIPTION
## What

Two small fixes around node firewall config:

1. **New optional helper script** at \`deploy/native-ubuntu/firewall.sh\`. Idempotent. Configures ufw with the ports a DMP node needs (SSH 22, DNS 53/udp+tcp, HTTP 80, HTTPS 443/tcp+udp). Three modes: \`--check\` (report only), no-flag (apply rules, don't touch ufw enable state), \`--enable\` (apply + \`ufw enable\` if disabled). Also \`--ssh-port N\` for non-default SSH ports.

2. **Fix \`install.sh\` missing \`53/tcp\`** in its inline ufw block. Was opening UDP 53 + TCP 80/443 + UDP 443 and missed TCP 53 — the gap that surfaced when investigating why \`_dnsmesh-seen.<zone>\` RRsets weren't propagating through some recursors (companion to PR #14, which adds the TCP listener to the DMP DNS server itself).

3. **Doc update** in \`docs/deployment/native-ubuntu.md\`: prerequisites list now includes TCP 53 and SSH 22, with a section on running the new helper before/after install.

## Why

PR #14 (TCP listener) is necessary on the server side; this PR is the matching fix on the firewall side. Both have to be in place for TCP fallback to actually work end-to-end.

The helper is also useful on its own for operators who want to run firewall config separately from the installer (e.g. set it up on a fresh box before the install, or fix rules on a live node without re-running install.sh).

## Notes on safety

- \`--enable\` is required to actually flip ufw on. If the operator typo'd \`--ssh-port\`, an automatic enable would lock them out. Make them say so explicitly.
- The helper only configures ufw. Cloud-provider firewalls (DO Cloud Firewall, AWS SG, GCP VPC) sit in front of the VM and need to be configured separately. Both the script and the docs say so.

## Test plan

- [x] \`bash -n\` syntax check passes.
- [x] \`--help\` prints sensible output.
- [ ] Run on a live host to verify it adds the right rules and is idempotent (re-running adds nothing).