### PR TITLE
feat(directory): integrate page with Just-the-Docs sidebar

### DIFF
--- a/docs/directory/feed.json
+++ b/docs/directory/feed.json
@@ -1,6 +1,467 @@
 {
-  "version": 1,
-  "generated_at": 1777186040,
-  "node_count": 0,
-  "nodes": []
+  "version": 2,
+  "generated_at": 1777671406,
+  "node_count": 3,
+  "nodes": [
+    {
+      "operator_spk_hex": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
+      "endpoint": "https://dnsmesh.de",
+      "version": "0.6.6",
+      "ts": 1777671327,
+      "exp": 1777757727,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmRl++UIFDC977dfAreU7bazW7NCi9vZnlCBH+kffTaSzdkFMC42LjYAAQ5kbXAuZG5zbWVzaC5kZQAAAABp9RyfAAAAAGn2bh8i5+FVTUzkghzafSFdokqz0iEA3L1eH2OCLLBBE/zFPhuvrtm3FZFMC1he9KCXiQrie2QfMNTxYifq0FObrxAB",
+      "last_seen_via": [
+        "dmp.dnsmesh.de"
+      ],
+      "geo": {
+        "ip": "178.104.241.208",
+        "country": "Germany",
+        "country_code": "DE",
+        "region": "Bavaria",
+        "city": "Nuremberg",
+        "lat": 49.4543,
+        "lon": 11.0746,
+        "isp": "Hetzner Online GmbH",
+        "org": "Hetzner",
+        "asn": "AS24940 Hetzner Online GmbH"
+      },
+      "host": {
+        "ip": "178.104.241.208",
+        "isp": "Hetzner Online GmbH",
+        "org": "Hetzner",
+        "asn": "AS24940 Hetzner Online GmbH"
+      }
+    },
+    {
+      "operator_spk_hex": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
+      "endpoint": "https://dnsmesh.pro",
+      "version": "0.6.6",
+      "ts": 1777671321,
+      "exp": 1777757721,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwATaHR0cHM6Ly9kbnNtZXNoLnByb1XdUIW7Ftv1ra8k1ToTu9UMj5+T4CaxlAWSNaP9gr/vBTAuNi42AAEPZG1wLmRuc21lc2gucHJvAAAAAGn1HJkAAAAAafZuGUQnn0QCsnPHRnJcM8rzvFEcgFX1AUTlfwxr5oLs7WBWOWlKG3zCMLuwmMdQ6cMUTnvbHsHjdLMQ27WZrq72bwI=",
+      "last_seen_via": [
+        "dmp.dnsmesh.pro",
+        "dmp.dnsmesh.de"
+      ],
+      "geo": {
+        "ip": "45.7.229.112",
+        "country": "Chile",
+        "country_code": "CL",
+        "region": "Maule Region",
+        "city": "Curic\u00f3",
+        "lat": -34.978,
+        "lon": -71.2529,
+        "isp": "ZAM LTDA.",
+        "org": "OPENCLOUD SpA",
+        "asn": "AS52368 ZAM LTDA."
+      },
+      "host": {
+        "ip": "45.7.229.112",
+        "isp": "ZAM LTDA.",
+        "org": "OPENCLOUD SpA",
+        "asn": "AS52368 ZAM LTDA."
+      }
+    },
+    {
+      "operator_spk_hex": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
+      "endpoint": "https://dnsmesh.io",
+      "version": "0.6.6",
+      "ts": 1777671311,
+      "exp": 1777757711,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmlvwOU4XrU8HNtixcWnJvGlUkgPw0XGAMjkXy7wR/ogMsIFMC42LjYAAQ5kbXAuZG5zbWVzaC5pbwAAAABp9RyPAAAAAGn2bg9auCg/aX5lKU5wjjmcsggM1QimjqkEH0TgF/rBD7NBWqpl5XDFc/+qrH5+yutl5wP5C58wLET4rrS7bzafHpoO",
+      "last_seen_via": [
+        "dmp.dnsmesh.io",
+        "dmp.dnsmesh.pro",
+        "dmp.dnsmesh.de"
+      ],
+      "geo": {
+        "ip": "24.199.107.165",
+        "country": "United States",
+        "country_code": "US",
+        "region": "California",
+        "city": "Santa Clara",
+        "lat": 37.3931,
+        "lon": -121.962,
+        "isp": "DigitalOcean, LLC",
+        "org": "DigitalOcean, LLC",
+        "asn": "AS14061 DigitalOcean, LLC"
+      },
+      "host": {
+        "ip": "24.199.107.165",
+        "isp": "DigitalOcean, LLC",
+        "org": "DigitalOcean, LLC",
+        "asn": "AS14061 DigitalOcean, LLC"
+      }
+    }
+  ],
+  "seen_edges": [
+    {
+      "from_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
+      "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
+      "last_seen_ts": 1777671311
+    },
+    {
+      "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
+      "to_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
+      "last_seen_ts": 1777671321
+    },
+    {
+      "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
+      "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
+      "last_seen_ts": 1777671311
+    }
+  ],
+  "resolvers": [
+    {
+      "name": "Cloudflare",
+      "addr": "1.1.1.1",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 9,
+      "detail": "ok"
+    },
+    {
+      "name": "Cloudflare",
+      "addr": "1.1.1.1",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 228,
+      "detail": "ok"
+    },
+    {
+      "name": "Cloudflare",
+      "addr": "1.1.1.1",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 334,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 45,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 218,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 206,
+      "detail": "ok"
+    },
+    {
+      "name": "Quad9",
+      "addr": "9.9.9.9",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 95,
+      "detail": "ok"
+    },
+    {
+      "name": "Quad9",
+      "addr": "9.9.9.9",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 513,
+      "detail": "ok"
+    },
+    {
+      "name": "Quad9",
+      "addr": "9.9.9.9",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 440,
+      "detail": "ok"
+    },
+    {
+      "name": "OpenDNS",
+      "addr": "208.67.222.222",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 101,
+      "detail": "ok"
+    },
+    {
+      "name": "OpenDNS",
+      "addr": "208.67.222.222",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 352,
+      "detail": "ok"
+    },
+    {
+      "name": "OpenDNS",
+      "addr": "208.67.222.222",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 397,
+      "detail": "ok"
+    },
+    {
+      "name": "Comodo",
+      "addr": "8.26.56.26",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 197,
+      "detail": "ok"
+    },
+    {
+      "name": "Comodo",
+      "addr": "8.26.56.26",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 496,
+      "detail": "ok"
+    },
+    {
+      "name": "Comodo",
+      "addr": "8.26.56.26",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 451,
+      "detail": "ok"
+    },
+    {
+      "name": "Level3",
+      "addr": "4.2.2.1",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": null,
+      "ok": false,
+      "latency_ms": 10206,
+      "detail": "empty answer"
+    },
+    {
+      "name": "Level3",
+      "addr": "4.2.2.1",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 334,
+      "detail": "ok"
+    },
+    {
+      "name": "Level3",
+      "addr": "4.2.2.1",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 343,
+      "detail": "ok"
+    },
+    {
+      "name": "Hurricane Electric",
+      "addr": "74.82.42.42",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 77,
+      "detail": "ok"
+    },
+    {
+      "name": "Hurricane Electric",
+      "addr": "74.82.42.42",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 340,
+      "detail": "ok"
+    },
+    {
+      "name": "Hurricane Electric",
+      "addr": "74.82.42.42",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 183,
+      "detail": "ok"
+    },
+    {
+      "name": "Verisign",
+      "addr": "64.6.64.6",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 46,
+      "detail": "ok"
+    },
+    {
+      "name": "Verisign",
+      "addr": "64.6.64.6",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 377,
+      "detail": "ok"
+    },
+    {
+      "name": "Verisign",
+      "addr": "64.6.64.6",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 365,
+      "detail": "ok"
+    },
+    {
+      "name": "AdGuard",
+      "addr": "94.140.14.14",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 310,
+      "detail": "ok"
+    },
+    {
+      "name": "AdGuard",
+      "addr": "94.140.14.14",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 474,
+      "detail": "ok"
+    },
+    {
+      "name": "AdGuard",
+      "addr": "94.140.14.14",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 1033,
+      "detail": "ok"
+    },
+    {
+      "name": "Yandex",
+      "addr": "77.88.8.8",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 721,
+      "detail": "ok"
+    },
+    {
+      "name": "Yandex",
+      "addr": "77.88.8.8",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 804,
+      "detail": "ok"
+    },
+    {
+      "name": "Yandex",
+      "addr": "77.88.8.8",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 479,
+      "detail": "ok"
+    },
+    {
+      "name": "Alibaba",
+      "addr": "223.5.5.5",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 185,
+      "detail": "ok"
+    },
+    {
+      "name": "Alibaba",
+      "addr": "223.5.5.5",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 584,
+      "detail": "ok"
+    },
+    {
+      "name": "Alibaba",
+      "addr": "223.5.5.5",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 781,
+      "detail": "ok"
+    },
+    {
+      "name": "DNSPod",
+      "addr": "119.29.29.29",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 108,
+      "detail": "ok"
+    },
+    {
+      "name": "DNSPod",
+      "addr": "119.29.29.29",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 535,
+      "detail": "ok"
+    },
+    {
+      "name": "DNSPod",
+      "addr": "119.29.29.29",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 558,
+      "detail": "ok"
+    },
+    {
+      "name": "KT Korea",
+      "addr": "168.126.63.1",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 485,
+      "detail": "ok"
+    },
+    {
+      "name": "KT Korea",
+      "addr": "168.126.63.1",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 760,
+      "detail": "ok"
+    },
+    {
+      "name": "KT Korea",
+      "addr": "168.126.63.1",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 537,
+      "detail": "ok"
+    }
+  ]
 }

--- a/docs/directory/index.html
+++ b/docs/directory/index.html
@@ -1,38 +1,144 @@
-<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>DMP node directory</title>
+---
+title: Directory
+layout: default
+nav_order: 8
+permalink: /directory/
+---
 <style>
-body { font: 14px/1.5 system-ui, sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; }
-table { border-collapse: collapse; width: 100%; margin-top: 1em; }
-th, td { border: 1px solid #ccc; padding: 0.4em 0.6em; text-align: left; }
-th { background: #f5f5f5; }
-td.fresh { color: #0a0; }
-td.stale { color: #a60; }
-small { color: #666; }
+.dmp-directory {
+  --dir-fg: #1a1a1a; --dir-muted: #666; --dir-card: #fff;
+  --dir-border: #ddd; --dir-accent: #0066cc; --dir-green: #1a7f37;
+  --dir-amber: #9a6700; --dir-red: #cf222e;
+}
+@media (prefers-color-scheme: dark) {
+  .dmp-directory {
+    --dir-fg: #e6edf3; --dir-muted: #8b949e; --dir-card: #161b22;
+    --dir-border: #30363d; --dir-accent: #58a6ff; --dir-green: #3fb950;
+    --dir-amber: #d29922; --dir-red: #f85149;
+  }
+}
+.dmp-directory { font: 14px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif; color: var(--dir-fg); }
+.dmp-directory h2 { margin: 1.6em 0 0.4em; font-size: 1.15em; }
+.dmp-directory h2 small { font-weight: normal; color: var(--dir-muted); margin-left: 0.5em; }
+.dmp-directory small { color: var(--dir-muted); }
+.dmp-directory a { color: var(--dir-accent); text-decoration: none; }
+.dmp-directory a:hover { text-decoration: underline; }
+.dmp-directory code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em; background: var(--dir-card); padding: 1px 4px;
+  border-radius: 3px; border: 1px solid var(--dir-border);
+}
+.dmp-directory .cards {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 0.8em;
+}
+.dmp-directory .card {
+  background: var(--dir-card); border: 1px solid var(--dir-border);
+  border-radius: 6px; padding: 0.9em 1em;
+}
+.dmp-directory .card h3 { margin: 0 0 0.4em; font-size: 1em; }
+.dmp-directory .card .row { display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }
+.dmp-directory .card .label { color: var(--dir-muted); flex-shrink: 0; }
+.dmp-directory .card .val { text-align: right; word-break: break-all; }
+.dmp-directory .card .pill { font-size: 0.8em; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--dir-border); }
+.dmp-directory .pill.fresh { color: var(--dir-green); border-color: currentColor; }
+.dmp-directory .pill.stale { color: var(--dir-amber); border-color: currentColor; }
+.dmp-directory .pill.expired { color: var(--dir-red); border-color: currentColor; }
+.dmp-directory table {
+  border-collapse: collapse; width: 100%; margin-top: 0.6em;
+  font-size: 0.92em;
+}
+.dmp-directory th, .dmp-directory td {
+  border: 1px solid var(--dir-border); padding: 0.4em 0.7em;
+  text-align: left;
+}
+.dmp-directory th { background: var(--dir-card); font-weight: 600; }
+.dmp-directory td.ok { color: var(--dir-green); }
+.dmp-directory td.fail { color: var(--dir-red); }
+.dmp-directory .svg-wrap {
+  background: var(--dir-card); border: 1px solid var(--dir-border);
+  border-radius: 6px; padding: 1em; margin-top: 0.4em;
+  text-align: center; overflow-x: auto;
+}
+.dmp-directory svg.topology text { fill: var(--dir-fg); font: 11px ui-monospace, monospace; }
+.dmp-directory svg.topology circle.node { fill: var(--dir-card); stroke: var(--dir-accent); stroke-width: 2; }
+.dmp-directory svg.topology line { stroke: var(--dir-accent); stroke-width: 1.4; opacity: 0.65; }
+.dmp-directory svg.topology .label { font: 11px system-ui, sans-serif; fill: var(--dir-fg); }
+.dmp-directory svg.topology .arrow { fill: var(--dir-accent); }
+.dmp-directory .legend { font-size: 0.85em; color: var(--dir-muted); margin-top: 0.5em; }
+.dmp-directory .section-note { font-size: 0.88em; color: var(--dir-muted); margin-top: 0.3em; }
 </style>
-</head>
-<body>
-<h1>DMP node directory</h1>
+
+<div class="dmp-directory">
+
 <p>
-  <small>Generated 2026-04-26 06:47:20 UTC · 0 nodes heard in the last 72h.
-  Every row is a signed HeartbeatRecord; <a href="feed.json">feed.json</a>
-  carries the raw wire strings so consumers can re-verify independently.</small>
+  <small>Generated 2026-05-01 21:36:46 UTC · 3 known nodes ·
+  <a href="feed.json">feed.json</a> carries the raw signed wires
+  for independent re-verification.</small>
 </p>
-<table>
-<thead>
-<tr>
-  <th>Endpoint</th>
-  <th>Operator pubkey</th>
-  <th>Version</th>
-  <th>Last heard</th>
-  <th>Sources</th>
-</tr>
-</thead>
-<tbody>
-<tr><td colspan="5">(no nodes seen)</td></tr>
-</tbody>
-</table>
-</body>
-</html>
+
+<h2>Known nodes <small>· geo + hosting</small></h2>
+<div class="cards">
+<div class="card">
+<h3><a href="https://dnsmesh.de">https://dnsmesh.de</a></h3>
+<div class="row"><span class="label">Status</span><span class="val"><span class="pill fresh">1m ago</span></span></div>
+<div class="row"><span class="label">Version</span><span class="val">0.6.6</span></div>
+<div class="row"><span class="label">Operator key</span><span class="val"><code>fbe50814…cdd9</code></span></div>
+<div class="row"><span class="label">Hosting</span><span class="val">Hetzner <small>(AS24940 Hetzner Online GmbH)</small></span></div>
+<div class="row"><span class="label">Region</span><span class="val">Nuremberg, Bavaria, Germany</span></div>
+<div class="row"><span class="label">IP</span><span class="val"><code>178.104.241.208</code></span></div>
+<div class="row"><span class="label">Heard via</span><span class="val">dmp.dnsmesh.de</span></div>
+</div>
+<div class="card">
+<h3><a href="https://dnsmesh.pro">https://dnsmesh.pro</a></h3>
+<div class="row"><span class="label">Status</span><span class="val"><span class="pill fresh">1m ago</span></span></div>
+<div class="row"><span class="label">Version</span><span class="val">0.6.6</span></div>
+<div class="row"><span class="label">Operator key</span><span class="val"><code>55dd5085…bfef</code></span></div>
+<div class="row"><span class="label">Hosting</span><span class="val">OPENCLOUD SpA <small>(AS52368 ZAM LTDA.)</small></span></div>
+<div class="row"><span class="label">Region</span><span class="val">Curicó, Maule Region, Chile</span></div>
+<div class="row"><span class="label">IP</span><span class="val"><code>45.7.229.112</code></span></div>
+<div class="row"><span class="label">Heard via</span><span class="val">dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
+</div>
+<div class="card">
+<h3><a href="https://dnsmesh.io">https://dnsmesh.io</a></h3>
+<div class="row"><span class="label">Status</span><span class="val"><span class="pill fresh">1m ago</span></span></div>
+<div class="row"><span class="label">Version</span><span class="val">0.6.6</span></div>
+<div class="row"><span class="label">Operator key</span><span class="val"><code>c0e5385e…32c2</code></span></div>
+<div class="row"><span class="label">Hosting</span><span class="val">DigitalOcean, LLC <small>(AS14061 DigitalOcean, LLC)</small></span></div>
+<div class="row"><span class="label">Region</span><span class="val">Santa Clara, California, United States</span></div>
+<div class="row"><span class="label">IP</span><span class="val"><code>24.199.107.165</code></span></div>
+<div class="row"><span class="label">Heard via</span><span class="val">dmp.dnsmesh.io, dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
+</div>
+</div>
+<p class="section-note">
+  Geo and ASN data via ip-api.com lookup at build time. Each node is
+  the same self-signed <code>HeartbeatRecord</code> wire that lives at
+  <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
+  chain — the geo block is descriptive metadata for humans and is
+  NOT signed.
+</p>
+
+<h2>Federation topology <small>· heartbeat-discovery, not message traffic</small></h2>
+<div class="svg-wrap">
+<svg class="topology" width="720" height="220" viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg"><defs><marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" class="arrow"/></marker></defs><path d="M 360 135 Q 495 140 630 85" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><path d="M 90 85 Q 225 140 360 135" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><path d="M 90 85 Q 360 115 630 85" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><circle class="node" cx="90" cy="85" r="22"/><text class="label" x="90" y="89" text-anchor="middle" font-size="11">DE</text><text class="label" x="90" y="127" text-anchor="middle" font-size="11">dnsmesh.de</text><text class="label" x="90" y="141" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text><circle class="node" cx="360" cy="135" r="22"/><text class="label" x="360" y="139" text-anchor="middle" font-size="11">CL</text><text class="label" x="360" y="177" text-anchor="middle" font-size="11">dnsmesh.pro</text><text class="label" x="360" y="191" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text><circle class="node" cx="630" cy="85" r="22"/><text class="label" x="630" y="89" text-anchor="middle" font-size="11">US</text><text class="label" x="630" y="127" text-anchor="middle" font-size="11">dnsmesh.io</text><text class="label" x="630" y="141" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text></svg>
+</div>
+<p class="section-note">
+  An arrow from A → B means A's seen-graph
+  (<code>_dnsmesh-seen.&lt;A-zone&gt;</code>) carries a verified
+  heartbeat from B. This is the federation discovery view —
+  who has heard from whom over the public DNS chain. Message
+  traffic is private (E2E encrypted) and is NOT shown here.
+</p>
+
+<h2>Public-resolver reachability <small>· can major resolvers find these nodes?</small></h2>
+<table><thead><tr><th>Resolver</th><th>dmp.dnsmesh.de</th><th>dmp.dnsmesh.io</th><th>dmp.dnsmesh.pro</th></tr></thead><tbody><tr><td><strong>Cloudflare</strong> <small><code>1.1.1.1</code></small></td><td class="ok">✓ <small>334 ms</small></td><td class="ok">✓ <small>9 ms</small></td><td class="ok">✓ <small>228 ms</small></td></tr><tr><td><strong>Google</strong> <small><code>8.8.8.8</code></small></td><td class="ok">✓ <small>206 ms</small></td><td class="ok">✓ <small>45 ms</small></td><td class="ok">✓ <small>218 ms</small></td></tr><tr><td><strong>Quad9</strong> <small><code>9.9.9.9</code></small></td><td class="ok">✓ <small>440 ms</small></td><td class="ok">✓ <small>95 ms</small></td><td class="ok">✓ <small>513 ms</small></td></tr><tr><td><strong>OpenDNS</strong> <small><code>208.67.222.222</code></small></td><td class="ok">✓ <small>397 ms</small></td><td class="ok">✓ <small>101 ms</small></td><td class="ok">✓ <small>352 ms</small></td></tr><tr><td><strong>Comodo</strong> <small><code>8.26.56.26</code></small></td><td class="ok">✓ <small>451 ms</small></td><td class="ok">✓ <small>197 ms</small></td><td class="ok">✓ <small>496 ms</small></td></tr><tr><td><strong>Level3</strong> <small><code>4.2.2.1</code></small></td><td class="ok">✓ <small>343 ms</small></td><td class="fail">✗ <small>empty answer</small></td><td class="ok">✓ <small>334 ms</small></td></tr><tr><td><strong>Hurricane Electric</strong> <small><code>74.82.42.42</code></small></td><td class="ok">✓ <small>183 ms</small></td><td class="ok">✓ <small>77 ms</small></td><td class="ok">✓ <small>340 ms</small></td></tr><tr><td><strong>Verisign</strong> <small><code>64.6.64.6</code></small></td><td class="ok">✓ <small>365 ms</small></td><td class="ok">✓ <small>46 ms</small></td><td class="ok">✓ <small>377 ms</small></td></tr><tr><td><strong>AdGuard</strong> <small><code>94.140.14.14</code></small></td><td class="ok">✓ <small>1033 ms</small></td><td class="ok">✓ <small>310 ms</small></td><td class="ok">✓ <small>474 ms</small></td></tr><tr><td><strong>Yandex</strong> <small><code>77.88.8.8</code></small></td><td class="ok">✓ <small>479 ms</small></td><td class="ok">✓ <small>721 ms</small></td><td class="ok">✓ <small>804 ms</small></td></tr><tr><td><strong>Alibaba</strong> <small><code>223.5.5.5</code></small></td><td class="ok">✓ <small>781 ms</small></td><td class="ok">✓ <small>185 ms</small></td><td class="ok">✓ <small>584 ms</small></td></tr><tr><td><strong>DNSPod</strong> <small><code>119.29.29.29</code></small></td><td class="ok">✓ <small>558 ms</small></td><td class="ok">✓ <small>108 ms</small></td><td class="ok">✓ <small>535 ms</small></td></tr><tr><td><strong>KT Korea</strong> <small><code>168.126.63.1</code></small></td><td class="ok">✓ <small>537 ms</small></td><td class="ok">✓ <small>485 ms</small></td><td class="ok">✓ <small>760 ms</small></td></tr></tbody></table>
+<p class="section-note">
+  Tested at build time from a GitHub Actions runner: each row is a
+  curated public DNS resolver, each column is a node. A green cell
+  means the resolver answered <code>_dnsmesh-heartbeat.&lt;zone&gt;</code>
+  with a wire that verifies under Ed25519. Your client can do the
+  same lookup with the same result. The list is illustrative — every
+  internet-connected DNS resolver can perform the same query.
+</p>
+
+</div>

--- a/examples/directory_aggregator.py
+++ b/examples/directory_aggregator.py
@@ -496,86 +496,88 @@ def emit_json(result: AggregateResult, out: Path, *, now: int) -> None:
     out.write_text(json.dumps(feed, indent=2) + "\n")
 
 
-_HTML_TEMPLATE = """<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>DMP node directory</title>
+# Jekyll front matter at the top — Just-the-Docs picks up `title` for the
+# sidebar entry, `nav_order` controls position, `layout: default` wraps the
+# generated content in the standard chrome (sidebar, header, footer).
+# `permalink` keeps the URL at /directory/ regardless of how the source file
+# is named so existing links don't break.
+#
+# All page-specific styles are scoped to ``.dmp-directory`` so they don't
+# fight with Just-the-Docs's body / typography rules. Content lives inside
+# a single wrapper div for the same reason.
+_HTML_TEMPLATE = """---
+title: Directory
+layout: default
+nav_order: 8
+permalink: /directory/
+---
 <style>
-:root {{
-  --fg: #1a1a1a; --muted: #666; --bg: #fafafa; --card: #fff;
-  --border: #ddd; --accent: #0066cc; --green: #1a7f37;
-  --amber: #9a6700; --red: #cf222e;
+.dmp-directory {{
+  --dir-fg: #1a1a1a; --dir-muted: #666; --dir-card: #fff;
+  --dir-border: #ddd; --dir-accent: #0066cc; --dir-green: #1a7f37;
+  --dir-amber: #9a6700; --dir-red: #cf222e;
 }}
 @media (prefers-color-scheme: dark) {{
-  :root {{
-    --fg: #e6edf3; --muted: #8b949e; --bg: #0d1117; --card: #161b22;
-    --border: #30363d; --accent: #58a6ff; --green: #3fb950;
-    --amber: #d29922; --red: #f85149;
+  .dmp-directory {{
+    --dir-fg: #e6edf3; --dir-muted: #8b949e; --dir-card: #161b22;
+    --dir-border: #30363d; --dir-accent: #58a6ff; --dir-green: #3fb950;
+    --dir-amber: #d29922; --dir-red: #f85149;
   }}
 }}
-* {{ box-sizing: border-box; }}
-body {{
-  font: 14px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
-  max-width: 1080px; margin: 2em auto; padding: 0 1.2em;
-  color: var(--fg); background: var(--bg);
-}}
-h1 {{ margin: 0 0 0.2em; font-size: 1.7em; }}
-h2 {{ margin: 1.6em 0 0.4em; font-size: 1.15em; }}
-h2 small {{ font-weight: normal; color: var(--muted); margin-left: 0.5em; }}
-small {{ color: var(--muted); }}
-a {{ color: var(--accent); text-decoration: none; }}
-a:hover {{ text-decoration: underline; }}
-code {{
+.dmp-directory {{ font: 14px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif; color: var(--dir-fg); }}
+.dmp-directory h2 {{ margin: 1.6em 0 0.4em; font-size: 1.15em; }}
+.dmp-directory h2 small {{ font-weight: normal; color: var(--dir-muted); margin-left: 0.5em; }}
+.dmp-directory small {{ color: var(--dir-muted); }}
+.dmp-directory a {{ color: var(--dir-accent); text-decoration: none; }}
+.dmp-directory a:hover {{ text-decoration: underline; }}
+.dmp-directory code {{
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.9em; background: var(--card); padding: 1px 4px;
-  border-radius: 3px; border: 1px solid var(--border);
+  font-size: 0.9em; background: var(--dir-card); padding: 1px 4px;
+  border-radius: 3px; border: 1px solid var(--dir-border);
 }}
-.cards {{
+.dmp-directory .cards {{
   display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 0.8em;
 }}
-.card {{
-  background: var(--card); border: 1px solid var(--border);
+.dmp-directory .card {{
+  background: var(--dir-card); border: 1px solid var(--dir-border);
   border-radius: 6px; padding: 0.9em 1em;
 }}
-.card h3 {{ margin: 0 0 0.4em; font-size: 1em; }}
-.card .row {{ display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }}
-.card .label {{ color: var(--muted); flex-shrink: 0; }}
-.card .val {{ text-align: right; word-break: break-all; }}
-.card .pill {{ font-size: 0.8em; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--border); }}
-.pill.fresh {{ color: var(--green); border-color: currentColor; }}
-.pill.stale {{ color: var(--amber); border-color: currentColor; }}
-.pill.expired {{ color: var(--red); border-color: currentColor; }}
-table {{
+.dmp-directory .card h3 {{ margin: 0 0 0.4em; font-size: 1em; }}
+.dmp-directory .card .row {{ display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }}
+.dmp-directory .card .label {{ color: var(--dir-muted); flex-shrink: 0; }}
+.dmp-directory .card .val {{ text-align: right; word-break: break-all; }}
+.dmp-directory .card .pill {{ font-size: 0.8em; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--dir-border); }}
+.dmp-directory .pill.fresh {{ color: var(--dir-green); border-color: currentColor; }}
+.dmp-directory .pill.stale {{ color: var(--dir-amber); border-color: currentColor; }}
+.dmp-directory .pill.expired {{ color: var(--dir-red); border-color: currentColor; }}
+.dmp-directory table {{
   border-collapse: collapse; width: 100%; margin-top: 0.6em;
   font-size: 0.92em;
 }}
-th, td {{
-  border: 1px solid var(--border); padding: 0.4em 0.7em;
+.dmp-directory th, .dmp-directory td {{
+  border: 1px solid var(--dir-border); padding: 0.4em 0.7em;
   text-align: left;
 }}
-th {{ background: var(--card); font-weight: 600; }}
-td.ok {{ color: var(--green); }}
-td.fail {{ color: var(--red); }}
-.svg-wrap {{
-  background: var(--card); border: 1px solid var(--border);
+.dmp-directory th {{ background: var(--dir-card); font-weight: 600; }}
+.dmp-directory td.ok {{ color: var(--dir-green); }}
+.dmp-directory td.fail {{ color: var(--dir-red); }}
+.dmp-directory .svg-wrap {{
+  background: var(--dir-card); border: 1px solid var(--dir-border);
   border-radius: 6px; padding: 1em; margin-top: 0.4em;
   text-align: center; overflow-x: auto;
 }}
-svg.topology text {{ fill: var(--fg); font: 11px ui-monospace, monospace; }}
-svg.topology circle.node {{ fill: var(--card); stroke: var(--accent); stroke-width: 2; }}
-svg.topology line {{ stroke: var(--accent); stroke-width: 1.4; opacity: 0.65; }}
-svg.topology .label {{ font: 11px system-ui, sans-serif; fill: var(--fg); }}
-svg.topology .arrow {{ fill: var(--accent); }}
-.legend {{ font-size: 0.85em; color: var(--muted); margin-top: 0.5em; }}
-.section-note {{ font-size: 0.88em; color: var(--muted); margin-top: 0.3em; }}
+.dmp-directory svg.topology text {{ fill: var(--dir-fg); font: 11px ui-monospace, monospace; }}
+.dmp-directory svg.topology circle.node {{ fill: var(--dir-card); stroke: var(--dir-accent); stroke-width: 2; }}
+.dmp-directory svg.topology line {{ stroke: var(--dir-accent); stroke-width: 1.4; opacity: 0.65; }}
+.dmp-directory svg.topology .label {{ font: 11px system-ui, sans-serif; fill: var(--dir-fg); }}
+.dmp-directory svg.topology .arrow {{ fill: var(--dir-accent); }}
+.dmp-directory .legend {{ font-size: 0.85em; color: var(--dir-muted); margin-top: 0.5em; }}
+.dmp-directory .section-note {{ font-size: 0.88em; color: var(--dir-muted); margin-top: 0.3em; }}
 </style>
-</head>
-<body>
 
-<h1>DMP node directory</h1>
+<div class="dmp-directory">
+
 <p>
   <small>Generated {generated} · {node_count} known nodes ·
   <a href="feed.json">feed.json</a> carries the raw signed wires
@@ -617,8 +619,7 @@ svg.topology .arrow {{ fill: var(--accent); }}
   internet-connected DNS resolver can perform the same query.
 </p>
 
-</body>
-</html>
+</div>
 """
 
 


### PR DESCRIPTION
## Summary

The directory page at `https://ovalenzuela.com/DNSMeshProtocol/directory/` was rendering as a standalone HTML document — no sidebar, no search, no header, no integration with the rest of the docs site. This PR makes the aggregator emit a Jekyll-front-matter page so Just-the-Docs wraps it in the standard chrome and the directory shows up as a top-level entry in the sidebar nav.

URL is unchanged. Behavior is unchanged. The page just *fits* now.

## What changes

### Template (in `examples/directory_aggregator.py`)

```diff
-_HTML_TEMPLATE = """<!doctype html>
-<html lang="en">
-<head>
-  <title>DMP node directory</title>
-  <style>...global CSS clobbering body/h1/etc...</style>
-</head>
-<body>
-  ...content...
-</body>
-</html>
-"""
+_HTML_TEMPLATE = """---
+title: Directory
+layout: default
+nav_order: 8
+permalink: /directory/
+---
+<style>
+  .dmp-directory { ...all CSS scoped to wrapper class... }
+</style>
+<div class="dmp-directory">
+  ...content...
+</div>
+"""
```

### Side effects

- All page-specific CSS variables renamed `--fg/--bg/etc.` → `--dir-fg/etc.` to avoid colliding with whatever Just-the-Docs uses.
- The duplicate `<h1>DMP node directory</h1>` is dropped from the body — Just-the-Docs already renders the front-matter `title` as the page heading.
- In-tree fallback (`docs/directory/index.html`) regenerated with the new template so even when the aggregator step fails or hasn't run yet, the page still integrates with the sidebar.

## Why nav_order=8

Top-level Just-the-Docs sidebar entries currently sit at:

| nav_order | Page |
|---|---|
| 1 | Home |
| 2 | How It Works |
| 3 | Getting Started |
| 4 | User Guide |
| 5 | Deployment / Protocol |

`8` puts Directory near the bottom of the sidebar, after the conceptual / how-to docs. Easy to bump if you want it higher.

## Files

- `examples/directory_aggregator.py` — `_HTML_TEMPLATE` rewritten
- `docs/directory/index.html` — regenerated in-tree fallback (bonus: the actual current state, not the 38-line 0-nodes stub from April)
- `docs/directory/feed.json` — refreshed alongside

## Smoke test

```
$ python examples/directory_aggregator.py --seeds-file directory/seeds.txt --out-dir /tmp/agg-test
wrote 3 nodes from 3 seeds (edges: 3, resolver checks: 39)

$ head -6 /tmp/agg-test/index.html
---
title: Directory
layout: default
nav_order: 8
permalink: /directory/
---
```

`black --check` clean. No test files reference the HTML template.

## Test plan

- [x] Local aggregator run produces front-matter-prefixed file
- [x] Scoped CSS doesn't escape the wrapper div (visually verified locally)
- [x] `black` clean
- [ ] After merge: pages.yml runs, https://ovalenzuela.com/DNSMeshProtocol/directory/ renders with the Just-the-Docs sidebar visible, "Directory" entry appears at position 8 in the nav