### PR TITLE
release: 0.6.2 — federation discovery fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,91 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.6.2] — 2026-04-30 — federation discovery fix
+
+Targeted patch release. The seen-graph DNS path
+(`_dnsmesh-seen.<zone>`) was crashing on the public reference
+nodes once a few heartbeat ticks had run, breaking federation
+discovery for any RFC-strict recursive resolver. Three
+independent bugs combined to produce the symptom; this release
+fixes all three. Operators upgrade in place via
+`pip install -U dnsmesh && systemctl restart dnsmesh-node`
+(native install) or `docker compose pull && docker compose up -d`
+(Docker). Wire format, on-disk schema, and CLI surfaces are
+byte-identical to 0.6.1.
+
+### Fixed
+
+- **DNS server crashed on `dns.exception.TooBig` for oversized
+  UDP responses.** When the response RRset exceeded the
+  resolver's negotiated EDNS buffer (1232 bytes by default),
+  `dns.message.to_wire()` raised, Python's socketserver swallowed
+  the exception, and the UDP socket sent nothing. Recursive
+  resolvers saw "no answer" and returned SERVFAIL with EDE=23
+  ("Network Error") — silently breaking discovery. Server now
+  catches `TooBig` on the UDP path and emits a valid TC=1
+  truncated stub per RFC 1035 §4.2.2 so resolvers fall back to
+  TCP. (PR #14.)
+- **Authoritative DNS server didn't accept TCP at all.** The
+  RFC 1035 §4.2.2 / RFC 7766 fallback path is mandatory for
+  RFC-strict resolvers (Google 8.8.8.8, Level3 4.2.2.x). Without
+  it, any TC=1 truncated UDP response was a dead end. New
+  threading TCP listener at the same port as UDP, with
+  bounded per-connection concurrency, slow-loris mitigation
+  (lazy work-permit acquire after the message body is read,
+  separate accept-cap semaphore for open sockets), and
+  `request_queue_size = 128` so the kernel can absorb the
+  "many recursors retrying TCP within milliseconds" burst.
+  Six rounds of Codex review baked in. (PR #14.)
+- **Self-wire leaked into the local SeenStore via peer
+  gossip.** Once federation converged and a peer included our
+  wire in its own `_dnsmesh-seen.<peer-zone>` RRset,
+  `_fetch_and_ingest` accepted it and stored a self row.
+  `_publish_seen_graph` then republished it under our own
+  seen-zone, creating a discovery-graph self-loop and bloating
+  the RRset toward the EDNS buffer cap (which then tripped
+  the TooBig crash above). Fix: parse-and-verify each ingested
+  wire and drop ones whose `operator_spk` matches our own
+  before `SeenStore.accept`. (PR #16.)
+- **Process-memory `_last_seen_wires` lost on restart.** The
+  worker tracks "wires we published last tick" so it knows
+  what to evict on the next tick. The map is
+  process-memory only, so a worker restart left every prior
+  wire in place — and `publish_txt_record` is append-with-
+  content-keyed-dedup, so each tick layered fresh wires on top
+  without removing the stale ones. Across upgrade cycles the
+  RRset grew unbounded until each wire's exp fired (24h
+  default). One-shot orphan sweep on first
+  `_publish_seen_graph` invocation cleans them up — mirrors
+  the round-22 sweep added for `_publish_own`. Cluster
+  siblings' wires under a shared `_dnsmesh-seen.<shared-zone>`
+  are left intact (matched by `(operator_spk, endpoint)` to
+  avoid touching anything that isn't ours). (PR #16.)
+
+### Added
+
+- **`deploy/native-ubuntu/firewall.sh`** — optional helper that
+  configures `ufw` for the canonical DMP port set: SSH 22, DNS
+  53/udp+tcp, HTTP 80, HTTPS 443/tcp+udp. Idempotent. Three
+  modes: `--check` (audit only), default (apply rules), `--enable`
+  (apply + ufw enable). Driven by an operator note that the inline
+  ufw block in `install.sh` was missing TCP 53. (PR #15.)
+
+### Changed
+
+- **All Docker compose files now publish both UDP and TCP for
+  port 53.** Mandatory for RFC 1035 §4.2.2 fallback to work
+  through the host port mapping. Affects `docker-compose.yml`,
+  `docker-compose.prod.yml`, `docker-compose.cluster.yml`,
+  `deploy/docker/compose.yml`, and the m9/m10 test harnesses
+  under `scripts/`. (PR #14.)
+- **`Dockerfile` `EXPOSE`** updated to declare `5353/udp`,
+  `5353/tcp`, and `8053/tcp`. (PR #14.)
+- **Container integration test reader** switched from
+  `dns.query.udp()` to `dns.query.udp_with_fallback()` with EDNS0
+  4096-byte buffer advertised, modeling what a real RFC-strict
+  client does instead of the bare 512-byte default. (PR #14.)
+
 ## [0.6.1] — 2026-04-29 — publication-readiness pass
 
 Cleanup release on top of 0.6.0. Wire format, on-disk schema, and

--- a/dmp/__init__.py
+++ b/dmp/__init__.py
@@ -1,3 +1,3 @@
 """DNS Mesh Protocol - Federated end-to-end encrypted messaging over DNS"""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # The import path stays `import dmp` — distribution name and
     # import name intentionally differ (same pattern as pyyaml → yaml).
     name="dnsmesh",
-    version="0.6.1",
+    version="0.6.2",
     author="Oscar Valenzuela B",
     author_email="oscar.valenzuela.b@gmail.com",
     description="A federated end-to-end encrypted messaging protocol delivered over DNS",


### PR DESCRIPTION
## Summary

Targeted patch release closing the seen-graph DNS path bug that broke federation discovery on the public reference nodes. Three independent bugs combined to produce the symptom; this release ships fixes for all three.

Wire format, on-disk schema, and CLI surfaces are byte-identical to 0.6.1.

## Production diagnosis

`dnsmesh.io`'s landing page reported "Recent peers (2)" but the directory aggregator showed `seen_edges: 0`. Tracing it down:

```
$ dig @1.1.1.1 +tcp TXT _dnsmesh-seen.dmp.dnsmesh.io
;; status: SERVFAIL  EDE=23 "Network Error"
```

From inside the host, UDP only:

- `_dnsmesh-heartbeat.<zone>` → NOERROR + 310-byte answer ✅
- `_dnsmesh-seen.<zone>` → server returned a sub-12-byte malformed packet → dig reported "short < header size" + timeout ❌

Journal log gave the smoking gun: `dns.exception.TooBig: The DNS message is too big.` thrown from `response.to_wire()`. Python's socketserver swallowed it, leaving the UDP socket without a reply.

## What's in 0.6.2

| Bug | Fix | PR |
|---|---|---|
| Server crashed on TooBig for oversized UDP responses | UDP path now catches TooBig and emits TC=1 truncated stub per RFC 1035 §4.2.2 | #14 |
| No TCP listener at all (no fallback path for TC=1) | New threading TCP listener at the same port as UDP, slow-loris mitigation, accept cap | #14 |
| Self-wire leaked into local SeenStore via peer gossip | `_fetch_and_ingest` parses and drops wires where `operator_spk == self` | #16 |
| Orphan-sweep gap on worker restart | One-shot sweep on first `_publish_seen_graph` invocation; cluster-shared zones safe | #16 |
| Optional firewall helper for native-Ubuntu installs | `deploy/native-ubuntu/firewall.sh` (idempotent) | #15 |

## Files in this PR

- `dmp/__init__.py` — `__version__ = "0.6.2"`
- `setup.py` — `version="0.6.2"`
- `CHANGELOG.md` — 0.6.2 entry

## Release plan after merge

1. Pull main locally, `scripts/release/tag.sh all 0.6.2` to create the three tags
2. Push tags one at a time so we can watch each publish workflow:
   - `git push origin sdk-v0.6.2` → publish-pypi
   - `git push origin cli-v0.6.2` → publish-binaries (Linux/macOS/Windows GitHub Release)
   - `git push origin image-v0.6.2` → publish-image (Docker Hub)
3. Once `dnsmesh==0.6.2` is on PyPI, upgrade the live nodes:
   ```
   ssh root@dnsmesh.io 'pip install --upgrade dnsmesh && systemctl restart dnsmesh-node'
   ssh root@dnsmesh.pro 'pip install --upgrade dnsmesh && systemctl restart dnsmesh-node'
   ```
4. Wait one heartbeat tick (5 min). Verify with `dig @1.1.1.1 +tcp TXT _dnsmesh-seen.dmp.dnsmesh.io` — should return the peer's wire (not SERVFAIL). Refresh the directory page; topology arrows should appear.

## Test plan

- [x] PR #14 already on main, all checks green (1423 passed, 3 skipped)
- [x] PR #16 already on main, all checks green
- [x] `pytest tests/ --ignore=tests/test_docker_integration.py` — 1423 passed, 3 skipped
- [x] `black --check dmp tests` — clean
- [ ] After merge: `tag.sh all 0.6.2` → push tags → confirm publishers ship
- [ ] After live upgrade: `dig _dnsmesh-seen` returns peer wire from public chain
- [ ] After live upgrade: directory page renders federation arrows