### PR TITLE
fix(dns_server): apex A/AAAA records for self-glued delegations

### DIFF
--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -51,6 +51,8 @@ import dns.rcode
 import dns.rdataclass
 import dns.rdatatype
 import dns.rdtypes.ANY.TXT
+import dns.rdtypes.IN.A
+import dns.rdtypes.IN.AAAA
 import dns.rrset
 import dns.tsig
 
@@ -246,6 +248,52 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
         # Only handle the first question (standard DNS behavior).
         question = query.question[0]
         qname = question.name.to_text(omit_final_dot=True)
+
+        # Apex A/AAAA — answer the served-zone apex with the operator's
+        # configured public address(es). Strict recursive resolvers
+        # (Google 8.8.8.8, Level3 4.2.2.x) re-resolve the NS-target
+        # name out-of-bailiwick rather than trusting the parent zone's
+        # glue. With self-glued delegations like
+        # ``dmp.example NS dmp.example`` (the standard DigitalOcean
+        # subzone-delegation pattern), strict resolvers ask US for the
+        # A record of our own apex; without an answer they return
+        # NXDOMAIN for every name under the zone. Lenient resolvers
+        # (Cloudflare, Quad9) trust the glue and never ask, which
+        # masks the bug in casual testing. Configured via
+        # ``DMP_DNS_APEX_A`` + ``DMP_DNS_APEX_AAAA`` on DMPNode.
+        apex_zone = getattr(self.server, "apex_zone", None) or ""
+        if apex_zone and qname.lower() == apex_zone.lower():
+            ttl = self.server.ttl
+            if question.rdtype == dns.rdatatype.A:
+                apex_a = getattr(self.server, "apex_a", None)
+                if apex_a:
+                    response.answer.append(
+                        dns.rrset.from_rdata(
+                            question.name,
+                            ttl,
+                            dns.rdtypes.IN.A.A(
+                                rdclass=dns.rdataclass.IN,
+                                rdtype=dns.rdatatype.A,
+                                address=apex_a,
+                            ),
+                        )
+                    )
+                return response
+            if question.rdtype == dns.rdatatype.AAAA:
+                apex_aaaa = getattr(self.server, "apex_aaaa", None)
+                if apex_aaaa:
+                    response.answer.append(
+                        dns.rrset.from_rdata(
+                            question.name,
+                            ttl,
+                            dns.rdtypes.IN.AAAA.AAAA(
+                                rdclass=dns.rdataclass.IN,
+                                rdtype=dns.rdatatype.AAAA,
+                                address=apex_aaaa,
+                            ),
+                        )
+                    )
+                return response
 
         if question.rdtype != dns.rdatatype.TXT:
             # We only serve TXT. Everything else → NOERROR with empty answer.
@@ -898,6 +946,9 @@ class _ThreadingUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
         update_max_ttl=DEFAULT_UPDATE_MAX_TTL,
         update_max_value_bytes=DEFAULT_UPDATE_MAX_VALUE_BYTES,
         update_max_values_per_name=DEFAULT_UPDATE_MAX_VALUES_PER_NAME,
+        apex_zone=None,
+        apex_a=None,
+        apex_aaaa=None,
         semaphore=None,
     ):
         super().__init__(server_address, handler_cls)
@@ -917,6 +968,12 @@ class _ThreadingUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
         self.update_max_ttl = int(update_max_ttl)
         self.update_max_value_bytes = int(update_max_value_bytes)
         self.update_max_values_per_name = int(update_max_values_per_name)
+        # Apex A/AAAA records — see `_DMPRequestHandler._build_response`
+        # for the full rationale. Operator-configured via
+        # `DMP_DNS_APEX_A` / `DMP_DNS_APEX_AAAA`.
+        self.apex_zone = apex_zone or None
+        self.apex_a = apex_a or None
+        self.apex_aaaa = apex_aaaa or None
         # ``semaphore`` lets the caller (DMPDnsServer) hand in a
         # shared bounded-worker budget so UDP + TCP listeners enforce
         # ONE global cap of ``max_concurrency`` handler threads
@@ -1001,6 +1058,9 @@ class _ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         update_max_ttl=DEFAULT_UPDATE_MAX_TTL,
         update_max_value_bytes=DEFAULT_UPDATE_MAX_VALUE_BYTES,
         update_max_values_per_name=DEFAULT_UPDATE_MAX_VALUES_PER_NAME,
+        apex_zone=None,
+        apex_a=None,
+        apex_aaaa=None,
         semaphore=None,
     ):
         super().__init__(server_address, handler_cls)
@@ -1020,6 +1080,12 @@ class _ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         self.update_max_ttl = int(update_max_ttl)
         self.update_max_value_bytes = int(update_max_value_bytes)
         self.update_max_values_per_name = int(update_max_values_per_name)
+        # Apex A/AAAA — see _ThreadingUDPServer for rationale. TCP
+        # listener exposes the same fields so strict resolvers using
+        # the TCP path see the same authoritative apex address.
+        self.apex_zone = apex_zone or None
+        self.apex_a = apex_a or None
+        self.apex_aaaa = apex_aaaa or None
         # ``_semaphore`` (work permit, shared with UDP) caps in-flight
         # handler work — query parsing, response building, sendall.
         # Acquired lazily inside the handler AFTER the message body
@@ -1111,6 +1177,9 @@ class DMPDnsServer:
         update_max_ttl: int = DEFAULT_UPDATE_MAX_TTL,
         update_max_value_bytes: int = DEFAULT_UPDATE_MAX_VALUE_BYTES,
         update_max_values_per_name: int = DEFAULT_UPDATE_MAX_VALUES_PER_NAME,
+        apex_zone: Optional[str] = None,
+        apex_a: Optional[str] = None,
+        apex_aaaa: Optional[str] = None,
         tcp_enabled: bool = True,
     ):
         """``writer``, a TSIG source, and ``allowed_zones`` together
@@ -1179,6 +1248,16 @@ class DMPDnsServer:
         self.update_max_ttl = int(update_max_ttl)
         self.update_max_value_bytes = int(update_max_value_bytes)
         self.update_max_values_per_name = int(update_max_values_per_name)
+        # Apex A/AAAA. Operators on a self-glued subzone delegation
+        # (parent zone publishes ``<sub> NS <sub>`` plus glue A) need
+        # the node to answer A queries for its own apex name so
+        # strict recursive resolvers (Google 8.8.8.8, Level3 4.2.2.x)
+        # accept the delegation. Operators on a more conventional
+        # ``<sub> NS <sub-of-parent>`` setup don't need this and can
+        # leave it None.
+        self.apex_zone = apex_zone or None
+        self.apex_a = apex_a or None
+        self.apex_aaaa = apex_aaaa or None
         self.tcp_enabled = bool(tcp_enabled)
         self._server: Optional[_ThreadingUDPServer] = None
         self._thread: Optional[threading.Thread] = None
@@ -1208,6 +1287,9 @@ class DMPDnsServer:
             "update_max_ttl": self.update_max_ttl,
             "update_max_value_bytes": self.update_max_value_bytes,
             "update_max_values_per_name": self.update_max_values_per_name,
+            "apex_zone": self.apex_zone,
+            "apex_a": self.apex_a,
+            "apex_aaaa": self.apex_aaaa,
         }
 
     def start(self) -> None:

--- a/dmp/server/node.py
+++ b/dmp/server/node.py
@@ -20,6 +20,14 @@ Environment variables (all optional, sensible defaults for dev):
     DMP_DNS_TTL            TTL seconds advertised in DNS     default: 60
     DMP_DNS_RATE           DNS queries per second per IP     default: 0 (disabled)
     DMP_DNS_BURST          DNS burst budget per IP           default: 0
+    DMP_DNS_APEX_A         IPv4 address served at the zone   default: none
+                           apex (DMP_DOMAIN). Required for
+                           self-glued subzone delegations
+                           (parent zone uses ``<sub> NS <sub>``
+                           with glue A) so strict resolvers
+                           accept the delegation.
+    DMP_DNS_APEX_AAAA      IPv6 address served at the zone   default: none
+                           apex. Same use case as DMP_DNS_APEX_A.
     DMP_HTTP_HOST          bind host for HTTP API            default: 0.0.0.0
     DMP_HTTP_PORT          TCP port for HTTP API             default: 8053
     DMP_HTTP_TOKEN         bearer token for /v1/*            default: none (open)
@@ -648,6 +656,18 @@ class DMPNodeConfig:
     # new connections/packets rather than spawning unbounded threads.
     http_max_concurrency: int = 64
     dns_max_concurrency: int = 128
+    # Apex A/AAAA records. Set on operators whose parent-zone delegation
+    # uses self-glue (``<sub> NS <sub>`` + glue A on the parent). Strict
+    # recursive resolvers (Google 8.8.8.8, Level3 4.2.2.x) re-resolve the
+    # NS-target out-of-bailiwick rather than trusting the glue, and that
+    # second lookup hits OUR DNS server asking for the A of our own
+    # zone-apex name. Without an answer they return NXDOMAIN for every
+    # name under the zone — the federation discovery path silently
+    # breaks for a chunk of the resolver fleet (~33% in our 6-resolver
+    # reachability matrix). When set, the DNS server answers
+    # ``<dns_zone> A`` and ``<dns_zone> AAAA`` with these values.
+    dns_apex_a: Optional[str] = None
+    dns_apex_aaaa: Optional[str] = None
     cleanup_interval: float = 60.0
     log_level: str = "INFO"
     log_format: str = "text"  # "text" or "json"
@@ -779,6 +799,8 @@ class DMPNodeConfig:
             dns_max_concurrency=int(
                 os.environ.get("DMP_DNS_MAX_CONCURRENCY", cls.dns_max_concurrency)
             ),
+            dns_apex_a=os.environ.get("DMP_DNS_APEX_A") or None,
+            dns_apex_aaaa=os.environ.get("DMP_DNS_APEX_AAAA") or None,
             cleanup_interval=float(
                 os.environ.get("DMP_CLEANUP_INTERVAL", cls.cleanup_interval)
             ),
@@ -937,6 +959,16 @@ class DMPNode:
                 "update_max_value_bytes": int(self.config.max_value_bytes),
                 "update_max_values_per_name": int(self.config.max_values_per_name),
             }
+        # Apex A/AAAA — the served zone is the apex name we'll answer
+        # for. Falls through to whatever the caller set on the env var
+        # (DMP_DOMAIN / DMP_CLUSTER_BASE_DOMAIN / claim-provider zone)
+        # via _load_served_zone. If neither apex value is set we pass
+        # apex_zone=None too so the dispatcher fast-path stays inactive.
+        _apex_zone = (
+            _load_served_zone()
+            if (self.config.dns_apex_a or self.config.dns_apex_aaaa)
+            else None
+        )
         self.dns = DMPDnsServer(
             self.store,
             host=self.config.dns_host,
@@ -947,6 +979,9 @@ class DMPNode:
                 burst=self.config.dns_burst,
             ),
             max_concurrency=self.config.dns_max_concurrency,
+            apex_zone=_apex_zone,
+            apex_a=self.config.dns_apex_a,
+            apex_aaaa=self.config.dns_apex_aaaa,
             **update_kwargs,
         )
         # Derive the cluster base domain for the gossip endpoint — same

--- a/docs/deployment/dns-delegation.md
+++ b/docs/deployment/dns-delegation.md
@@ -241,6 +241,54 @@ most modern panels add this automatically when you create an NS
 record pointing at a name under the delegated zone. If your panel
 doesn't, delegate to `example.com.` instead (no glue needed).
 
+## Self-glued delegation: `DMP_DNS_APEX_A` (0.6.3+)
+
+DigitalOcean's "create DNS subdomain" flow produces a **self-glued**
+delegation by default: when you point `mesh.example.com` at the box,
+the panel writes
+
+```
+mesh.example.com.   3600 IN NS   mesh.example.com.   ; self-referential
+mesh.example.com.   3600 IN A    203.0.113.42         ; glue
+```
+
+The `NS` record names itself as the authoritative server, and a
+parent-side `A` record at the same name acts as glue.
+
+Lenient resolvers (Cloudflare 1.1.1.1, Quad9 9.9.9.9) trust the
+glue and resolve names under `mesh.example.com` correctly. **Strict
+resolvers (Google 8.8.8.8, Level3 4.2.2.x) re-resolve the
+NS-target name out-of-bailiwick** rather than trusting the parent
+zone's glue. They ask *the DMP node itself* "what's the A for
+`mesh.example.com`?" and, since the node by default only serves
+TXT, get nothing back. Result: NXDOMAIN for every name under the
+zone, federation discovery silently breaks for ~33% of the
+public-resolver fleet.
+
+The 0.6.3+ fix is operator-side: set `DMP_DNS_APEX_A` (and
+`DMP_DNS_APEX_AAAA` if the box has IPv6) in `/etc/dnsmesh/node.env`
+to your VPS's public address. The node then answers
+`<DMP_DOMAIN> A` and `<DMP_DOMAIN> AAAA` queries with that value,
+and strict resolvers stop NXDOMAINing.
+
+```bash
+# /etc/dnsmesh/node.env
+DMP_DNS_APEX_A=203.0.113.42
+# DMP_DNS_APEX_AAAA=2001:db8::42  # only if you have v6
+```
+
+```bash
+sudo systemctl restart dnsmesh-node
+
+# Verify with each strict resolver — expect NOERROR with an answer:
+dig @8.8.8.8 mesh.example.com A
+dig @4.2.2.2 mesh.example.com A
+```
+
+The cleaner alternative is to flip the delegation pattern at the
+registrar (out-of-bailiwick NS like `mesh.example NS ns1.example`,
+no glue needed). The apex A is the no-touch-the-DNS-panel path.
+
 ## DNS server settings on the node
 
 The DMP node needs to:

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -127,6 +127,171 @@ class TestDMPDnsServer:
             server2.stop()
 
 
+class TestDMPDnsServerApexAddressRecords:
+    """Operators on a self-glued subzone delegation
+    (``<sub> NS <sub>`` with parent-side glue A) need the node to
+    answer A queries for its OWN apex name. Strict resolvers
+    (Google 8.8.8.8, Level3 4.2.2.x) re-resolve the NS-target
+    out-of-bailiwick rather than trusting the parent-zone glue;
+    if we don't answer, they NXDOMAIN every name under the zone.
+
+    Without ``apex_zone``+``apex_a`` configured, behavior is
+    unchanged from prior releases (A → NOERROR with empty answer).
+    """
+
+    def test_apex_a_returned_for_zone_apex(self):
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.A)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        assert str(response.answer[0][0]) == "203.0.113.42"
+
+    def test_apex_aaaa_returned_for_zone_apex(self):
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_aaaa="2001:db8::42",
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.AAAA)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        assert str(response.answer[0][0]) == "2001:db8::42"
+
+    def test_apex_a_case_insensitive(self):
+        """DNS names are case-insensitive — a query for ``DMP.Mesh.Test``
+        must hit the same apex code path as ``dmp.mesh.test``."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+        ):
+            request = dns.message.make_query("DMP.Mesh.Test", dns.rdatatype.A)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        assert str(response.answer[0][0]) == "203.0.113.42"
+
+    def test_a_query_for_non_apex_name_returns_empty(self):
+        """A records are ONLY served at the configured apex. A query
+        for any other name under the zone (e.g. a TXT-bearing owner
+        like ``_dnsmesh-heartbeat.dmp.mesh.test``) gets the legacy
+        NOERROR-empty response — we don't accidentally start serving
+        every name in the world."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+        ):
+            request = dns.message.make_query(
+                "_dnsmesh-heartbeat.dmp.mesh.test", dns.rdatatype.A
+            )
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+
+    def test_aaaa_at_apex_without_aaaa_config_returns_empty(self):
+        """Apex configured with A only — AAAA query at apex returns
+        NOERROR-empty (not NXDOMAIN). DNS protocol semantics: a name
+        that exists with one type but not another should NOT NXDOMAIN."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.AAAA)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+
+    def test_apex_txt_still_routes_to_store(self):
+        """Apex A configuration must NOT mask TXT queries at the same
+        apex name. TXT continues to dispatch through the record store
+        — operators may publish records at the zone apex (e.g.
+        ``v=spf1 -all``) and we must serve them."""
+        store = InMemoryDNSStore()
+        store.publish_txt_record("dmp.mesh.test", "v=spf1 -all")
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.TXT)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        rdata = response.answer[0][0]
+        assert b"".join(rdata.strings) == b"v=spf1 -all"
+
+    def test_apex_unconfigured_a_returns_empty_answer(self):
+        """Without apex_zone configured, an A query at the would-be
+        apex name returns the legacy NOERROR-empty — the apex
+        fast-path stays disabled. Backward-compat invariant for
+        operators on a conventional NS-out-of-bailiwick delegation."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        # No apex_zone / apex_a passed → fast-path inactive.
+        with DMPDnsServer(store, host="127.0.0.1", port=port):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.A)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+
+    def test_apex_a_via_tcp(self):
+        """A queries arriving over TCP (recursors that go straight
+        to TCP, or after TC=1) must hit the same apex path."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.A)
+            response = dns.query.tcp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        assert str(response.answer[0][0]) == "203.0.113.42"
+
+
 class TestDMPDnsServerRateLimitAndConcurrency:
     """Regressions caught by codex review of the TCP listener PR.
 


### PR DESCRIPTION
## Summary

DMPDnsServer now answers A and AAAA queries at the configured zone apex with operator-supplied addresses. Without it, strict recursive resolvers (Google 8.8.8.8, Level3 4.2.2.x) NXDOMAIN every name under the zone when the parent zone uses self-glued delegation (the standard DigitalOcean "create subdomain" pattern).

## Background

The directory-page resolver matrix shows 4/6 resolvers reaching the public reference nodes — Google + Level3 fail. Diagnosis:

```
$ dig @8.8.8.8 _dnsmesh-heartbeat.dmp.dnsmesh.io
;; status: NXDOMAIN

$ dig @ns3.digitalocean.com NS dmp.dnsmesh.io
;; AUTHORITY SECTION:
dmp.dnsmesh.io.   3600 IN NS  dmp.dnsmesh.io.   ← self-referential
dmp.dnsmesh.io.   3600 IN A   24.199.107.165    ← parent-side glue

$ dig +trace _dnsmesh-heartbeat.dmp.dnsmesh.io
...
dmp.dnsmesh.io.   3600 IN NS  dmp.dnsmesh.io.
couldn't get address for 'dmp.dnsmesh.io': not found
```

Lenient resolvers (Cloudflare, Quad9) trust the parent-side glue. Strict resolvers re-resolve the NS-target name out-of-bailiwick — they ask the DMP node itself for `dmp.dnsmesh.io A` and the node, only serving TXT, returns nothing. Resolution loop terminates, NXDOMAIN propagates. Federation discovery silently breaks for ~33% of the resolver fleet.

## Fix

Operator-configured apex A/AAAA via env:

```
DMP_DNS_APEX_A=203.0.113.42
DMP_DNS_APEX_AAAA=2001:db8::42  # optional
```

`DMPNode.from_env` reads these, looks up the served zone via the existing `_load_served_zone()` helper, and wires `apex_zone` / `apex_a` / `apex_aaaa` through `DMPDnsServer` to both the UDP and TCP request handlers (strict resolvers can arrive on either transport, e.g. after TC=1).

Default-off: when the env vars aren't set, behavior is unchanged — the apex fast-path stays inactive, A queries fall through to the legacy "NOERROR with empty answer" branch. Operators on a conventional out-of-bailiwick NS delegation don't need this and won't notice.

## Files

- `dmp/server/dns_server.py` — apex dispatch in `_DMPRequestHandler._build_response`; `apex_zone` / `apex_a` / `apex_aaaa` plumbed through `DMPDnsServer`, `_ThreadingUDPServer`, `_ThreadingTCPServer`, and `_server_kwargs()`. Added `dns.rdtypes.IN.A` / `dns.rdtypes.IN.AAAA` imports.
- `dmp/server/node.py` — new `DMPNodeConfig.dns_apex_a` / `dns_apex_aaaa` fields read from env. Module docstring updated. Apex zone derivation gated on either env var being set so the fast-path stays off when nothing is configured.
- `tests/test_dns_server.py` — new `TestDMPDnsServerApexAddressRecords` class, 8 tests:
  - `test_apex_a_returned_for_zone_apex`
  - `test_apex_aaaa_returned_for_zone_apex`
  - `test_apex_a_case_insensitive`
  - `test_a_query_for_non_apex_name_returns_empty`
  - `test_aaaa_at_apex_without_aaaa_config_returns_empty` (NOERROR not NXDOMAIN — type-vs-name semantics)
  - `test_apex_txt_still_routes_to_store` (apex TXT passthrough invariant)
  - `test_apex_unconfigured_a_returns_empty_answer` (backward-compat default)
  - `test_apex_a_via_tcp` (TCP transport parity)
- `docs/deployment/dns-delegation.md` — new "Self-glued delegation: `DMP_DNS_APEX_A` (0.6.3+)" section right after the existing glue-record edge case, explaining the symptom, lenient-vs-strict resolver split, and the fix.

## Test plan

- [x] `pytest tests/test_dns_server.py::TestDMPDnsServerApexAddressRecords` — 8 passed
- [x] `pytest tests/ --ignore=tests/test_docker_integration.py` — 1431 passed, 3 skipped (1423 prior + 8 new)
- [x] `black --check dmp tests` — clean
- [ ] After merge + 0.6.3 release + live-node upgrade: `dig @8.8.8.8 _dnsmesh-heartbeat.dmp.dnsmesh.io` returns NOERROR with the heartbeat record (was NXDOMAIN). Same for Level3 (4.2.2.2). Directory page resolver matrix flips Google + Level3 from red to green.

## Release plan

After merge, this is the only fix in 0.6.3:
1. Bump `dmp/__init__.py` + `setup.py` to `0.6.2 → 0.6.3`
2. Append CHANGELOG entry
3. Tag `sdk-v0.6.3`, `cli-v0.6.3`, `image-v0.6.3` from main and push
4. After PyPI is fresh, run `upgrade.sh` on dnsmesh.io and dnsmesh.pro, set `DMP_DNS_APEX_A` in `/etc/dnsmesh/node.env`, restart