### PR TITLE
fix(dns_server): RFC 2308 + RFC 8020 negative responses

### DIFF
--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -238,6 +238,60 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
         flag1 = rcode_value & 0x0F
         return bytes(msg_id) + bytes([flag0, flag1, 0, 0, 0, 0, 0, 0, 0, 0])
 
+    def _build_apex_soa_rrset(self, owner_name: dns.name.Name):
+        """Construct the apex SOA RR or return None when the operator
+        hasn't configured both ``apex_ns`` and ``apex_soa_rname``.
+
+        Used in two places:
+          1. As the ANSWER for an SOA query at the apex.
+          2. In the AUTHORITY section of every NXDOMAIN / NODATA
+             response (RFC 2308 §3 — required so resolvers know how
+             long to negative-cache the answer; without it strict
+             resolvers like Google may treat the response as
+             malformed and propagate the negative state up the tree
+             via RFC 8020 NXDOMAIN-cut, poisoning every descendant
+             name).
+        """
+        apex_ns = getattr(self.server, "apex_ns", None)
+        apex_rname = getattr(self.server, "apex_soa_rname", None)
+        if not apex_ns or not apex_rname:
+            return None
+        ttl = self.server.ttl
+        # SOA RFC 1035 §3.3.13. SERIAL is per-second wall clock
+        # (monotonic for the next ~70 years inside the 32-bit
+        # serial-number arithmetic window of RFC 1982), REFRESH/
+        # RETRY/EXPIRE are BIND operator defaults, MINIMUM matches
+        # our standard TTL — and per RFC 2308 §5 also caps the
+        # negative-caching window for NXDOMAIN/NODATA answers.
+        return dns.rrset.from_rdata(
+            owner_name,
+            ttl,
+            dns.rdtypes.ANY.SOA.SOA(
+                rdclass=dns.rdataclass.IN,
+                rdtype=dns.rdatatype.SOA,
+                mname=dns.name.from_text(apex_ns),
+                rname=dns.name.from_text(apex_rname),
+                serial=int(time.time()),
+                refresh=3600,
+                retry=600,
+                expire=604800,
+                minimum=ttl,
+            ),
+        )
+
+    def _attach_negative_authority(self, response: dns.message.Message) -> None:
+        """Append the apex SOA to a negative response's AUTHORITY
+        section. RFC 2308 §3 requires this for both NXDOMAIN and
+        NODATA. Skipped silently when no apex zone is configured —
+        in that mode the server is operating in "TXT-only legacy"
+        and there's no SOA to point at."""
+        apex_zone = getattr(self.server, "apex_zone", None) or ""
+        if not apex_zone:
+            return
+        soa = self._build_apex_soa_rrset(dns.name.from_text(apex_zone))
+        if soa is not None:
+            response.authority.append(soa)
+
     def _build_response(self, query: dns.message.Message) -> dns.message.Message:
         reader: DNSRecordReader = self.server.reader
         response = dns.message.make_response(query)
@@ -268,7 +322,8 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
         #   DMP_DNS_APEX_NS                    — NS hostname (e.g. ns1.<parent>)
         #   DMP_DNS_APEX_SOA_RNAME             — SOA RNAME (operator email-as-name)
         apex_zone = getattr(self.server, "apex_zone", None) or ""
-        if apex_zone and qname.lower() == apex_zone.lower():
+        is_apex = bool(apex_zone) and qname.lower() == apex_zone.lower()
+        if is_apex:
             ttl = self.server.ttl
             if question.rdtype == dns.rdatatype.A:
                 apex_a = getattr(self.server, "apex_a", None)
@@ -284,8 +339,9 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
                             ),
                         )
                     )
-                return response
-            if question.rdtype == dns.rdatatype.AAAA:
+                    return response
+                # Fall through to NODATA below.
+            elif question.rdtype == dns.rdatatype.AAAA:
                 apex_aaaa = getattr(self.server, "apex_aaaa", None)
                 if apex_aaaa:
                     response.answer.append(
@@ -299,8 +355,8 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
                             ),
                         )
                     )
-                return response
-            if question.rdtype == dns.rdatatype.NS:
+                    return response
+            elif question.rdtype == dns.rdatatype.NS:
                 apex_ns = getattr(self.server, "apex_ns", None)
                 if apex_ns:
                     response.answer.append(
@@ -314,44 +370,59 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
                             ),
                         )
                     )
-                return response
-            if question.rdtype == dns.rdatatype.SOA:
-                apex_ns = getattr(self.server, "apex_ns", None)
-                apex_rname = getattr(self.server, "apex_soa_rname", None)
-                if apex_ns and apex_rname:
-                    # SOA RFC 1035 §3.3.13. Defaults match a typical
-                    # authoritative-only zone with no AXFR slaves —
-                    # SERIAL is per-second wall clock (monotonic
-                    # for the next ~70 years inside the 32-bit
-                    # serial-number arithmetic window of RFC 1982),
-                    # REFRESH/RETRY/EXPIRE are the BIND operator
-                    # defaults, MINIMUM matches our standard TTL.
-                    response.answer.append(
-                        dns.rrset.from_rdata(
-                            question.name,
-                            ttl,
-                            dns.rdtypes.ANY.SOA.SOA(
-                                rdclass=dns.rdataclass.IN,
-                                rdtype=dns.rdatatype.SOA,
-                                mname=dns.name.from_text(apex_ns),
-                                rname=dns.name.from_text(apex_rname),
-                                serial=int(time.time()),
-                                refresh=3600,
-                                retry=600,
-                                expire=604800,
-                                minimum=ttl,
-                            ),
-                        )
-                    )
-                return response
+                    return response
+            elif question.rdtype == dns.rdatatype.SOA:
+                soa = self._build_apex_soa_rrset(question.name)
+                if soa is not None:
+                    response.answer.append(soa)
+                    return response
+
+        # Below this point we're answering NEGATIVELY (no records or
+        # wrong type for this name). Pick NXDOMAIN vs NODATA carefully:
+        #
+        #   - NODATA (NOERROR + 0 answer): the NAME exists in our zone
+        #     but has no records of the requested type. Required for
+        #     the zone apex (which always exists when apex_zone is
+        #     configured — we serve A/NS/SOA there) AND for any name
+        #     where TXT records exist but the resolver asked for a
+        #     different type.
+        #
+        #   - NXDOMAIN (RCODE 3): the NAME doesn't exist at all in
+        #     our zone. Strict resolvers cache this aggressively
+        #     (RFC 8020 NXDOMAIN-cut: a cached NXDOMAIN at any
+        #     ancestor lets the resolver synthesize NXDOMAIN for
+        #     EVERY descendant without re-querying us). So NXDOMAIN
+        #     at the apex is catastrophic — it poisons every owner
+        #     name under the zone. We only return it for genuinely-
+        #     nonexistent sub-names (no TXT record on disk).
+        #
+        # Both responses MUST carry the apex SOA in AUTHORITY per
+        # RFC 2308 §3 so the resolver knows the negative-caching TTL.
+        # Without it, Google specifically discards the response or
+        # treats the entire zone as broken.
 
         if question.rdtype != dns.rdatatype.TXT:
-            # We only serve TXT. Everything else → NOERROR with empty answer.
+            # Non-TXT queries on names we don't serve other types for
+            # → NODATA, never NXDOMAIN. Even a sub-name like
+            # ``_typo.dmp.example A`` returns NODATA because the cost
+            # of being wrong (poisoning TXT lookups via NXDOMAIN-cut)
+            # is much higher than the cost of a slightly-incorrect
+            # NODATA on a name that actually doesn't exist.
+            self._attach_negative_authority(response)
             return response
 
         values = reader.query_txt_record(qname)
         if not values:
+            if is_apex:
+                # Apex name exists; just no TXT here. NODATA.
+                self._attach_negative_authority(response)
+                return response
+            # Genuine NXDOMAIN. SOA in AUTHORITY for negative-caching
+            # TTL (RFC 2308 §3) — without this Google treats the
+            # response as malformed AND, if cached, RFC 8020 cut
+            # would poison the whole zone. Both fixes in one call.
             response.set_rcode(dns.rcode.NXDOMAIN)
+            self._attach_negative_authority(response)
             return response
 
         ttl = self.server.ttl

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -496,6 +496,197 @@ class TestDMPDnsServerApexSoaNs:
         assert s2 > s1, f"SOA serial should advance: {s1} -> {s2}"
 
 
+class TestDMPDnsServerNegativeResponses:
+    """RFC 2308 + RFC 8020 compliance.
+
+    Hit in production: Google Public DNS NXDOMAIN'd every name under
+    a healthy DMP zone for 9+ hours after a delegation cleanup. Root
+    cause turned out to be two intertwined bugs:
+
+    1. The DMP server returned NXDOMAIN at the zone apex for
+       record types it didn't have (e.g., TXT at apex when no TXT
+       records exist there). The apex name DOES exist (the zone
+       has SOA/NS/A there), so the correct response is NODATA
+       (NOERROR with empty answer), not NXDOMAIN. Per RFC 8020
+       "NXDOMAIN cut", a strict resolver caches NXDOMAIN at an
+       ancestor and SYNTHESIZES NXDOMAIN for every descendant
+       without re-querying — so a single bad NXDOMAIN at the apex
+       poisons the entire zone for the resolver's cache lifetime.
+
+    2. NXDOMAIN AND NODATA responses lacked the apex SOA in their
+       AUTHORITY section. RFC 2308 §3 requires SOA in negative
+       responses so the resolver knows the negative-caching TTL.
+       Without it, RFC 2308 §5 says the response SHOULD NOT be
+       cached, and Google in particular treats the whole exchange
+       as suspect.
+
+    Both fixes ship together — there's no point fixing one without
+    the other since the symptom requires both to manifest.
+    """
+
+    def _apex_server(self):
+        return DMPDnsServer(
+            InMemoryDNSStore(),
+            host="127.0.0.1",
+            port=_free_port(),
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        )
+
+    def test_apex_txt_with_no_records_returns_nodata_not_nxdomain(self):
+        """The exact bug that caused 9+ hours of Google NXDOMAINing.
+        Apex name exists (we serve A/NS/SOA there), so a TXT query
+        at the apex with no TXT records should be NODATA (NOERROR +
+        0 answer), NOT NXDOMAIN."""
+        with self._apex_server() as srv:
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.TXT)
+            response = dns.query.udp(request, "127.0.0.1", port=srv.port, timeout=2.0)
+
+        assert (
+            response.rcode() == 0
+        ), "MUST be NOERROR; NXDOMAIN poisons zone via RFC 8020 cut"
+        assert response.answer == []
+
+    def test_apex_unconfigured_type_returns_nodata(self):
+        """Same property for any other type the operator hasn't
+        configured at the apex. CAA, MX, etc. → NODATA."""
+        with self._apex_server() as srv:
+            for rdtype in (dns.rdatatype.CAA, dns.rdatatype.MX, dns.rdatatype.SRV):
+                request = dns.message.make_query("dmp.mesh.test", rdtype)
+                response = dns.query.udp(
+                    request, "127.0.0.1", port=srv.port, timeout=2.0
+                )
+                assert (
+                    response.rcode() == 0
+                ), f"{dns.rdatatype.to_text(rdtype)} at apex MUST NOT NXDOMAIN"
+                assert response.answer == []
+
+    def test_nxdomain_response_includes_soa_in_authority(self):
+        """RFC 2308 §3 — negative responses MUST carry the zone SOA
+        in AUTHORITY for negative-caching TTL. Without it RFC 2308
+        §5 says the answer SHOULD NOT be cached."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        ):
+            request = dns.message.make_query("_typo.dmp.mesh.test", dns.rdatatype.TXT)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        # Genuine sub-name nonexistence → NXDOMAIN.
+        assert response.rcode() == 3
+        # And SOA in authority.
+        assert len(response.authority) == 1
+        soa = response.authority[0][0]
+        assert soa.rdtype == dns.rdatatype.SOA
+        assert soa.mname.to_text(omit_final_dot=True).lower() == "ns1.mesh.test"
+
+    def test_nodata_response_includes_soa_in_authority(self):
+        """RFC 2308 §3 also covers NOERROR-empty (NODATA) responses.
+        A non-TXT query on a sub-name (where we don't track non-TXT
+        records) returns NODATA + SOA, not naked NOERROR-empty."""
+        store = InMemoryDNSStore()
+        store.publish_txt_record(
+            "_dnsmesh-heartbeat.dmp.mesh.test", "v=dmp1;t=heartbeat;..."
+        )
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        ):
+            # AAAA on a name we have TXT for → NODATA.
+            request = dns.message.make_query(
+                "_dnsmesh-heartbeat.dmp.mesh.test", dns.rdatatype.AAAA
+            )
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+        assert len(response.authority) == 1
+        assert response.authority[0][0].rdtype == dns.rdatatype.SOA
+
+    def test_apex_nodata_includes_soa_in_authority(self):
+        """The apex case from bug #1 also needs SOA — the response
+        is NODATA, and RFC 2308 §3 still applies."""
+        with self._apex_server() as srv:
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.TXT)
+            response = dns.query.udp(request, "127.0.0.1", port=srv.port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+        assert len(response.authority) == 1
+        assert response.authority[0][0].rdtype == dns.rdatatype.SOA
+
+    def test_subname_non_txt_returns_nodata_not_nxdomain(self):
+        """A query for AAAA at a random sub-name like
+        ``_typo.dmp.mesh.test`` returns NODATA, not NXDOMAIN —
+        because we can't tell whether the name "exists" for some
+        type we don't manage. The conservative answer (NODATA) is
+        safer than NXDOMAIN, which would propagate via NXDOMAIN-cut
+        to any TXT lookups under the same prefix."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_ns="ns1.mesh.test",
+            apex_soa_rname="hostmaster.mesh.test",
+        ):
+            request = dns.message.make_query("_typo.dmp.mesh.test", dns.rdatatype.AAAA)
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert response.answer == []
+        # SOA still required.
+        assert len(response.authority) == 1
+        assert response.authority[0][0].rdtype == dns.rdatatype.SOA
+
+    def test_negative_responses_unconfigured_apex_no_soa(self):
+        """Backward compat: when the operator hasn't set
+        ``apex_zone``/``apex_ns``/``apex_soa_rname``, the server has
+        no SOA to attach. Negative responses fall back to the legacy
+        naked behavior — RFC-non-compliant, but no regression
+        relative to 0.6.4 and earlier for operators who haven't
+        opted into the new env vars."""
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(store, host="127.0.0.1", port=port):
+            request = dns.message.make_query(
+                "_typo.unmanaged.example", dns.rdatatype.TXT
+            )
+            response = dns.query.udp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        # Sub-name with no records, no apex configured → NXDOMAIN
+        # with no SOA (legacy behavior).
+        assert response.rcode() == 3
+        assert response.authority == []
+
+    def test_apex_soa_query_unaffected_by_no_records(self):
+        """SOA at the apex must still ANSWER (not return NODATA).
+        Sanity check that the apex-meta path isn't accidentally
+        falling through to the negative branch."""
+        with self._apex_server() as srv:
+            request = dns.message.make_query("dmp.mesh.test", dns.rdatatype.SOA)
+            response = dns.query.udp(request, "127.0.0.1", port=srv.port, timeout=2.0)
+
+        assert response.rcode() == 0
+        assert len(response.answer) == 1
+        assert response.answer[0][0].rdtype == dns.rdatatype.SOA
+
+
 class TestDMPDnsServerRateLimitAndConcurrency:
     """Regressions caught by codex review of the TCP listener PR.
 


### PR DESCRIPTION
## Summary

Two intertwined bugs caused Google Public DNS to NXDOMAIN every name under a healthy DMP zone for **9+ hours** after a delegation cleanup, despite apex SOA + NS being correctly configured. The fix targets the actual root cause this time, validated independently via codex review of RFC 2308, RFC 8020, and Google Public DNS security docs.

## Diagnosis

Direct comparison with a healthy auth (DigitalOcean) showed:

```
Our auth NXDOMAIN response:
;; flags: qr aa rd; ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1   ← naked

DigitalOcean's NXDOMAIN response:
;; flags: qr aa rd; ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; AUTHORITY SECTION:
dnsmesh.io. 1800 IN SOA ns1.digitalocean.com. ...               ← SOA per RFC 2308 §3
```

And our apex behavior:

```
$ dig @<our-auth> TXT dmp.dnsmesh.io
;; status: NXDOMAIN  ← wrong! The name exists (we serve A/NS/SOA there)
```

This is two bugs:

1. **NXDOMAIN at the zone apex for missing record types.** Our server returned NXDOMAIN whenever a TXT lookup at the apex found no TXT record there. But the apex *exists* — the zone has SOA/NS/A records at it (from 0.6.4). Per **RFC 8020** "NXDOMAIN cut", a strict resolver caches NXDOMAIN at any ancestor name and SYNTHESIZES NXDOMAIN for every descendant without re-querying. So a single bad NXDOMAIN at the apex poisons the entire zone for the resolver's cache lifetime.

2. **Naked NXDOMAIN and NODATA.** Both response types lacked the apex SOA in AUTHORITY. **RFC 2308 §3** requires the SOA so the resolver knows the negative-caching TTL. Without it RFC 2308 §5 says the response SHOULD NOT be cached, and Google specifically treats the exchange as malformed.

Both fixes ship together — there's no point fixing one without the other since the production symptom requires both to manifest.

## Codex review — independent validation

Quote from codex (full RFC walk + Google Public DNS docs search):

> 1. Yes. RFC 2308 §3 requires an authoritative server to include the zone's SOA in the AUTHORITY section for both NXDOMAIN and NODATA. RFC 2308 §5 also says negative responses without an SOA SHOULD NOT be cached. So your "naked NXDOMAIN" is non-compliant.
>
> 2. [...] Google Public DNS rejects malformed/suspicious authoritative responses and aims for standards compliance. That supports "Google may be stricter."
>
> 3. [...] Your symptom "fresh descendant names get NXDOMAIN from 8.8.8.8" matches RFC 8020: once a resolver has a cached NXDOMAIN for an ancestor, it may answer all descendants NXDOMAIN ("NXDOMAIN cut"). [...] Bottom line: fix the naked NXDOMAIN first; it is an RFC violation and may help. But also look for an incorrect authoritative NXDOMAIN on an ancestor.

The "incorrect ancestor NXDOMAIN" was exactly what we found at our zone apex. Both bugs identified, both fixed in this PR.

## Implementation

`dmp/server/dns_server.py`:

- New `_build_apex_soa_rrset()` helper — builds the SOA RR once, used for both the SOA-answer path AND the negative-AUTHORITY path. Returns None when the operator hasn't configured `apex_ns` + `apex_soa_rname` (backward compat).
- New `_attach_negative_authority()` — appends the apex SOA to NXDOMAIN and NODATA responses. Silently no-ops when no apex zone is configured (legacy operators get unchanged behavior).
- Query-dispatch path rewritten to distinguish:
  - **Apex name + missing type** → NODATA (NOERROR + empty + SOA). Critical: never NXDOMAIN at the apex.
  - **Sub-name + non-TXT type** → NODATA + SOA. We don't track non-TXT records, so we can't tell whether a sub-name "exists" for some other type. Conservative answer (NODATA) is safer than NXDOMAIN, which would propagate via NXDOMAIN-cut to TXT lookups under the same prefix.
  - **Sub-name + TXT + no record** → NXDOMAIN + SOA. Only path that returns NXDOMAIN now, and it's safe (genuinely-nonexistent sub-name doesn't trigger zone-wide poisoning).

`tests/test_dns_server.py` — `TestDMPDnsServerNegativeResponses` class with 8 tests:

- `test_apex_txt_with_no_records_returns_nodata_not_nxdomain` — the exact bug
- `test_apex_unconfigured_type_returns_nodata` — CAA/MX/SRV at apex
- `test_nxdomain_response_includes_soa_in_authority` — RFC 2308 §3
- `test_nodata_response_includes_soa_in_authority` — RFC 2308 §3
- `test_apex_nodata_includes_soa_in_authority` — apex case
- `test_subname_non_txt_returns_nodata_not_nxdomain` — conservative fallback
- `test_negative_responses_unconfigured_apex_no_soa` — backward compat
- `test_apex_soa_query_unaffected_by_no_records` — sanity

## Test plan

- [x] `pytest tests/test_dns_server.py::TestDMPDnsServerNegativeResponses` — 8 passed
- [x] `pytest tests/ --ignore=tests/test_docker_integration.py` — 1447 passed (1439 prior + 8 new), 3 skipped
- [x] `black --check dmp tests` clean
- [x] Codex review independently validates the diagnosis against RFC 2308 + RFC 8020
- [ ] After merge + 0.6.5 release + live-node upgrade: `dig @8.8.8.8 TXT dmp.dnsmesh.io` returns NOERROR (NODATA) instead of NXDOMAIN. Then `dig @8.8.8.8 TXT _dnsmesh-heartbeat.dmp.dnsmesh.io` finally answers. (Google's RFC 8020 negative cache will need to expire OR be flushed via dns.google/cache for the ancestor names; once a fresh query lands, the new NODATA response replaces the poisoned NXDOMAIN.)

## Release plan

After merge, this is the only fix in 0.6.5:
1. Bump `dmp/__init__.py` + `setup.py` to `0.6.4 → 0.6.5`
2. CHANGELOG entry
3. Tag `sdk-v0.6.5`, `cli-v0.6.5`, `image-v0.6.5` from main and push
4. Upgrade live nodes via `upgrade.sh`, restart
5. Manually flush `dmp.dnsmesh.{io,pro,de}` ANY/SOA at https://dns.google/cache to force Google to re-query and pick up the new NODATA-with-SOA responses