### PR TITLE
fix(dns_server): apex SOA + NS records for strict-resolver delegations

### DIFF
--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -50,6 +50,8 @@ import dns.opcode
 import dns.rcode
 import dns.rdataclass
 import dns.rdatatype
+import dns.rdtypes.ANY.NS
+import dns.rdtypes.ANY.SOA
 import dns.rdtypes.ANY.TXT
 import dns.rdtypes.IN.A
 import dns.rdtypes.IN.AAAA
@@ -249,18 +251,22 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
         question = query.question[0]
         qname = question.name.to_text(omit_final_dot=True)
 
-        # Apex A/AAAA — answer the served-zone apex with the operator's
-        # configured public address(es). Strict recursive resolvers
-        # (Google 8.8.8.8, Level3 4.2.2.x) re-resolve the NS-target
-        # name out-of-bailiwick rather than trusting the parent zone's
-        # glue. With self-glued delegations like
-        # ``dmp.example NS dmp.example`` (the standard DigitalOcean
-        # subzone-delegation pattern), strict resolvers ask US for the
-        # A record of our own apex; without an answer they return
-        # NXDOMAIN for every name under the zone. Lenient resolvers
-        # (Cloudflare, Quad9) trust the glue and never ask, which
-        # masks the bug in casual testing. Configured via
-        # ``DMP_DNS_APEX_A`` + ``DMP_DNS_APEX_AAAA`` on DMPNode.
+        # Apex address + zone-meta records — answer at the served-zone
+        # apex with operator-configured values. Strict recursive
+        # resolvers (Google 8.8.8.8, Level3 4.2.2.x) re-resolve the
+        # NS-target name out-of-bailiwick rather than trusting the
+        # parent zone's glue, AND validate that the auth advertises
+        # SOA + NS at its own apex. If either of those queries comes
+        # back empty (NOERROR/0-answer), they mark the whole zone as
+        # a "lame delegation" and NXDOMAIN every name under it.
+        # Lenient resolvers (Cloudflare, Quad9) skip the validation
+        # step, which is why this bug hides in casual testing.
+        #
+        # Operator config (all optional, all gated on the served zone
+        # being known via DMP_DOMAIN):
+        #   DMP_DNS_APEX_A / DMP_DNS_APEX_AAAA — public address(es)
+        #   DMP_DNS_APEX_NS                    — NS hostname (e.g. ns1.<parent>)
+        #   DMP_DNS_APEX_SOA_RNAME             — SOA RNAME (operator email-as-name)
         apex_zone = getattr(self.server, "apex_zone", None) or ""
         if apex_zone and qname.lower() == apex_zone.lower():
             ttl = self.server.ttl
@@ -290,6 +296,50 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
                                 rdclass=dns.rdataclass.IN,
                                 rdtype=dns.rdatatype.AAAA,
                                 address=apex_aaaa,
+                            ),
+                        )
+                    )
+                return response
+            if question.rdtype == dns.rdatatype.NS:
+                apex_ns = getattr(self.server, "apex_ns", None)
+                if apex_ns:
+                    response.answer.append(
+                        dns.rrset.from_rdata(
+                            question.name,
+                            ttl,
+                            dns.rdtypes.ANY.NS.NS(
+                                rdclass=dns.rdataclass.IN,
+                                rdtype=dns.rdatatype.NS,
+                                target=dns.name.from_text(apex_ns),
+                            ),
+                        )
+                    )
+                return response
+            if question.rdtype == dns.rdatatype.SOA:
+                apex_ns = getattr(self.server, "apex_ns", None)
+                apex_rname = getattr(self.server, "apex_soa_rname", None)
+                if apex_ns and apex_rname:
+                    # SOA RFC 1035 §3.3.13. Defaults match a typical
+                    # authoritative-only zone with no AXFR slaves —
+                    # SERIAL is per-second wall clock (monotonic
+                    # for the next ~70 years inside the 32-bit
+                    # serial-number arithmetic window of RFC 1982),
+                    # REFRESH/RETRY/EXPIRE are the BIND operator
+                    # defaults, MINIMUM matches our standard TTL.
+                    response.answer.append(
+                        dns.rrset.from_rdata(
+                            question.name,
+                            ttl,
+                            dns.rdtypes.ANY.SOA.SOA(
+                                rdclass=dns.rdataclass.IN,
+                                rdtype=dns.rdatatype.SOA,
+                                mname=dns.name.from_text(apex_ns),
+                                rname=dns.name.from_text(apex_rname),
+                                serial=int(time.time()),
+                                refresh=3600,
+                                retry=600,
+                                expire=604800,
+                                minimum=ttl,
                             ),
                         )
                     )
@@ -949,6 +999,8 @@ class _ThreadingUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
         apex_zone=None,
         apex_a=None,
         apex_aaaa=None,
+        apex_ns=None,
+        apex_soa_rname=None,
         semaphore=None,
     ):
         super().__init__(server_address, handler_cls)
@@ -968,12 +1020,16 @@ class _ThreadingUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
         self.update_max_ttl = int(update_max_ttl)
         self.update_max_value_bytes = int(update_max_value_bytes)
         self.update_max_values_per_name = int(update_max_values_per_name)
-        # Apex A/AAAA records — see `_DMPRequestHandler._build_response`
-        # for the full rationale. Operator-configured via
-        # `DMP_DNS_APEX_A` / `DMP_DNS_APEX_AAAA`.
+        # Apex A/AAAA/NS/SOA records — see
+        # ``_DMPRequestHandler._build_response`` for the full
+        # rationale. Operator-configured via ``DMP_DNS_APEX_A``,
+        # ``DMP_DNS_APEX_AAAA``, ``DMP_DNS_APEX_NS``,
+        # ``DMP_DNS_APEX_SOA_RNAME``.
         self.apex_zone = apex_zone or None
         self.apex_a = apex_a or None
         self.apex_aaaa = apex_aaaa or None
+        self.apex_ns = apex_ns or None
+        self.apex_soa_rname = apex_soa_rname or None
         # ``semaphore`` lets the caller (DMPDnsServer) hand in a
         # shared bounded-worker budget so UDP + TCP listeners enforce
         # ONE global cap of ``max_concurrency`` handler threads
@@ -1061,6 +1117,8 @@ class _ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         apex_zone=None,
         apex_a=None,
         apex_aaaa=None,
+        apex_ns=None,
+        apex_soa_rname=None,
         semaphore=None,
     ):
         super().__init__(server_address, handler_cls)
@@ -1080,12 +1138,14 @@ class _ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         self.update_max_ttl = int(update_max_ttl)
         self.update_max_value_bytes = int(update_max_value_bytes)
         self.update_max_values_per_name = int(update_max_values_per_name)
-        # Apex A/AAAA — see _ThreadingUDPServer for rationale. TCP
-        # listener exposes the same fields so strict resolvers using
-        # the TCP path see the same authoritative apex address.
+        # Apex A/AAAA/NS/SOA — see _ThreadingUDPServer for rationale.
+        # TCP listener exposes the same fields so strict resolvers
+        # using the TCP path see identical authoritative apex records.
         self.apex_zone = apex_zone or None
         self.apex_a = apex_a or None
         self.apex_aaaa = apex_aaaa or None
+        self.apex_ns = apex_ns or None
+        self.apex_soa_rname = apex_soa_rname or None
         # ``_semaphore`` (work permit, shared with UDP) caps in-flight
         # handler work — query parsing, response building, sendall.
         # Acquired lazily inside the handler AFTER the message body
@@ -1180,6 +1240,8 @@ class DMPDnsServer:
         apex_zone: Optional[str] = None,
         apex_a: Optional[str] = None,
         apex_aaaa: Optional[str] = None,
+        apex_ns: Optional[str] = None,
+        apex_soa_rname: Optional[str] = None,
         tcp_enabled: bool = True,
     ):
         """``writer``, a TSIG source, and ``allowed_zones`` together
@@ -1248,16 +1310,26 @@ class DMPDnsServer:
         self.update_max_ttl = int(update_max_ttl)
         self.update_max_value_bytes = int(update_max_value_bytes)
         self.update_max_values_per_name = int(update_max_values_per_name)
-        # Apex A/AAAA. Operators on a self-glued subzone delegation
-        # (parent zone publishes ``<sub> NS <sub>`` plus glue A) need
-        # the node to answer A queries for its own apex name so
-        # strict recursive resolvers (Google 8.8.8.8, Level3 4.2.2.x)
-        # accept the delegation. Operators on a more conventional
-        # ``<sub> NS <sub-of-parent>`` setup don't need this and can
-        # leave it None.
+        # Apex A/AAAA/NS/SOA. Operators whose parent-zone delegation
+        # uses self-glue or any pattern where strict recursors will
+        # ask the auth for its own apex records need to set these so
+        # Google 8.8.8.8 / Level3 4.2.2.x accept the delegation.
+        # Without them strict resolvers mark the zone as a "lame
+        # delegation" and NXDOMAIN every name under it.
+        #   - apex_a     — IPv4 served at <apex_zone> A
+        #   - apex_aaaa  — IPv6 served at <apex_zone> AAAA
+        #   - apex_ns    — NS hostname served at <apex_zone> NS, also
+        #                  used as MNAME in the SOA RR
+        #   - apex_soa_rname — SOA RNAME (operator email-as-DNS-name,
+        #                      e.g. "hostmaster.<parent>")
+        # SOA is served only when both apex_ns AND apex_soa_rname are
+        # configured (the SOA needs both a primary nameserver and a
+        # responsible-party email per RFC 1035).
         self.apex_zone = apex_zone or None
         self.apex_a = apex_a or None
         self.apex_aaaa = apex_aaaa or None
+        self.apex_ns = apex_ns or None
+        self.apex_soa_rname = apex_soa_rname or None
         self.tcp_enabled = bool(tcp_enabled)
         self._server: Optional[_ThreadingUDPServer] = None
         self._thread: Optional[threading.Thread] = None
@@ -1290,6 +1362,8 @@ class DMPDnsServer:
             "apex_zone": self.apex_zone,
             "apex_a": self.apex_a,
             "apex_aaaa": self.apex_aaaa,
+            "apex_ns": self.apex_ns,
+            "apex_soa_rname": self.apex_soa_rname,
         }
 
     def start(self) -> None:

--- a/dmp/server/node.py
+++ b/dmp/server/node.py
@@ -28,6 +28,17 @@ Environment variables (all optional, sensible defaults for dev):
                            accept the delegation.
     DMP_DNS_APEX_AAAA      IPv6 address served at the zone   default: none
                            apex. Same use case as DMP_DNS_APEX_A.
+    DMP_DNS_APEX_NS        NS hostname served at the zone    default: none
+                           apex (e.g. "ns1.dnsmesh.de"). Required
+                           in addition to DMP_DNS_APEX_A for strict
+                           resolvers (Google 8.8.8.8, Level3 4.2.2.x)
+                           to accept the delegation as non-lame.
+                           Used as MNAME in the SOA RR too.
+    DMP_DNS_APEX_SOA_RNAME SOA RNAME at the zone apex        default: none
+                           (operator email-as-DNS-name, e.g.
+                           "hostmaster.dnsmesh.de"). The SOA RR
+                           is only emitted when both this AND
+                           DMP_DNS_APEX_NS are set.
     DMP_HTTP_HOST          bind host for HTTP API            default: 0.0.0.0
     DMP_HTTP_PORT          TCP port for HTTP API             default: 8053
     DMP_HTTP_TOKEN         bearer token for /v1/*            default: none (open)
@@ -668,6 +679,18 @@ class DMPNodeConfig:
     # ``<dns_zone> A`` and ``<dns_zone> AAAA`` with these values.
     dns_apex_a: Optional[str] = None
     dns_apex_aaaa: Optional[str] = None
+    # Apex NS + SOA RNAME. Set together when the operator wants
+    # strict resolvers (Google 8.8.8.8, Level3 4.2.2.x) to accept the
+    # delegation as non-lame: those resolvers query the auth for SOA
+    # and NS at its own apex; an empty NOERROR back is the trigger
+    # for marking the zone as broken. ``dns_apex_ns`` is a hostname
+    # (e.g. "ns1.dnsmesh.de") served at the apex NS RR and used as
+    # MNAME inside the SOA. ``dns_apex_soa_rname`` is the SOA RNAME
+    # (operator email-as-DNS-name, e.g. "hostmaster.dnsmesh.de").
+    # The SOA RR is only emitted when both are set; the NS RR fires
+    # whenever ``dns_apex_ns`` is set.
+    dns_apex_ns: Optional[str] = None
+    dns_apex_soa_rname: Optional[str] = None
     cleanup_interval: float = 60.0
     log_level: str = "INFO"
     log_format: str = "text"  # "text" or "json"
@@ -801,6 +824,8 @@ class DMPNodeConfig:
             ),
             dns_apex_a=os.environ.get("DMP_DNS_APEX_A") or None,
             dns_apex_aaaa=os.environ.get("DMP_DNS_APEX_AAAA") or None,
+            dns_apex_ns=os.environ.get("DMP_DNS_APEX_NS") or None,
+            dns_apex_soa_rname=os.environ.get("DMP_DNS_APEX_SOA_RNAME") or None,
             cleanup_interval=float(
                 os.environ.get("DMP_CLEANUP_INTERVAL", cls.cleanup_interval)
             ),
@@ -959,16 +984,21 @@ class DMPNode:
                 "update_max_value_bytes": int(self.config.max_value_bytes),
                 "update_max_values_per_name": int(self.config.max_values_per_name),
             }
-        # Apex A/AAAA — the served zone is the apex name we'll answer
-        # for. Falls through to whatever the caller set on the env var
-        # (DMP_DOMAIN / DMP_CLUSTER_BASE_DOMAIN / claim-provider zone)
-        # via _load_served_zone. If neither apex value is set we pass
-        # apex_zone=None too so the dispatcher fast-path stays inactive.
-        _apex_zone = (
-            _load_served_zone()
-            if (self.config.dns_apex_a or self.config.dns_apex_aaaa)
-            else None
+        # Apex A/AAAA/NS/SOA — the served zone is the apex name we'll
+        # answer for. Falls through to whatever the caller set on the
+        # env var (DMP_DOMAIN / DMP_CLUSTER_BASE_DOMAIN /
+        # claim-provider zone) via _load_served_zone. If NO apex
+        # values are configured we pass apex_zone=None so the
+        # dispatcher fast-path stays inactive (backward compat).
+        _any_apex = any(
+            [
+                self.config.dns_apex_a,
+                self.config.dns_apex_aaaa,
+                self.config.dns_apex_ns,
+                self.config.dns_apex_soa_rname,
+            ]
         )
+        _apex_zone = _load_served_zone() if _any_apex else None
         self.dns = DMPDnsServer(
             self.store,
             host=self.config.dns_host,
@@ -982,6 +1012,8 @@ class DMPNode:
             apex_zone=_apex_zone,
             apex_a=self.config.dns_apex_a,
             apex_aaaa=self.config.dns_apex_aaaa,
+            apex_ns=self.config.dns_apex_ns,
+            apex_soa_rname=self.config.dns_apex_soa_rname,
             **update_kwargs,
         )
         # Derive the cluster base domain for the gossip endpoint — same

--- a/docs/deployment/dns-delegation.md
+++ b/docs/deployment/dns-delegation.md
@@ -289,6 +289,50 @@ The cleaner alternative is to flip the delegation pattern at the
 registrar (out-of-bailiwick NS like `mesh.example NS ns1.example`,
 no glue needed). The apex A is the no-touch-the-DNS-panel path.
 
+## Apex SOA + NS for strict resolvers (0.6.4+)
+
+Apex A alone isn't enough on Google + Level3. Strict resolvers also
+**validate the delegation** by querying the configured authoritative
+server for SOA + NS at the zone apex. If either query returns
+`NOERROR` with an empty answer (which is what 0.6.3 and earlier did
+— DMP only served TXT), the resolver concludes the auth doesn't own
+the zone, marks it "lame delegation", and NXDOMAINs every name under
+it. Cloudflare and Quad9 skip this validation, which is why they
+still resolve correctly while Google and Level3 don't.
+
+0.6.4 adds two env vars that flip this on:
+
+```bash
+# /etc/dnsmesh/node.env
+DMP_DNS_APEX_NS=ns1.example.com               # NS host (matches what the parent zone delegates to)
+DMP_DNS_APEX_SOA_RNAME=hostmaster.example.com # operator email-as-DNS-name
+```
+
+When both are set, the DMP DNS server answers:
+
+- `<DMP_DOMAIN> NS` → the configured NS hostname
+- `<DMP_DOMAIN> SOA` → SOA with MNAME=apex_ns, RNAME=apex_soa_rname,
+  SERIAL=epoch-seconds, REFRESH=3600, RETRY=600, EXPIRE=604800,
+  MINIMUM=`DMP_DNS_TTL`
+
+Strict resolvers stop NXDOMAINing the zone.
+
+```bash
+sudo systemctl restart dnsmesh-node
+
+# Verify Google + Level3:
+dig @8.8.8.8 SOA mesh.example.com
+dig @8.8.8.8 NS  mesh.example.com
+dig @8.8.8.8 TXT _dnsmesh-heartbeat.mesh.example.com
+dig @4.2.2.2 TXT _dnsmesh-heartbeat.mesh.example.com
+```
+
+The first time you set this on a long-running node, Google's lame-
+delegation cache is sticky — you may need to wait up to a few hours
+or use `https://dns.google/cache` to manually flush
+`<DMP_DOMAIN> SOA` (type 6) and `<DMP_DOMAIN> NS` (type 2) for the
+new state to be picked up.
+
 ## DNS server settings on the node
 
 The DMP node needs to:

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -292,6 +292,210 @@ class TestDMPDnsServerApexAddressRecords:
         assert str(response.answer[0][0]) == "203.0.113.42"
 
 
+class TestDMPDnsServerApexSoaNs:
+    """Strict recursive resolvers (Google 8.8.8.8, Level3 4.2.2.x)
+    validate a delegation by querying the configured authoritative
+    server for SOA + NS at the zone apex. If either query returns
+    NOERROR with an empty answer, they conclude the auth doesn't
+    actually own the zone, mark it "lame delegation", and NXDOMAIN
+    every name under it. Lenient resolvers (Cloudflare, Quad9) skip
+    this check, which is why the bug hides until Google's involved.
+
+    DMP_DNS_APEX_NS + DMP_DNS_APEX_SOA_RNAME flip this on. SOA needs
+    both (RFC 1035 §3.3.13 requires MNAME and RNAME); NS only needs
+    apex_ns. Without either, the dispatcher falls through to the
+    legacy NOERROR-empty branch.
+    """
+
+    def test_apex_ns_returned_for_zone_apex(self):
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.NS)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        rdata = response.answer[0][0]
+        assert rdata.rdtype == dns.rdatatype.NS
+        # NS target is dnspython Name; compare lowercase no-trailing-dot.
+        assert rdata.target.to_text(omit_final_dot=True).lower() == "ns1.mesh.test"
+
+    def test_apex_soa_returned_for_zone_apex(self):
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.SOA)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        soa = response.answer[0][0]
+        assert soa.rdtype == dns.rdatatype.SOA
+        assert soa.mname.to_text(omit_final_dot=True).lower() == "ns1.mesh.test"
+        assert soa.rname.to_text(omit_final_dot=True).lower() == "hostmaster.mesh.test"
+        # SERIAL is wall-clock based; just verify it's a sane recent value.
+        assert soa.serial > 1_700_000_000  # after 2023-11-15
+        assert soa.refresh == 3600
+        assert soa.retry == 600
+        assert soa.expire == 604800
+
+    def test_apex_soa_unconfigured_rname_returns_empty(self):
+        """SOA RFC requires both MNAME (apex_ns) AND RNAME
+        (apex_soa_rname). If only one is set we DON'T half-construct
+        an SOA — return NOERROR-empty so the resolver doesn't cache
+        a malformed record."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+            # apex_soa_rname intentionally unset
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.SOA)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+
+    def test_apex_ns_unconfigured_returns_empty(self):
+        """No apex_ns → NS query at apex returns NOERROR-empty."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store, host="127.0.0.1", port=port, apex_zone="dmp.mesh.test"
+        ):
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.NS)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+
+    def test_ns_at_non_apex_returns_empty(self):
+        """NS at a sub-name (not the apex) returns empty, not the
+        apex NS. We only serve NS at exactly the configured apex."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+        ):
+            request = dns.message.make_query(
+                "_dnsmesh-heartbeat.dmp.mesh.test", dns.rdatatype.NS
+            )
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+
+    def test_soa_at_non_apex_returns_empty(self):
+        """Same property for SOA — only at the apex name."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        ):
+            request = dns.message.make_query(
+                "_dnsmesh-heartbeat.dmp.mesh.test", dns.rdatatype.SOA
+            )
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+
+    def test_apex_records_combined_a_ns_soa(self):
+        """A node with the full apex bundle answers all three RR
+        types correctly at the same name. Sanity check that no two
+        config paths fight each other."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        ):
+            for rdtype, expected_present in [
+                (dns.rdatatype.A, True),
+                (dns.rdatatype.NS, True),
+                (dns.rdatatype.SOA, True),
+                (dns.rdatatype.AAAA, False),  # no apex_aaaa configured
+            ]:
+                request = dns.message.make_query("dmp.mesh.test", rdtype)
+                response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+                assert response.rcode() == 0
+                if expected_present:
+                    assert (
+                        len(response.answer) == 1
+                    ), f"{dns.rdatatype.to_text(rdtype)} expected 1 answer, got {len(response.answer)}"
+                else:
+                    assert (
+                        response.answer == []
+                    ), f"{dns.rdatatype.to_text(rdtype)} unexpected answer"
+
+    def test_apex_soa_serial_is_monotonic(self):
+        """SOA SERIAL must increase across queries so slaves (or
+        operators sanity-checking the zone) see a fresh value. We
+        don't have AXFR slaves but a manually-tuned tooling chain
+        depends on the property."""
+        import time as _time
+
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        ):
+            r1 = dns.query.udp(
+                dns.message.make_query("dmp.mesh.test", dns.rdatatype.SOA),
+                "127.0.0.1",
+                port=port,
+                timeout=2.0,
+            )
+            _time.sleep(1.05)
+            r2 = dns.query.udp(
+                dns.message.make_query("dmp.mesh.test", dns.rdatatype.SOA),
+                "127.0.0.1",
+                port=port,
+                timeout=2.0,
+            )
+
+        s1 = r1.answer[0][0].serial
+        s2 = r2.answer[0][0].serial
+        assert s2 > s1, f"SOA serial should advance: {s1} -> {s2}"
+
+
 class TestDMPDnsServerRateLimitAndConcurrency:
     """Regressions caught by codex review of the TCP listener PR.
 


### PR DESCRIPTION
## Summary

Strict recursive resolvers (Google 8.8.8.8, Level3 4.2.2.x) validate a delegation by querying the auth for SOA + NS at the zone apex. If either query returns `NOERROR` with an empty answer (which 0.6.3 and earlier did — DMP only served TXT plus the apex A from PR #18), the resolver concludes the auth doesn't own the zone, marks it "lame delegation", and NXDOMAINs every name under the zone.

Cloudflare and Quad9 skip the validation step, which is why this hides until Google or Level3 are involved.

## Diagnosis

Hit in production on `dnsmesh.de` — fresh delegation set up correctly out-of-bailiwick (`dmp.dnsmesh.de NS ns1.dnsmesh.de`), apex A served correctly via 0.6.3, ns1.dnsmesh.de A reachable from Google. But Google still NXDOMAINing every subname:

```
$ dig @178.104.241.208 NS  dmp.dnsmesh.de   →  NOERROR, aa flag, but 0 ANSWER  ← bug
$ dig @178.104.241.208 SOA dmp.dnsmesh.de   →  NOERROR, aa flag, but 0 ANSWER  ← bug
$ dig @8.8.8.8 TXT _dnsmesh-heartbeat.dmp.dnsmesh.de  →  NXDOMAIN
```

The auth was claiming to own the zone (aa flag set) but answering empty for SOA and NS at apex. Strict resolvers cache that as a lame-delegation marker; cache flushes don't help because re-validation hits the same empty response.

## Fix

Two new env vars:

```
DMP_DNS_APEX_NS=ns1.dnsmesh.de               # NS hostname (matches what the parent delegates to)
DMP_DNS_APEX_SOA_RNAME=hostmaster.dnsmesh.de # SOA RNAME (operator email-as-DNS-name)
```

When `DMP_DNS_APEX_NS` is set, the DMP DNS server answers NS at the apex with that hostname. SOA additionally requires `DMP_DNS_APEX_SOA_RNAME` (RFC 1035 §3.3.13 — MNAME and RNAME both required for a valid SOA RR). 

SOA defaults — operator-friendly, BIND-typical:
- SERIAL = epoch-seconds (monotonic for ~70 years inside RFC 1982 serial-number arithmetic)
- REFRESH = 3600
- RETRY = 600
- EXPIRE = 604800
- MINIMUM = `DMP_DNS_TTL` (matches the rest of the zone's TTL)

Without the env vars, behavior is unchanged — apex fast-path stays inactive, queries fall through to the legacy NOERROR-empty branch.

## Files

- `dmp/server/dns_server.py` — `_DMPRequestHandler._build_response` extended to handle SOA + NS at apex; `apex_ns` + `apex_soa_rname` plumbed through `DMPDnsServer`, `_ThreadingUDPServer`, `_ThreadingTCPServer`, `_server_kwargs()`. Added `dns.rdtypes.ANY.NS` + `dns.rdtypes.ANY.SOA` imports.
- `dmp/server/node.py` — `DMPNodeConfig.dns_apex_ns` + `dns_apex_soa_rname` env-driven fields. Module docstring updated. Apex-zone derivation gates on ANY apex value being set.
- `docs/deployment/dns-delegation.md` — new "Apex SOA + NS for strict resolvers (0.6.4+)" section right after the apex A doc, with diagnosis + verification dig commands.
- `tests/test_dns_server.py` — `TestDMPDnsServerApexSoaNs` class with 8 tests covering the apex match, RFC 1035 RNAME requirement, type-vs-name semantics, combined A/NS/SOA dispatch, and SERIAL monotonicity.

## Test plan

- [x] `pytest tests/test_dns_server.py::TestDMPDnsServerApexSoaNs` — 8 passed
- [x] `pytest tests/ --ignore=tests/test_docker_integration.py` — 1439 passed (1431 prior + 8 new), 3 skipped
- [x] `black --check dmp tests` clean
- [ ] After merge + 0.6.4 release + live-node upgrade with `DMP_DNS_APEX_NS` + `DMP_DNS_APEX_SOA_RNAME` set:
  - `dig @8.8.8.8 SOA dmp.dnsmesh.io` returns the apex SOA RR
  - `dig @8.8.8.8 NS  dmp.dnsmesh.io` returns the apex NS RR
  - `dig @8.8.8.8 TXT _dnsmesh-heartbeat.dmp.dnsmesh.io` returns NOERROR (was NXDOMAIN)
  - Same for `.pro` and `.de`
  - Directory page resolver matrix flips Google + Level3 from red to green

## Release plan

After merge, this is the only fix in 0.6.4:
1. Bump `dmp/__init__.py` + `setup.py` to `0.6.3 → 0.6.4`
2. CHANGELOG entry
3. Tag `sdk-v0.6.4`, `cli-v0.6.4`, `image-v0.6.4` from main and push
4. Upgrade live nodes: run `upgrade.sh`, append `DMP_DNS_APEX_NS=ns1.dnsmesh.<tld>` and `DMP_DNS_APEX_SOA_RNAME=hostmaster.dnsmesh.<tld>` to each `node.env`, restart