### PR TITLE
fix(heartbeat-worker): seen-graph self-filter + orphan sweep

### DIFF
--- a/dmp/server/heartbeat_worker.py
+++ b/dmp/server/heartbeat_worker.py
@@ -217,6 +217,22 @@ class HeartbeatWorker:
         # and-verify) and deletes them before publishing the fresh
         # one. Flips after the first successful sweep.
         self._orphan_sweep_done: bool = False
+        # Same orphan-sweep story for ``_dnsmesh-seen.<own-zone>``.
+        # ``_last_seen_wires`` is process-memory only, so every
+        # restart leaves the prior tick's published wires in place
+        # with no eviction tracking. They linger until each wire's
+        # ``exp`` fires (24h default), which over a few upgrade
+        # cycles inflates the seen RRset past the recursive-resolver
+        # UDP buffer (1232 bytes EDNS) — the response then exceeds
+        # ``to_wire()``'s size budget, the UDP path raises
+        # ``dns.exception.TooBig``, and federation discovery silently
+        # breaks. First ``_publish_seen_graph`` does a one-time sweep
+        # of any wire at ``_dnsmesh-seen.<own-zone>`` that is either
+        # (a) signed by THIS operator (self never belongs in a node's
+        # own seen RRset — seen is "OTHER nodes I have heard from")
+        # or (b) a stale prior-tick wire for a peer we still see, so
+        # cluster siblings' wires under shared zones remain intact.
+        self._seen_orphan_sweep_done: bool = False
 
     # ------------------------------------------------------------------
     # lifecycle
@@ -441,6 +457,92 @@ class HeartbeatWorker:
             )
         return deleted
 
+    def _sweep_orphan_seen_wires(
+        self, name: str, *, next_wires: Set[str], now: int
+    ) -> int:
+        """Delete prior-process orphans at ``_dnsmesh-seen.<own-zone>``.
+
+        Mirror of ``_sweep_orphan_self_wires`` for the seen RRset.
+        Two classes of wire are deleted:
+
+        1. Wires signed by THIS operator. Self never belongs in the
+           local seen RRset (seen = "OTHER nodes I have heard from").
+           Any self-wire there is leakage from a prior bootstrap path
+           that later got fixed; we clean it up unconditionally.
+
+        2. Wires for a peer ``(operator_spk, endpoint)`` that appears
+           in ``next_wires`` but with a different wire payload — the
+           existing one is our prior tick's stale copy of that peer.
+           Replacing it with the fresh ``next_wires`` entry collapses
+           the per-peer wire history into the latest signed copy.
+
+        Anything else stays. Cluster siblings publishing into a
+        shared ``_dnsmesh-seen.<shared-zone>`` keep their wires.
+        Wires we can't parse (bad sig, expired beyond skew, malformed)
+        are left alone — see ``_sweep_orphan_self_wires`` rationale.
+
+        Returns the number of orphan wires deleted.
+        """
+        reader = self._record_writer
+        if not hasattr(reader, "query_txt_record"):
+            return 0
+        try:
+            existing = reader.query_txt_record(name)
+        except Exception:
+            log.exception("orphan seen-wire sweep: query raised for %s", name)
+            return 0
+        if not existing:
+            return 0
+
+        own_spk = self._crypto.get_signing_public_key_bytes()
+        # Build a (spk_hex, endpoint) -> wire map of what we're about
+        # to publish so we can detect prior-tick stale copies of the
+        # SAME peer in the live RRset.
+        next_keyed: dict = {}
+        for w in next_wires:
+            rec = HeartbeatRecord.parse_and_verify(w, now=now, ts_skew_seconds=10**9)
+            if rec is None:
+                continue
+            next_keyed[(bytes(rec.operator_spk).hex(), rec.endpoint)] = w
+
+        deleted = 0
+        for value in existing:
+            if value in next_wires:
+                # Already what we want there — leave it.
+                continue
+            rec = HeartbeatRecord.parse_and_verify(
+                value, now=now, ts_skew_seconds=10**9
+            )
+            if rec is None:
+                continue
+            spk = bytes(rec.operator_spk)
+            should_delete = False
+            if spk == own_spk:
+                # Class 1: self in our own seen — never belongs.
+                should_delete = True
+            else:
+                # Class 2: prior-tick stale for a peer we still see.
+                key = (spk.hex(), rec.endpoint)
+                if key in next_keyed and next_keyed[key] != value:
+                    should_delete = True
+            if not should_delete:
+                continue
+            try:
+                if self._record_writer.delete_txt_record(name, value=value):
+                    deleted += 1
+            except Exception:
+                log.exception(
+                    "orphan seen-wire delete raised for %s; continuing",
+                    name,
+                )
+        if deleted:
+            log.info(
+                "swept %d orphan seen-wire(s) at %s on worker startup",
+                deleted,
+                name,
+            )
+        return deleted
+
     def _publish_seen_graph(self, now_i: int) -> int:
         """Republish recently-seen peer wires under
         ``_dnsmesh-seen.<dns_zone>`` as a multi-value TXT RRset.
@@ -479,12 +581,38 @@ class HeartbeatWorker:
         # ``_dnsmesh-seen.<shared-zone>``. We track exactly which
         # wires THIS node published last tick and evict only those —
         # peers' contributions stay intact.
+        own_spk_hex = self._crypto.get_signing_public_key_bytes().hex()
         next_wires: Set[str] = set()
         for row in rows:
             wire = getattr(row, "wire", None)
             if not isinstance(wire, str) or not wire:
                 continue
+            # Self never belongs in our own seen RRset. Seen is
+            # "OTHER nodes I have heard from" — listing ourselves
+            # there is both semantically wrong (an operator can't
+            # vouch for their own liveness via their own gossip
+            # claim) and a foot-gun: aggregators that build a
+            # discovery graph from seen-edges would draw a self-
+            # loop. Defensive filter even though ``_fetch_and_ingest``
+            # also drops self at the source — a future bootstrap
+            # path that lands self in the store via some other route
+            # (manifest re-ingest, admin import, …) shouldn't leak
+            # into DNS.
+            row_spk_hex = getattr(row, "operator_spk_hex", "") or ""
+            if row_spk_hex.lower() == own_spk_hex.lower():
+                continue
             next_wires.add(wire)
+
+        # One-shot startup sweep of orphan seen-wires from prior
+        # processes — see ``_seen_orphan_sweep_done`` docstring.
+        if not self._seen_orphan_sweep_done:
+            try:
+                self._sweep_orphan_seen_wires(name, next_wires=next_wires, now=now_i)
+            except Exception:
+                log.exception("orphan seen-wire sweep raised for %s", name)
+            # Mark done regardless of success so a persistent error
+            # in the sweep path doesn't re-run on every tick.
+            self._seen_orphan_sweep_done = True
         # Anything we published last time but won't republish now
         # has dropped out (peer aged out of SeenStore). Evict those
         # specific values from the RRset.
@@ -552,6 +680,18 @@ class HeartbeatWorker:
         except ValueError:
             pass
 
+        # Drop wires the peer is gossiping back to us about ourselves
+        # at ingest time. Without this filter, a peer that has us in
+        # its own seen-graph (which is the common case once federation
+        # converges) seeds our local SeenStore with our own wire under
+        # ``(operator_spk_hex, endpoint)`` — and then ``_publish_seen_graph``
+        # republishes it under our own ``_dnsmesh-seen.<zone>``. That
+        # creates a self-loop in the federation discovery graph and,
+        # in fleets where many peers see us, can also push the local
+        # seen RRset over the recursive-resolver UDP buffer. Drop at
+        # the source so self never lands in the store.
+        own_spk = self._crypto.get_signing_public_key_bytes()
+
         accepted = 0
         for name in names:
             try:
@@ -563,6 +703,15 @@ class HeartbeatWorker:
                 continue
             for wire in records[: self._cfg.max_gossip_per_response]:
                 if not isinstance(wire, str):
+                    continue
+                # Cheap pre-check: parse-and-verify is the same call
+                # ``SeenStore.accept`` does, but here we use it solely
+                # to read ``operator_spk`` so we can short-circuit on
+                # self before the store insert. A wire that fails
+                # verification here will also fail there; ``accept``
+                # returns None and we correctly don't count it.
+                rec = HeartbeatRecord.parse_and_verify(wire, now=now_i)
+                if rec is not None and bytes(rec.operator_spk) == own_spk:
                     continue
                 try:
                     if self._store.accept(wire, remote_addr=zone, now=now_i):

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -1013,6 +1013,281 @@ class TestSeenGraphPublish:
         }
 
 
+class TestSeenGraphSelfFilterAndOrphanSweep:
+    """Self never belongs in a node's own ``_dnsmesh-seen.<zone>``
+    RRset. Seen is "OTHER nodes I have heard from" — listing self
+    creates a discovery-graph self-loop and inflates the RRset toward
+    the recursive-resolver UDP buffer cap.
+
+    Two layers of protection:
+      1. Drop self-wires at ingest in ``_fetch_and_ingest`` so they
+         never land in the local SeenStore.
+      2. Filter self when building ``next_wires`` in
+         ``_publish_seen_graph`` — defense-in-depth if a future
+         bootstrap path leaks self into the store via some other
+         route.
+
+    Plus a one-shot orphan sweep on first tick to clean up
+    accumulated wires from prior process lifetimes (mirrors the
+    round-22 sweep added for the heartbeat RRset).
+    """
+
+    def test_self_wire_in_store_not_republished_in_seen(
+        self, store, transport, now
+    ) -> None:
+        """If self somehow lands in the local SeenStore, the publish
+        path must filter it out — a node never lists itself in its
+        own seen RRset."""
+        own = _signer("operator-A", salt=b"A" * 32)
+        # Inject self directly into the store, simulating a stale
+        # bootstrap path that put it there (e.g. older builds that
+        # didn't filter at ingest).
+        own_hb = HeartbeatRecord(
+            endpoint="https://self.example.com",
+            operator_spk=own.get_signing_public_key_bytes(),
+            version="0.5.0",
+            ts=now - 10,
+            exp=now + 86400,
+        )
+        store.accept(own_hb.sign(own), now=now)
+        # Plus a real peer so the test exercises the "publish only
+        # the non-self entry" path, not the empty-set branch.
+        _publish_peer_heartbeat(
+            transport,
+            _signer("peer-a", salt=b"P" * 32),
+            "peer-a.example",
+            endpoint="https://peer-a.example.com",
+            ts=now,
+        )
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.6.2",
+            dns_zone="self.example",
+            seed_zones=("peer-a.example",),
+        )
+        worker = HeartbeatWorker(
+            cfg, own, store, record_writer=transport, dns_reader=transport
+        )
+        worker.tick_once(now=now)
+
+        published = transport.query_txt_record(seen_rrset_name("self.example")) or []
+        own_spk_hex = own.get_signing_public_key_bytes().hex()
+        for wire in published:
+            rec = HeartbeatRecord.parse_and_verify(wire, now=now)
+            assert rec is not None
+            assert (
+                bytes(rec.operator_spk).hex() != own_spk_hex
+            ), "self-wire leaked into our own _dnsmesh-seen RRset"
+        # And the legitimate peer IS there.
+        assert len(published) == 1
+
+    def test_peer_gossiping_us_back_does_not_seed_self(
+        self, store, transport, now
+    ) -> None:
+        """Root-cause check: when a peer's ``_dnsmesh-seen.<peer-zone>``
+        RRset includes our own wire (a peer that has heard from us
+        and republishes), ``_fetch_and_ingest`` must drop it before
+        ``SeenStore.accept`` so self never enters the local store.
+        Otherwise step 2 (publish filter) is the only thing keeping
+        self out of DNS, and any future bug there leaks immediately.
+        """
+        own = _signer("operator-A", salt=b"A" * 32)
+        peer = _signer("peer-B", salt=b"B" * 32)
+
+        # Peer's heartbeat zone — normal, peer's own wire.
+        _publish_peer_heartbeat(
+            transport,
+            peer,
+            "peer.example",
+            endpoint="https://peer.example.com",
+            ts=now,
+        )
+        # Peer's seen-graph zone — peer is gossiping our wire back.
+        own_hb = HeartbeatRecord(
+            endpoint="https://self.example.com",
+            operator_spk=own.get_signing_public_key_bytes(),
+            version="0.6.0",
+            ts=now - 5,
+            exp=now + 86400,
+        )
+        transport.publish_txt_record(seen_rrset_name("peer.example"), own_hb.sign(own))
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.6.2",
+            dns_zone="self.example",
+            seed_zones=("peer.example",),
+        )
+        worker = HeartbeatWorker(
+            cfg, own, store, record_writer=transport, dns_reader=transport
+        )
+        worker.tick_once(now=now)
+
+        # The local store should hold the peer's wire but NOT our
+        # own — even though the peer's gossip path served it.
+        own_spk_hex = own.get_signing_public_key_bytes().hex()
+        for row in store.list_recent(now=now):
+            assert (
+                row.operator_spk_hex != own_spk_hex
+            ), "self-wire ingested into local SeenStore via peer gossip"
+        # Peer's wire IS there.
+        assert any(
+            row.operator_spk_hex == peer.get_signing_public_key_bytes().hex()
+            for row in store.list_recent(now=now)
+        )
+
+    def test_first_tick_sweeps_prior_process_seen_orphans(
+        self, store, transport, now
+    ) -> None:
+        """Pre-seed ``_dnsmesh-seen.<own-zone>`` with stale self-
+        wires from earlier process lifetimes (a real-world failure
+        mode caused by self-leak + process-memory eviction tracking).
+        The first tick must clean them up so the published RRset
+        shrinks back to a single entry per peer.
+        """
+        own = _signer("operator-A", salt=b"A" * 32)
+        zone = "self.example"
+        # Three orphan self-wires at the seen RRset, simulating
+        # multiple prior lifetimes that all leaked self.
+        for offset in (-300, -120, -30):
+            old = HeartbeatRecord(
+                endpoint="https://self.example.com",
+                operator_spk=own.get_signing_public_key_bytes(),
+                version="0.6.0",
+                ts=now + offset,
+                exp=now + offset + 86400,
+            )
+            transport.publish_txt_record(seen_rrset_name(zone), old.sign(own))
+        # And one legitimate peer wire we want to keep.
+        peer = _signer("peer-B", salt=b"B" * 32)
+        peer_wire = _publish_peer_heartbeat(
+            transport,
+            peer,
+            "peer.example",
+            endpoint="https://peer.example.com",
+            ts=now,
+        )
+        # Peer is in our store via the harvest below; pre-publish
+        # it directly into the seen RRset so the sweep has a real
+        # peer to keep.
+        transport.publish_txt_record(seen_rrset_name(zone), peer_wire)
+        assert len(transport.query_txt_record(seen_rrset_name(zone))) == 4
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.6.2",
+            dns_zone=zone,
+            seed_zones=("peer.example",),
+        )
+        worker = HeartbeatWorker(
+            cfg, own, store, record_writer=transport, dns_reader=transport
+        )
+        worker.tick_once(now=now)
+
+        records = transport.query_txt_record(seen_rrset_name(zone)) or []
+        own_spk_hex = own.get_signing_public_key_bytes().hex()
+        # No self left.
+        for w in records:
+            rec = HeartbeatRecord.parse_and_verify(w, now=now)
+            assert rec is not None
+            assert bytes(rec.operator_spk).hex() != own_spk_hex
+        # Peer wire still there (untouched by the sweep — we never
+        # delete other operators' wires).
+        assert peer_wire in records
+
+    def test_seen_sweep_does_not_touch_other_operators(
+        self, store, transport, now
+    ) -> None:
+        """A shared zone (cluster siblings publishing into the same
+        ``_dnsmesh-seen.<shared-zone>``) must keep peers' wires
+        intact through the sweep. Only THIS operator's self-leakage
+        + our own prior stale copies of currently-seen peers are
+        targets. Codex round-19 P1 carry-over behavior.
+        """
+        own = _signer("operator-A", salt=b"A" * 32)
+        zone = "shared.example"
+
+        # A sibling node has published a wire at the shared zone.
+        sibling_signer = _signer("sibling", salt=b"S" * 32)
+        sibling_peer_wire = _publish_peer_heartbeat(
+            transport,
+            sibling_signer,
+            "sib-peer.example",
+            endpoint="https://sib-peer.example.com",
+            ts=now - 30,
+        )
+        # Sibling published the sib-peer wire into the shared seen
+        # RRset directly (simulating cluster co-publish).
+        transport.publish_txt_record(seen_rrset_name(zone), sibling_peer_wire)
+
+        # Plant a self-orphan from an earlier process lifetime.
+        own_old = HeartbeatRecord(
+            endpoint="https://self.example.com",
+            operator_spk=own.get_signing_public_key_bytes(),
+            version="0.6.0",
+            ts=now - 200,
+            exp=now - 200 + 86400,
+        )
+        transport.publish_txt_record(seen_rrset_name(zone), own_old.sign(own))
+        assert len(transport.query_txt_record(seen_rrset_name(zone))) == 2
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.6.2",
+            dns_zone=zone,
+        )
+        worker = HeartbeatWorker(
+            cfg, own, store, record_writer=transport, dns_reader=transport
+        )
+        worker.tick_once(now=now)
+
+        records = transport.query_txt_record(seen_rrset_name(zone)) or []
+        # Sibling's wire SURVIVED.
+        assert sibling_peer_wire in records
+        # Self-orphan deleted.
+        own_spk_hex = own.get_signing_public_key_bytes().hex()
+        for w in records:
+            rec = HeartbeatRecord.parse_and_verify(w, now=now)
+            assert rec is not None
+            assert bytes(rec.operator_spk).hex() != own_spk_hex
+
+    def test_seen_sweep_only_runs_once(self, store, transport, now) -> None:
+        """Subsequent ticks shouldn't re-sweep — the in-process
+        ``_last_seen_wires`` tracking handles eviction from there
+        forward. Re-querying the RRset every tick is wasted I/O and
+        could mask a legitimate operator-side write that should be
+        treated as authoritative."""
+        own = _signer("operator-A", salt=b"A" * 32)
+        zone = "self.example"
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.6.2",
+            dns_zone=zone,
+        )
+        worker = HeartbeatWorker(
+            cfg, own, store, record_writer=transport, dns_reader=transport
+        )
+        worker.tick_once(now=now)
+        assert worker._seen_orphan_sweep_done is True
+
+        # Plant a fake self-orphan AFTER tick 1. Subsequent ticks
+        # must NOT touch it (the flag gates the one-time behavior).
+        rogue = HeartbeatRecord(
+            endpoint="https://self.example.com",
+            operator_spk=own.get_signing_public_key_bytes(),
+            version="0.6.0",
+            ts=now - 60,
+            exp=now - 60 + 86400,
+        )
+        rogue_wire = rogue.sign(own)
+        transport.publish_txt_record(seen_rrset_name(zone), rogue_wire)
+
+        worker.tick_once(now=now + 60)
+        records = transport.query_txt_record(seen_rrset_name(zone)) or []
+        assert rogue_wire in records, "post-sweep planted wire must NOT be re-cleaned"
+
+
 class TestLifecycle:
     def test_start_stop(self, store, transport) -> None:
         cfg = HeartbeatWorkerConfig(


### PR DESCRIPTION
## Summary

Three related federation-discovery bugs surfaced in production today on the live `dnsmesh.io` node. Combined with PR #14's TCP-listener-and-TooBig fix already on main, this PR closes the remaining gaps so **0.6.2** can ship a complete fix.

## Production diagnosis

Each node's landing page was reporting "Recent peers (2)" but the directory aggregator showed `seen_edges: 0`. Tracing it down:

```
$ dig @1.1.1.1 +tcp TXT _dnsmesh-seen.dmp.dnsmesh.io
;; status: SERVFAIL  EDE=23 "Network Error"
```

From inside the host (UDP only, the live node has no TCP listener yet):

- `_dnsmesh-heartbeat.<zone>` → NOERROR + 310-byte answer ✅
- `_dnsmesh-seen.<zone>` → server returns sub-12-byte malformed packet → dig reports "short < header size" + timeout ❌

The journal had the smoking gun:

```
dns.exception.TooBig: The DNS message is too big.
```

`response.to_wire()` was raising and Python's socketserver swallowed the exception, leaving the UDP socket without a reply.

## The three bugs

| Bug | Impact | Fix |
|---|---|---|
| **C — server crashes on TooBig** | Single oversized response kills federation discovery for any RFC-strict resolver | Already on main via PR #14 (TC=1 truncated stub on UDP, SERVFAIL on TCP) |
| **A — self leaks into local SeenStore** | Once a peer gossips us back in their seen-graph, we ingest our own wire and republish it under our own seen-zone, creating a self-loop and bloating the RRset | This PR — `_fetch_and_ingest` parses each wire and skips ones whose `operator_spk == self` |
| **B — `_last_seen_wires` lost on restart** | Worker restart loses eviction tracking; prior wires linger 24h until TTL expires; across upgrade cycles the RRset grows past the 1232-byte EDNS buffer and trips Bug C | This PR — one-shot orphan sweep on first `_publish_seen_graph` invocation, mirroring the round-22 sweep added for the heartbeat RRset |

The live node had 7 rows in the records table for `_dnsmesh-seen.dmp.dnsmesh.io` (3 distinct self-wires + 4 distinct peer-wires) while `heartbeats_seen` only had 2 rows — concrete proof of orphan accumulation.

## What changed

`dmp/server/heartbeat_worker.py`:

- `_fetch_and_ingest`: parse-and-verify each wire to check `operator_spk` before `SeenStore.accept` and skip self at the source (Bug A root cause).
- `_publish_seen_graph`: defense-in-depth filter on `operator_spk_hex` when building `next_wires`. A future bootstrap path that plants self in the store via some other route still cannot leak into DNS.
- `_sweep_orphan_seen_wires`: new method, runs once per worker lifetime. Deletes self-wires unconditionally and stale prior-tick copies of peers we still see (matched by `(operator_spk_hex, endpoint)`). Cluster siblings' wires under shared `_dnsmesh-seen.<shared-zone>` stay intact.
- `_seen_orphan_sweep_done` flag gates the one-time behavior so subsequent ticks rely on the in-process `_last_seen_wires` tracking.

`tests/test_heartbeat_worker.py` — 5 new tests in `TestSeenGraphSelfFilterAndOrphanSweep`:

- `test_self_wire_in_store_not_republished_in_seen` — Bug A defense-in-depth.
- `test_peer_gossiping_us_back_does_not_seed_self` — Bug A root cause.
- `test_first_tick_sweeps_prior_process_seen_orphans` — Bug B.
- `test_seen_sweep_does_not_touch_other_operators` — cluster-shared-zone safety.
- `test_seen_sweep_only_runs_once` — flag invariant.

## Test plan

- [x] `pytest tests/test_heartbeat_worker.py` — 31 passed (26 prior + 5 new)
- [x] `pytest tests/ --ignore=tests/test_docker_integration.py` — 1423 passed, 3 skipped
- [x] `black --check dmp tests` — clean
- [ ] After merge: tag `sdk-v0.6.2`, `cli-v0.6.2`, `image-v0.6.2`. Wait for the live nodes to pick up the image, query `_dnsmesh-seen` on both ends, confirm directory aggregator shows arrows.