### PR TITLE
chore(directory): add dmp.dnsmesh.de seed

### DIFF
--- a/directory/seeds.txt
+++ b/directory/seeds.txt
@@ -25,3 +25,4 @@
 
 dmp.dnsmesh.io
 dmp.dnsmesh.pro
+dmp.dnsmesh.de


### PR DESCRIPTION
## Summary

New public reference node, hosted on a German VPS at \`178.104.241.208\`, running 0.6.3 with apex-A configured. Federation seeded against the existing \`.io\` and \`.pro\` nodes so it shows up in their seen-graphs after the next heartbeat tick.

Out-of-bailiwick NS delegation from day one (\`dmp.dnsmesh.de NS ns1.dnsmesh.de\`) so Google + Level3 accept the zone without the staggered-recovery delay we hit on the \`.io\` and \`.pro\` cleanup.

## Verification

\`\`\`
$ dig +short @1.1.1.1 A dmp.dnsmesh.de
178.104.241.208

$ dig +tcp +short @1.1.1.1 TXT _dnsmesh-heartbeat.dmp.dnsmesh.de
"v=dmp1;t=heartbeat;..."  (endpoint=https://dnsmesh.de, version=0.6.3)

$ curl -fsSI https://dnsmesh.de/
HTTP/2 200
\`\`\`

## Files

- \`directory/seeds.txt\` — appended one line: \`dmp.dnsmesh.de\`

## Test plan

- [x] DNS chain works via the public recursive resolvers
- [x] Heartbeat publishing
- [x] HTTPS + valid Let's Encrypt cert at https://dnsmesh.de/
- [ ] After merge: pages.yml runs aggregator, directory page lists 3 nodes (was 2) and topology shows triangle once seen-graph converges