### PR TITLE
release: 0.6.5 — RFC 2308 + RFC 8020 negative responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.6.5] — 2026-05-01 — RFC 2308 + RFC 8020 negative responses
+
+Third (and actual) round of strict-resolver compatibility fixes.
+0.6.3 added apex A/AAAA. 0.6.4 added apex SOA + NS. Both were
+necessary, neither was sufficient — Google Public DNS was still
+NXDOMAINing every name under healthy DMP zones for **9+ hours**
+after the 0.6.4 deploy. Diagnosis traced to two intertwined bugs
+in the negative-response path that this release closes.
+
+Validated independently via codex review of RFC 2308, RFC 8020,
+and Google Public DNS security docs.
+
+Wire format, on-disk schema, and CLI surfaces are byte-identical
+to 0.6.4. Operators upgrade in place via
+`pip install -U dnsmesh && systemctl restart dnsmesh-node`
+(native install) or `docker compose pull && docker compose up -d`
+(Docker).
+
+### Fixed
+
+- **NXDOMAIN at the zone apex for missing record types poisoned
+  the entire zone via RFC 8020 NXDOMAIN-cut.** When a TXT lookup
+  at the apex name (e.g. ``dmp.dnsmesh.io TXT``) found no record,
+  the server returned NXDOMAIN. But the apex *exists* — the zone
+  has SOA/NS/A records there from 0.6.4. The correct answer is
+  NODATA (NOERROR + 0 answer), not NXDOMAIN. Per RFC 8020, a
+  strict resolver caches NXDOMAIN at any ancestor and SYNTHESIZES
+  NXDOMAIN for every descendant without re-querying — so a single
+  bad apex NXDOMAIN poisoned every owner name under the zone.
+  Server now returns NODATA at the apex regardless of which
+  record type was queried, and only returns NXDOMAIN for genuine
+  sub-name TXT-not-found cases. (PR #25.)
+- **Naked NXDOMAIN and NODATA — no SOA in AUTHORITY.** RFC 2308
+  §3 requires the zone SOA in the AUTHORITY section of every
+  negative response so the resolver knows the negative-caching
+  TTL. Without it RFC 2308 §5 says the response SHOULD NOT be
+  cached, and Google specifically treats the exchange as
+  malformed. Server now appends the apex SOA to NXDOMAIN AND
+  NODATA responses when ``DMP_DNS_APEX_NS`` and
+  ``DMP_DNS_APEX_SOA_RNAME`` are configured. Backward compat:
+  legacy operators without the env vars get the unchanged "naked"
+  behavior — RFC-non-compliant, no regression. (PR #25.)
+- **Sub-name non-TXT queries return NODATA, not NXDOMAIN.** We
+  don't track non-TXT records under sub-names, so we can't tell
+  whether a sub-name "exists" for some other type. The
+  conservative answer (NODATA) is safer than NXDOMAIN, which
+  would propagate via NXDOMAIN-cut to TXT lookups under the same
+  prefix. (PR #25.)
+
+### Operator note
+
+After upgrading, Google's poisoned NXDOMAIN cache for the apex
+names will need to expire OR be flushed at
+``https://dns.google/cache``. Once a fresh query lands, the new
+NODATA-with-SOA response replaces the cached NXDOMAIN and the
+zone unlocks for descendant queries.
+
 ## [0.6.4] — 2026-05-01 — apex SOA + NS records for strict-resolver delegations
 
 Continuation of the strict-resolver compatibility work that started

--- a/dmp/__init__.py
+++ b/dmp/__init__.py
@@ -1,3 +1,3 @@
 """DNS Mesh Protocol - Federated end-to-end encrypted messaging over DNS"""
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # The import path stays `import dmp` — distribution name and
     # import name intentionally differ (same pattern as pyyaml → yaml).
     name="dnsmesh",
-    version="0.6.4",
+    version="0.6.5",
     author="Oscar Valenzuela B",
     author_email="oscar.valenzuela.b@gmail.com",
     description="A federated end-to-end encrypted messaging protocol delivered over DNS",


### PR DESCRIPTION
## Summary

Third (and actual) round of strict-resolver compatibility fixes, shipping PR #25. 0.6.3 added apex A/AAAA. 0.6.4 added apex SOA + NS. Both were necessary but neither was sufficient — Google was still NXDOMAINing every name under healthy DMP zones for 9+ hours after the 0.6.4 deploy.

Wire format, on-disk schema, and CLI surfaces unchanged from 0.6.4.

## What's in 0.6.5

- **PR #25** — RFC 2308 + RFC 8020 negative-response fixes:
  - Apex with missing record types now returns NODATA (NOERROR + 0 answer), never NXDOMAIN. This stops Google's RFC 8020 NXDOMAIN-cut from poisoning the entire zone.
  - All negative responses (NXDOMAIN AND NODATA) now include the apex SOA in AUTHORITY per RFC 2308 §3, so resolvers know the negative-caching TTL.
  - Sub-name non-TXT queries return NODATA (not NXDOMAIN) — conservative fallback to avoid accidental zone poisoning.
- 8 new tests in `TestDMPDnsServerNegativeResponses` covering all the negative-response paths.
- Validated independently via codex review of RFC 2308 + RFC 8020.

## Files

- `dmp/__init__.py` — `__version__ = "0.6.5"`
- `setup.py` — `version="0.6.5"`
- `CHANGELOG.md` — 0.6.5 entry

## Release plan after merge

```bash
git checkout main && git pull
scripts/release/tag.sh all
git push origin sdk-v0.6.5 image-v0.6.5 cli-v0.6.5
```

After PyPI is fresh, upgrade all 3 nodes:

```bash
ssh root@dnsmesh.io          'curl -fsSL https://raw.githubusercontent.com/oscarvalenzuelab/DNSMeshProtocol/main/deploy/native-ubuntu/upgrade.sh | sudo bash'
ssh -p 22208 root@dnsmesh.pro 'curl -fsSL https://raw.githubusercontent.com/oscarvalenzuelab/DNSMeshProtocol/main/deploy/native-ubuntu/upgrade.sh | sudo bash'
ssh root@178.104.241.208     'curl -fsSL https://raw.githubusercontent.com/oscarvalenzuelab/DNSMeshProtocol/main/deploy/native-ubuntu/upgrade.sh | sudo bash'
```

Verify:

```bash
# Apex now NODATA (not NXDOMAIN) — the actual fix:
dig @8.8.8.8 TXT dmp.dnsmesh.io   # expect NOERROR + 0 answer + SOA in authority

# Then heartbeat (after Google flushes the poisoned cache):
dig @8.8.8.8 TXT _dnsmesh-heartbeat.dmp.dnsmesh.io  # expect NOERROR with the heartbeat
```

Google's poisoned NXDOMAIN cache for the apex names will likely need a manual flush at https://dns.google/cache (one round via playwright like before). Once a fresh query lands, the new NODATA-with-SOA response replaces the cached NXDOMAIN and the zone unlocks.

## Test plan

- [x] PR #25 already on main, all CI green (1447 passed, 3 skipped)
- [x] Codex review independently validated against RFC 2308 + RFC 8020
- [x] `black --check dmp tests` clean
- [ ] After merge: tag + push + verify each publisher fires green
- [ ] After live upgrade: apex queries return NOERROR (not NXDOMAIN) with SOA in authority
- [ ] After Google cache flush: heartbeat queries via 8.8.8.8 finally answer
- [ ] Directory page resolver matrix flips Google green for all 3 zones