### PR TITLE
fix(directory): rename CSS classes to dir-* (Just-the-Docs collisions)

### DIFF
--- a/docs/directory/feed.json
+++ b/docs/directory/feed.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
-  "generated_at": 1777671406,
+  "generated_at": 1777672277,
   "node_count": 3,
   "nodes": [
     {
       "operator_spk_hex": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "endpoint": "https://dnsmesh.de",
       "version": "0.6.6",
-      "ts": 1777671327,
-      "exp": 1777757727,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmRl++UIFDC977dfAreU7bazW7NCi9vZnlCBH+kffTaSzdkFMC42LjYAAQ5kbXAuZG5zbWVzaC5kZQAAAABp9RyfAAAAAGn2bh8i5+FVTUzkghzafSFdokqz0iEA3L1eH2OCLLBBE/zFPhuvrtm3FZFMC1he9KCXiQrie2QfMNTxYifq0FObrxAB",
+      "ts": 1777672232,
+      "exp": 1777758632,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmRl++UIFDC977dfAreU7bazW7NCi9vZnlCBH+kffTaSzdkFMC42LjYAAQ5kbXAuZG5zbWVzaC5kZQAAAABp9SAoAAAAAGn2cahC+3bho0jbQz9d2WLb0kIxVPBMwrcGgUqqw5aVaHxSw/9SpfeJwh2lXUsVeQNRl8r2aya1ABHVhIm6pTR6jugL",
       "last_seen_via": [
         "dmp.dnsmesh.de"
       ],
@@ -36,9 +36,9 @@
       "operator_spk_hex": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
       "endpoint": "https://dnsmesh.pro",
       "version": "0.6.6",
-      "ts": 1777671321,
-      "exp": 1777757721,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwATaHR0cHM6Ly9kbnNtZXNoLnByb1XdUIW7Ftv1ra8k1ToTu9UMj5+T4CaxlAWSNaP9gr/vBTAuNi42AAEPZG1wLmRuc21lc2gucHJvAAAAAGn1HJkAAAAAafZuGUQnn0QCsnPHRnJcM8rzvFEcgFX1AUTlfwxr5oLs7WBWOWlKG3zCMLuwmMdQ6cMUTnvbHsHjdLMQ27WZrq72bwI=",
+      "ts": 1777672227,
+      "exp": 1777758627,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwATaHR0cHM6Ly9kbnNtZXNoLnByb1XdUIW7Ftv1ra8k1ToTu9UMj5+T4CaxlAWSNaP9gr/vBTAuNi42AAEPZG1wLmRuc21lc2gucHJvAAAAAGn1ICMAAAAAafZxo+BTZEBhhn6+cxYiorGbzRouxpxolsgR0m6I7r6AssKz/h4gBV+w649W2wAxvqUHWzgKhXJ4K62qrZJ0Jp3QRwE=",
       "last_seen_via": [
         "dmp.dnsmesh.pro",
         "dmp.dnsmesh.de"
@@ -66,9 +66,9 @@
       "operator_spk_hex": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
       "endpoint": "https://dnsmesh.io",
       "version": "0.6.6",
-      "ts": 1777671311,
-      "exp": 1777757711,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmlvwOU4XrU8HNtixcWnJvGlUkgPw0XGAMjkXy7wR/ogMsIFMC42LjYAAQ5kbXAuZG5zbWVzaC5pbwAAAABp9RyPAAAAAGn2bg9auCg/aX5lKU5wjjmcsggM1QimjqkEH0TgF/rBD7NBWqpl5XDFc/+qrH5+yutl5wP5C58wLET4rrS7bzafHpoO",
+      "ts": 1777672215,
+      "exp": 1777758615,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmlvwOU4XrU8HNtixcWnJvGlUkgPw0XGAMjkXy7wR/ogMsIFMC42LjYAAQ5kbXAuZG5zbWVzaC5pbwAAAABp9SAXAAAAAGn2cZcSD58hBWXil6yFGN/FKfr5yWxpyGdvXo6QWPJ3FoLTQ1rY0mdl9u2g/PW7d9GrjVrT86Mbh6lZoPPDF8Qd6PUM",
       "last_seen_via": [
         "dmp.dnsmesh.io",
         "dmp.dnsmesh.pro",
@@ -98,17 +98,17 @@
     {
       "from_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
       "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
-      "last_seen_ts": 1777671311
+      "last_seen_ts": 1777672215
     },
     {
       "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "to_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
-      "last_seen_ts": 1777671321
+      "last_seen_ts": 1777672227
     },
     {
       "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
-      "last_seen_ts": 1777671311
+      "last_seen_ts": 1777672215
     }
   ],
   "resolvers": [
@@ -118,7 +118,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 9,
+      "latency_ms": 68,
       "detail": "ok"
     },
     {
@@ -127,7 +127,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 228,
+      "latency_ms": 178,
       "detail": "ok"
     },
     {
@@ -136,7 +136,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 334,
+      "latency_ms": 336,
       "detail": "ok"
     },
     {
@@ -145,7 +145,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 45,
+      "latency_ms": 104,
       "detail": "ok"
     },
     {
@@ -154,7 +154,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 218,
+      "latency_ms": 343,
       "detail": "ok"
     },
     {
@@ -163,7 +163,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 206,
+      "latency_ms": 157,
       "detail": "ok"
     },
     {
@@ -172,7 +172,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 95,
+      "latency_ms": 78,
       "detail": "ok"
     },
     {
@@ -181,7 +181,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 513,
+      "latency_ms": 215,
       "detail": "ok"
     },
     {
@@ -190,7 +190,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 440,
+      "latency_ms": 364,
       "detail": "ok"
     },
     {
@@ -199,7 +199,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 101,
+      "latency_ms": 81,
       "detail": "ok"
     },
     {
@@ -208,7 +208,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 352,
+      "latency_ms": 332,
       "detail": "ok"
     },
     {
@@ -217,7 +217,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 397,
+      "latency_ms": 349,
       "detail": "ok"
     },
     {
@@ -226,7 +226,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 197,
+      "latency_ms": 55,
       "detail": "ok"
     },
     {
@@ -235,7 +235,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 496,
+      "latency_ms": 350,
       "detail": "ok"
     },
     {
@@ -244,7 +244,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 451,
+      "latency_ms": 354,
       "detail": "ok"
     },
     {
@@ -262,7 +262,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 334,
+      "latency_ms": 330,
       "detail": "ok"
     },
     {
@@ -271,7 +271,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 343,
+      "latency_ms": 349,
       "detail": "ok"
     },
     {
@@ -280,7 +280,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 77,
+      "latency_ms": 35,
       "detail": "ok"
     },
     {
@@ -289,7 +289,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 340,
+      "latency_ms": 210,
       "detail": "ok"
     },
     {
@@ -298,7 +298,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 183,
+      "latency_ms": 153,
       "detail": "ok"
     },
     {
@@ -307,7 +307,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 46,
+      "latency_ms": 42,
       "detail": "ok"
     },
     {
@@ -315,26 +315,26 @@
       "addr": "64.6.64.6",
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
-      "ok": true,
-      "latency_ms": 377,
-      "detail": "ok"
-    },
-    {
-      "name": "Verisign",
-      "addr": "64.6.64.6",
-      "zone": "dmp.dnsmesh.de",
-      "endpoint": "https://dnsmesh.de",
       "ok": true,
       "latency_ms": 365,
       "detail": "ok"
     },
     {
+      "name": "Verisign",
+      "addr": "64.6.64.6",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 481,
+      "detail": "ok"
+    },
+    {
       "name": "AdGuard",
       "addr": "94.140.14.14",
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 310,
+      "latency_ms": 266,
       "detail": "ok"
     },
     {
@@ -343,7 +343,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 474,
+      "latency_ms": 808,
       "detail": "ok"
     },
     {
@@ -352,7 +352,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 1033,
+      "latency_ms": 666,
       "detail": "ok"
     },
     {
@@ -361,7 +361,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 721,
+      "latency_ms": 677,
       "detail": "ok"
     },
     {
@@ -370,7 +370,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 804,
+      "latency_ms": 856,
       "detail": "ok"
     },
     {
@@ -379,7 +379,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 479,
+      "latency_ms": 442,
       "detail": "ok"
     },
     {
@@ -388,7 +388,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 185,
+      "latency_ms": 184,
       "detail": "ok"
     },
     {
@@ -397,7 +397,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 584,
+      "latency_ms": 183,
       "detail": "ok"
     },
     {
@@ -406,7 +406,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 781,
+      "latency_ms": 189,
       "detail": "ok"
     },
     {
@@ -415,7 +415,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 108,
+      "latency_ms": 111,
       "detail": "ok"
     },
     {
@@ -423,44 +423,44 @@
       "addr": "119.29.29.29",
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 569,
+      "detail": "ok"
+    },
+    {
+      "name": "DNSPod",
+      "addr": "119.29.29.29",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 574,
+      "detail": "ok"
+    },
+    {
+      "name": "KT Korea",
+      "addr": "168.126.63.1",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 484,
+      "detail": "ok"
+    },
+    {
+      "name": "KT Korea",
+      "addr": "168.126.63.1",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 757,
+      "detail": "ok"
+    },
+    {
+      "name": "KT Korea",
+      "addr": "168.126.63.1",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
       "ok": true,
       "latency_ms": 535,
-      "detail": "ok"
-    },
-    {
-      "name": "DNSPod",
-      "addr": "119.29.29.29",
-      "zone": "dmp.dnsmesh.de",
-      "endpoint": "https://dnsmesh.de",
-      "ok": true,
-      "latency_ms": 558,
-      "detail": "ok"
-    },
-    {
-      "name": "KT Korea",
-      "addr": "168.126.63.1",
-      "zone": "dmp.dnsmesh.io",
-      "endpoint": "https://dnsmesh.io",
-      "ok": true,
-      "latency_ms": 485,
-      "detail": "ok"
-    },
-    {
-      "name": "KT Korea",
-      "addr": "168.126.63.1",
-      "zone": "dmp.dnsmesh.pro",
-      "endpoint": "https://dnsmesh.pro",
-      "ok": true,
-      "latency_ms": 760,
-      "detail": "ok"
-    },
-    {
-      "name": "KT Korea",
-      "addr": "168.126.63.1",
-      "zone": "dmp.dnsmesh.de",
-      "endpoint": "https://dnsmesh.de",
-      "ok": true,
-      "latency_ms": 537,
       "detail": "ok"
     }
   ]

--- a/docs/directory/index.html
+++ b/docs/directory/index.html
@@ -5,112 +5,94 @@ nav_order: 8
 permalink: /directory/
 ---
 <style>
-.dmp-directory {
-  --dir-fg: #1a1a1a; --dir-muted: #666; --dir-card: #fff;
-  --dir-border: #ddd; --dir-accent: #0066cc; --dir-green: #1a7f37;
-  --dir-amber: #9a6700; --dir-red: #cf222e;
-}
-@media (prefers-color-scheme: dark) {
-  .dmp-directory {
-    --dir-fg: #e6edf3; --dir-muted: #8b949e; --dir-card: #161b22;
-    --dir-border: #30363d; --dir-accent: #58a6ff; --dir-green: #3fb950;
-    --dir-amber: #d29922; --dir-red: #f85149;
-  }
-}
-.dmp-directory { font: 14px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif; color: var(--dir-fg); }
 .dmp-directory h2 { margin: 1.6em 0 0.4em; font-size: 1.15em; }
-.dmp-directory h2 small { font-weight: normal; color: var(--dir-muted); margin-left: 0.5em; }
-.dmp-directory small { color: var(--dir-muted); }
-.dmp-directory a { color: var(--dir-accent); text-decoration: none; }
-.dmp-directory a:hover { text-decoration: underline; }
-.dmp-directory code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.9em; background: var(--dir-card); padding: 1px 4px;
-  border-radius: 3px; border: 1px solid var(--dir-border);
-}
-.dmp-directory .cards {
+.dmp-directory h2 small { font-weight: normal; opacity: 0.75; margin-left: 0.5em; }
+.dmp-directory small { opacity: 0.75; }
+.dmp-directory .dir-cards {
   display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 0.8em;
 }
-.dmp-directory .card {
-  background: var(--dir-card); border: 1px solid var(--dir-border);
+.dmp-directory .dir-card {
+  border: 1px solid currentColor; border-color: rgba(127,127,127,0.3);
   border-radius: 6px; padding: 0.9em 1em;
 }
-.dmp-directory .card h3 { margin: 0 0 0.4em; font-size: 1em; }
-.dmp-directory .card .row { display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }
-.dmp-directory .card .label { color: var(--dir-muted); flex-shrink: 0; }
-.dmp-directory .card .val { text-align: right; word-break: break-all; }
-.dmp-directory .card .pill { font-size: 0.8em; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--dir-border); }
-.dmp-directory .pill.fresh { color: var(--dir-green); border-color: currentColor; }
-.dmp-directory .pill.stale { color: var(--dir-amber); border-color: currentColor; }
-.dmp-directory .pill.expired { color: var(--dir-red); border-color: currentColor; }
+.dmp-directory .dir-card h3 { margin: 0 0 0.4em; font-size: 1em; }
+.dmp-directory .dir-row { display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }
+.dmp-directory .dir-row-label { opacity: 0.7; flex-shrink: 0; font-weight: normal; }
+.dmp-directory .dir-row-val { text-align: right; word-break: break-all; }
+.dmp-directory .dir-pill {
+  font-size: 0.8em; padding: 1px 8px; border-radius: 10px;
+  border: 1px solid currentColor; display: inline-block;
+}
+.dmp-directory .dir-pill.fresh { color: #3fb950; }
+.dmp-directory .dir-pill.stale { color: #d29922; }
+.dmp-directory .dir-pill.expired { color: #f85149; }
 .dmp-directory table {
   border-collapse: collapse; width: 100%; margin-top: 0.6em;
   font-size: 0.92em;
 }
 .dmp-directory th, .dmp-directory td {
-  border: 1px solid var(--dir-border); padding: 0.4em 0.7em;
-  text-align: left;
+  border: 1px solid rgba(127,127,127,0.3);
+  padding: 0.4em 0.7em; text-align: left;
 }
-.dmp-directory th { background: var(--dir-card); font-weight: 600; }
-.dmp-directory td.ok { color: var(--dir-green); }
-.dmp-directory td.fail { color: var(--dir-red); }
-.dmp-directory .svg-wrap {
-  background: var(--dir-card); border: 1px solid var(--dir-border);
+.dmp-directory th { font-weight: 600; }
+.dmp-directory td.dir-ok { color: #3fb950; }
+.dmp-directory td.dir-fail { color: #f85149; }
+.dmp-directory .dir-svg-wrap {
+  border: 1px solid rgba(127,127,127,0.3);
   border-radius: 6px; padding: 1em; margin-top: 0.4em;
   text-align: center; overflow-x: auto;
 }
-.dmp-directory svg.topology text { fill: var(--dir-fg); font: 11px ui-monospace, monospace; }
-.dmp-directory svg.topology circle.node { fill: var(--dir-card); stroke: var(--dir-accent); stroke-width: 2; }
-.dmp-directory svg.topology line { stroke: var(--dir-accent); stroke-width: 1.4; opacity: 0.65; }
-.dmp-directory svg.topology .label { font: 11px system-ui, sans-serif; fill: var(--dir-fg); }
-.dmp-directory svg.topology .arrow { fill: var(--dir-accent); }
-.dmp-directory .legend { font-size: 0.85em; color: var(--dir-muted); margin-top: 0.5em; }
-.dmp-directory .section-note { font-size: 0.88em; color: var(--dir-muted); margin-top: 0.3em; }
+.dmp-directory svg.dir-topology text { fill: currentColor; font: 11px ui-monospace, monospace; }
+.dmp-directory svg.dir-topology circle.dir-node { fill: transparent; stroke: currentColor; stroke-width: 2; opacity: 0.8; }
+.dmp-directory svg.dir-topology line { stroke: currentColor; stroke-width: 1.4; opacity: 0.55; }
+.dmp-directory svg.dir-topology .dir-svg-label { font: 11px system-ui, sans-serif; fill: currentColor; }
+.dmp-directory svg.dir-topology .dir-arrow { fill: currentColor; opacity: 0.7; }
+.dmp-directory .dir-section-note { font-size: 0.88em; opacity: 0.75; margin-top: 0.3em; }
 </style>
 
 <div class="dmp-directory">
 
 <p>
-  <small>Generated 2026-05-01 21:36:46 UTC · 3 known nodes ·
+  <small>Generated 2026-05-01 21:51:17 UTC · 3 known nodes ·
   <a href="feed.json">feed.json</a> carries the raw signed wires
   for independent re-verification.</small>
 </p>
 
 <h2>Known nodes <small>· geo + hosting</small></h2>
-<div class="cards">
-<div class="card">
+<div class="dir-cards">
+<div class="dir-card">
 <h3><a href="https://dnsmesh.de">https://dnsmesh.de</a></h3>
-<div class="row"><span class="label">Status</span><span class="val"><span class="pill fresh">1m ago</span></span></div>
-<div class="row"><span class="label">Version</span><span class="val">0.6.6</span></div>
-<div class="row"><span class="label">Operator key</span><span class="val"><code>fbe50814…cdd9</code></span></div>
-<div class="row"><span class="label">Hosting</span><span class="val">Hetzner <small>(AS24940 Hetzner Online GmbH)</small></span></div>
-<div class="row"><span class="label">Region</span><span class="val">Nuremberg, Bavaria, Germany</span></div>
-<div class="row"><span class="label">IP</span><span class="val"><code>178.104.241.208</code></span></div>
-<div class="row"><span class="label">Heard via</span><span class="val">dmp.dnsmesh.de</span></div>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">45s ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
+<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>fbe50814…cdd9</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">Hetzner <small>(AS24940 Hetzner Online GmbH)</small></span></div>
+<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Nuremberg, Bavaria, Germany</span></div>
+<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>178.104.241.208</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.de</span></div>
 </div>
-<div class="card">
+<div class="dir-card">
 <h3><a href="https://dnsmesh.pro">https://dnsmesh.pro</a></h3>
-<div class="row"><span class="label">Status</span><span class="val"><span class="pill fresh">1m ago</span></span></div>
-<div class="row"><span class="label">Version</span><span class="val">0.6.6</span></div>
-<div class="row"><span class="label">Operator key</span><span class="val"><code>55dd5085…bfef</code></span></div>
-<div class="row"><span class="label">Hosting</span><span class="val">OPENCLOUD SpA <small>(AS52368 ZAM LTDA.)</small></span></div>
-<div class="row"><span class="label">Region</span><span class="val">Curicó, Maule Region, Chile</span></div>
-<div class="row"><span class="label">IP</span><span class="val"><code>45.7.229.112</code></span></div>
-<div class="row"><span class="label">Heard via</span><span class="val">dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">50s ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
+<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>55dd5085…bfef</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">OPENCLOUD SpA <small>(AS52368 ZAM LTDA.)</small></span></div>
+<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Curicó, Maule Region, Chile</span></div>
+<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>45.7.229.112</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
 </div>
-<div class="card">
+<div class="dir-card">
 <h3><a href="https://dnsmesh.io">https://dnsmesh.io</a></h3>
-<div class="row"><span class="label">Status</span><span class="val"><span class="pill fresh">1m ago</span></span></div>
-<div class="row"><span class="label">Version</span><span class="val">0.6.6</span></div>
-<div class="row"><span class="label">Operator key</span><span class="val"><code>c0e5385e…32c2</code></span></div>
-<div class="row"><span class="label">Hosting</span><span class="val">DigitalOcean, LLC <small>(AS14061 DigitalOcean, LLC)</small></span></div>
-<div class="row"><span class="label">Region</span><span class="val">Santa Clara, California, United States</span></div>
-<div class="row"><span class="label">IP</span><span class="val"><code>24.199.107.165</code></span></div>
-<div class="row"><span class="label">Heard via</span><span class="val">dmp.dnsmesh.io, dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">1m ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
+<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>c0e5385e…32c2</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">DigitalOcean, LLC <small>(AS14061 DigitalOcean, LLC)</small></span></div>
+<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Santa Clara, California, United States</span></div>
+<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>24.199.107.165</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.io, dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
 </div>
 </div>
-<p class="section-note">
+<p class="dir-section-note">
   Geo and ASN data via ip-api.com lookup at build time. Each node is
   the same self-signed <code>HeartbeatRecord</code> wire that lives at
   <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
@@ -119,10 +101,10 @@ permalink: /directory/
 </p>
 
 <h2>Federation topology <small>· heartbeat-discovery, not message traffic</small></h2>
-<div class="svg-wrap">
-<svg class="topology" width="720" height="220" viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg"><defs><marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" class="arrow"/></marker></defs><path d="M 360 135 Q 495 140 630 85" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><path d="M 90 85 Q 225 140 360 135" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><path d="M 90 85 Q 360 115 630 85" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><circle class="node" cx="90" cy="85" r="22"/><text class="label" x="90" y="89" text-anchor="middle" font-size="11">DE</text><text class="label" x="90" y="127" text-anchor="middle" font-size="11">dnsmesh.de</text><text class="label" x="90" y="141" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text><circle class="node" cx="360" cy="135" r="22"/><text class="label" x="360" y="139" text-anchor="middle" font-size="11">CL</text><text class="label" x="360" y="177" text-anchor="middle" font-size="11">dnsmesh.pro</text><text class="label" x="360" y="191" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text><circle class="node" cx="630" cy="85" r="22"/><text class="label" x="630" y="89" text-anchor="middle" font-size="11">US</text><text class="label" x="630" y="127" text-anchor="middle" font-size="11">dnsmesh.io</text><text class="label" x="630" y="141" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text></svg>
+<div class="dir-svg-wrap">
+<svg class="dir-topology" width="720" height="220" viewBox="0 0 720 220" xmlns="http://www.w3.org/2000/svg"><defs><marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" class="dir-arrow"/></marker></defs><path d="M 360 135 Q 495 140 630 85" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><path d="M 90 85 Q 225 140 360 135" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><path d="M 90 85 Q 360 115 630 85" fill="none" stroke="currentColor" stroke-width="1.4" opacity="0.55" marker-end="url(#arrowhead)"/><circle class="dir-node" cx="90" cy="85" r="22"/><text class="dir-svg-label" x="90" y="89" text-anchor="middle" font-size="11">DE</text><text class="dir-svg-label" x="90" y="127" text-anchor="middle" font-size="11">dnsmesh.de</text><text class="dir-svg-label" x="90" y="141" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text><circle class="dir-node" cx="360" cy="135" r="22"/><text class="dir-svg-label" x="360" y="139" text-anchor="middle" font-size="11">CL</text><text class="dir-svg-label" x="360" y="177" text-anchor="middle" font-size="11">dnsmesh.pro</text><text class="dir-svg-label" x="360" y="191" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text><circle class="dir-node" cx="630" cy="85" r="22"/><text class="dir-svg-label" x="630" y="89" text-anchor="middle" font-size="11">US</text><text class="dir-svg-label" x="630" y="127" text-anchor="middle" font-size="11">dnsmesh.io</text><text class="dir-svg-label" x="630" y="141" text-anchor="middle" font-size="10" opacity="0.7">0.6.6</text></svg>
 </div>
-<p class="section-note">
+<p class="dir-section-note">
   An arrow from A → B means A's seen-graph
   (<code>_dnsmesh-seen.&lt;A-zone&gt;</code>) carries a verified
   heartbeat from B. This is the federation discovery view —
@@ -131,8 +113,8 @@ permalink: /directory/
 </p>
 
 <h2>Public-resolver reachability <small>· can major resolvers find these nodes?</small></h2>
-<table><thead><tr><th>Resolver</th><th>dmp.dnsmesh.de</th><th>dmp.dnsmesh.io</th><th>dmp.dnsmesh.pro</th></tr></thead><tbody><tr><td><strong>Cloudflare</strong> <small><code>1.1.1.1</code></small></td><td class="ok">✓ <small>334 ms</small></td><td class="ok">✓ <small>9 ms</small></td><td class="ok">✓ <small>228 ms</small></td></tr><tr><td><strong>Google</strong> <small><code>8.8.8.8</code></small></td><td class="ok">✓ <small>206 ms</small></td><td class="ok">✓ <small>45 ms</small></td><td class="ok">✓ <small>218 ms</small></td></tr><tr><td><strong>Quad9</strong> <small><code>9.9.9.9</code></small></td><td class="ok">✓ <small>440 ms</small></td><td class="ok">✓ <small>95 ms</small></td><td class="ok">✓ <small>513 ms</small></td></tr><tr><td><strong>OpenDNS</strong> <small><code>208.67.222.222</code></small></td><td class="ok">✓ <small>397 ms</small></td><td class="ok">✓ <small>101 ms</small></td><td class="ok">✓ <small>352 ms</small></td></tr><tr><td><strong>Comodo</strong> <small><code>8.26.56.26</code></small></td><td class="ok">✓ <small>451 ms</small></td><td class="ok">✓ <small>197 ms</small></td><td class="ok">✓ <small>496 ms</small></td></tr><tr><td><strong>Level3</strong> <small><code>4.2.2.1</code></small></td><td class="ok">✓ <small>343 ms</small></td><td class="fail">✗ <small>empty answer</small></td><td class="ok">✓ <small>334 ms</small></td></tr><tr><td><strong>Hurricane Electric</strong> <small><code>74.82.42.42</code></small></td><td class="ok">✓ <small>183 ms</small></td><td class="ok">✓ <small>77 ms</small></td><td class="ok">✓ <small>340 ms</small></td></tr><tr><td><strong>Verisign</strong> <small><code>64.6.64.6</code></small></td><td class="ok">✓ <small>365 ms</small></td><td class="ok">✓ <small>46 ms</small></td><td class="ok">✓ <small>377 ms</small></td></tr><tr><td><strong>AdGuard</strong> <small><code>94.140.14.14</code></small></td><td class="ok">✓ <small>1033 ms</small></td><td class="ok">✓ <small>310 ms</small></td><td class="ok">✓ <small>474 ms</small></td></tr><tr><td><strong>Yandex</strong> <small><code>77.88.8.8</code></small></td><td class="ok">✓ <small>479 ms</small></td><td class="ok">✓ <small>721 ms</small></td><td class="ok">✓ <small>804 ms</small></td></tr><tr><td><strong>Alibaba</strong> <small><code>223.5.5.5</code></small></td><td class="ok">✓ <small>781 ms</small></td><td class="ok">✓ <small>185 ms</small></td><td class="ok">✓ <small>584 ms</small></td></tr><tr><td><strong>DNSPod</strong> <small><code>119.29.29.29</code></small></td><td class="ok">✓ <small>558 ms</small></td><td class="ok">✓ <small>108 ms</small></td><td class="ok">✓ <small>535 ms</small></td></tr><tr><td><strong>KT Korea</strong> <small><code>168.126.63.1</code></small></td><td class="ok">✓ <small>537 ms</small></td><td class="ok">✓ <small>485 ms</small></td><td class="ok">✓ <small>760 ms</small></td></tr></tbody></table>
-<p class="section-note">
+<table><thead><tr><th>Resolver</th><th>dmp.dnsmesh.de</th><th>dmp.dnsmesh.io</th><th>dmp.dnsmesh.pro</th></tr></thead><tbody><tr><td><strong>Cloudflare</strong> <small><code>1.1.1.1</code></small></td><td class="dir-ok">✓ <small>336 ms</small></td><td class="dir-ok">✓ <small>68 ms</small></td><td class="dir-ok">✓ <small>178 ms</small></td></tr><tr><td><strong>Google</strong> <small><code>8.8.8.8</code></small></td><td class="dir-ok">✓ <small>157 ms</small></td><td class="dir-ok">✓ <small>104 ms</small></td><td class="dir-ok">✓ <small>343 ms</small></td></tr><tr><td><strong>Quad9</strong> <small><code>9.9.9.9</code></small></td><td class="dir-ok">✓ <small>364 ms</small></td><td class="dir-ok">✓ <small>78 ms</small></td><td class="dir-ok">✓ <small>215 ms</small></td></tr><tr><td><strong>OpenDNS</strong> <small><code>208.67.222.222</code></small></td><td class="dir-ok">✓ <small>349 ms</small></td><td class="dir-ok">✓ <small>81 ms</small></td><td class="dir-ok">✓ <small>332 ms</small></td></tr><tr><td><strong>Comodo</strong> <small><code>8.26.56.26</code></small></td><td class="dir-ok">✓ <small>354 ms</small></td><td class="dir-ok">✓ <small>55 ms</small></td><td class="dir-ok">✓ <small>350 ms</small></td></tr><tr><td><strong>Level3</strong> <small><code>4.2.2.1</code></small></td><td class="dir-ok">✓ <small>349 ms</small></td><td class="dir-fail">✗ <small>empty answer</small></td><td class="dir-ok">✓ <small>330 ms</small></td></tr><tr><td><strong>Hurricane Electric</strong> <small><code>74.82.42.42</code></small></td><td class="dir-ok">✓ <small>153 ms</small></td><td class="dir-ok">✓ <small>35 ms</small></td><td class="dir-ok">✓ <small>210 ms</small></td></tr><tr><td><strong>Verisign</strong> <small><code>64.6.64.6</code></small></td><td class="dir-ok">✓ <small>481 ms</small></td><td class="dir-ok">✓ <small>42 ms</small></td><td class="dir-ok">✓ <small>365 ms</small></td></tr><tr><td><strong>AdGuard</strong> <small><code>94.140.14.14</code></small></td><td class="dir-ok">✓ <small>666 ms</small></td><td class="dir-ok">✓ <small>266 ms</small></td><td class="dir-ok">✓ <small>808 ms</small></td></tr><tr><td><strong>Yandex</strong> <small><code>77.88.8.8</code></small></td><td class="dir-ok">✓ <small>442 ms</small></td><td class="dir-ok">✓ <small>677 ms</small></td><td class="dir-ok">✓ <small>856 ms</small></td></tr><tr><td><strong>Alibaba</strong> <small><code>223.5.5.5</code></small></td><td class="dir-ok">✓ <small>189 ms</small></td><td class="dir-ok">✓ <small>184 ms</small></td><td class="dir-ok">✓ <small>183 ms</small></td></tr><tr><td><strong>DNSPod</strong> <small><code>119.29.29.29</code></small></td><td class="dir-ok">✓ <small>574 ms</small></td><td class="dir-ok">✓ <small>111 ms</small></td><td class="dir-ok">✓ <small>569 ms</small></td></tr><tr><td><strong>KT Korea</strong> <small><code>168.126.63.1</code></small></td><td class="dir-ok">✓ <small>535 ms</small></td><td class="dir-ok">✓ <small>484 ms</small></td><td class="dir-ok">✓ <small>757 ms</small></td></tr></tbody></table>
+<p class="dir-section-note">
   Tested at build time from a GitHub Actions runner: each row is a
   curated public DNS resolver, each column is a node. A green cell
   means the resolver answered <code>_dnsmesh-heartbeat.&lt;zone&gt;</code>

--- a/examples/directory_aggregator.py
+++ b/examples/directory_aggregator.py
@@ -502,9 +502,14 @@ def emit_json(result: AggregateResult, out: Path, *, now: int) -> None:
 # `permalink` keeps the URL at /directory/ regardless of how the source file
 # is named so existing links don't break.
 #
-# All page-specific styles are scoped to ``.dmp-directory`` so they don't
-# fight with Just-the-Docs's body / typography rules. Content lives inside
-# a single wrapper div for the same reason.
+# All HTML class names are prefixed ``dir-`` to avoid colliding with
+# Just-the-Docs's own classes — most painfully ``.label``, which the theme
+# uses for its blue pill badges and which previously turned every
+# ``Status / Version / Operator key / …`` row-label into a glaring blue
+# button. Colors inherit from the parent theme via ``inherit`` /
+# ``currentColor`` where possible so the directory page follows whatever
+# color scheme the docs site is configured for (currently ``dark`` per
+# ``docs/_config.yml``).
 _HTML_TEMPLATE = """---
 title: Directory
 layout: default
@@ -512,68 +517,50 @@ nav_order: 8
 permalink: /directory/
 ---
 <style>
-.dmp-directory {{
-  --dir-fg: #1a1a1a; --dir-muted: #666; --dir-card: #fff;
-  --dir-border: #ddd; --dir-accent: #0066cc; --dir-green: #1a7f37;
-  --dir-amber: #9a6700; --dir-red: #cf222e;
-}}
-@media (prefers-color-scheme: dark) {{
-  .dmp-directory {{
-    --dir-fg: #e6edf3; --dir-muted: #8b949e; --dir-card: #161b22;
-    --dir-border: #30363d; --dir-accent: #58a6ff; --dir-green: #3fb950;
-    --dir-amber: #d29922; --dir-red: #f85149;
-  }}
-}}
-.dmp-directory {{ font: 14px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif; color: var(--dir-fg); }}
 .dmp-directory h2 {{ margin: 1.6em 0 0.4em; font-size: 1.15em; }}
-.dmp-directory h2 small {{ font-weight: normal; color: var(--dir-muted); margin-left: 0.5em; }}
-.dmp-directory small {{ color: var(--dir-muted); }}
-.dmp-directory a {{ color: var(--dir-accent); text-decoration: none; }}
-.dmp-directory a:hover {{ text-decoration: underline; }}
-.dmp-directory code {{
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.9em; background: var(--dir-card); padding: 1px 4px;
-  border-radius: 3px; border: 1px solid var(--dir-border);
-}}
-.dmp-directory .cards {{
+.dmp-directory h2 small {{ font-weight: normal; opacity: 0.75; margin-left: 0.5em; }}
+.dmp-directory small {{ opacity: 0.75; }}
+.dmp-directory .dir-cards {{
   display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 0.8em;
 }}
-.dmp-directory .card {{
-  background: var(--dir-card); border: 1px solid var(--dir-border);
+.dmp-directory .dir-card {{
+  border: 1px solid currentColor; border-color: rgba(127,127,127,0.3);
   border-radius: 6px; padding: 0.9em 1em;
 }}
-.dmp-directory .card h3 {{ margin: 0 0 0.4em; font-size: 1em; }}
-.dmp-directory .card .row {{ display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }}
-.dmp-directory .card .label {{ color: var(--dir-muted); flex-shrink: 0; }}
-.dmp-directory .card .val {{ text-align: right; word-break: break-all; }}
-.dmp-directory .card .pill {{ font-size: 0.8em; padding: 1px 7px; border-radius: 10px; border: 1px solid var(--dir-border); }}
-.dmp-directory .pill.fresh {{ color: var(--dir-green); border-color: currentColor; }}
-.dmp-directory .pill.stale {{ color: var(--dir-amber); border-color: currentColor; }}
-.dmp-directory .pill.expired {{ color: var(--dir-red); border-color: currentColor; }}
+.dmp-directory .dir-card h3 {{ margin: 0 0 0.4em; font-size: 1em; }}
+.dmp-directory .dir-row {{ display: flex; justify-content: space-between; gap: 1em; margin: 0.18em 0; font-size: 0.92em; }}
+.dmp-directory .dir-row-label {{ opacity: 0.7; flex-shrink: 0; font-weight: normal; }}
+.dmp-directory .dir-row-val {{ text-align: right; word-break: break-all; }}
+.dmp-directory .dir-pill {{
+  font-size: 0.8em; padding: 1px 8px; border-radius: 10px;
+  border: 1px solid currentColor; display: inline-block;
+}}
+.dmp-directory .dir-pill.fresh {{ color: #3fb950; }}
+.dmp-directory .dir-pill.stale {{ color: #d29922; }}
+.dmp-directory .dir-pill.expired {{ color: #f85149; }}
 .dmp-directory table {{
   border-collapse: collapse; width: 100%; margin-top: 0.6em;
   font-size: 0.92em;
 }}
 .dmp-directory th, .dmp-directory td {{
-  border: 1px solid var(--dir-border); padding: 0.4em 0.7em;
-  text-align: left;
+  border: 1px solid rgba(127,127,127,0.3);
+  padding: 0.4em 0.7em; text-align: left;
 }}
-.dmp-directory th {{ background: var(--dir-card); font-weight: 600; }}
-.dmp-directory td.ok {{ color: var(--dir-green); }}
-.dmp-directory td.fail {{ color: var(--dir-red); }}
-.dmp-directory .svg-wrap {{
-  background: var(--dir-card); border: 1px solid var(--dir-border);
+.dmp-directory th {{ font-weight: 600; }}
+.dmp-directory td.dir-ok {{ color: #3fb950; }}
+.dmp-directory td.dir-fail {{ color: #f85149; }}
+.dmp-directory .dir-svg-wrap {{
+  border: 1px solid rgba(127,127,127,0.3);
   border-radius: 6px; padding: 1em; margin-top: 0.4em;
   text-align: center; overflow-x: auto;
 }}
-.dmp-directory svg.topology text {{ fill: var(--dir-fg); font: 11px ui-monospace, monospace; }}
-.dmp-directory svg.topology circle.node {{ fill: var(--dir-card); stroke: var(--dir-accent); stroke-width: 2; }}
-.dmp-directory svg.topology line {{ stroke: var(--dir-accent); stroke-width: 1.4; opacity: 0.65; }}
-.dmp-directory svg.topology .label {{ font: 11px system-ui, sans-serif; fill: var(--dir-fg); }}
-.dmp-directory svg.topology .arrow {{ fill: var(--dir-accent); }}
-.dmp-directory .legend {{ font-size: 0.85em; color: var(--dir-muted); margin-top: 0.5em; }}
-.dmp-directory .section-note {{ font-size: 0.88em; color: var(--dir-muted); margin-top: 0.3em; }}
+.dmp-directory svg.dir-topology text {{ fill: currentColor; font: 11px ui-monospace, monospace; }}
+.dmp-directory svg.dir-topology circle.dir-node {{ fill: transparent; stroke: currentColor; stroke-width: 2; opacity: 0.8; }}
+.dmp-directory svg.dir-topology line {{ stroke: currentColor; stroke-width: 1.4; opacity: 0.55; }}
+.dmp-directory svg.dir-topology .dir-svg-label {{ font: 11px system-ui, sans-serif; fill: currentColor; }}
+.dmp-directory svg.dir-topology .dir-arrow {{ fill: currentColor; opacity: 0.7; }}
+.dmp-directory .dir-section-note {{ font-size: 0.88em; opacity: 0.75; margin-top: 0.3em; }}
 </style>
 
 <div class="dmp-directory">
@@ -585,10 +572,10 @@ permalink: /directory/
 </p>
 
 <h2>Known nodes <small>· geo + hosting</small></h2>
-<div class="cards">
+<div class="dir-cards">
 {node_cards}
 </div>
-<p class="section-note">
+<p class="dir-section-note">
   Geo and ASN data via ip-api.com lookup at build time. Each node is
   the same self-signed <code>HeartbeatRecord</code> wire that lives at
   <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
@@ -597,10 +584,10 @@ permalink: /directory/
 </p>
 
 <h2>Federation topology <small>· heartbeat-discovery, not message traffic</small></h2>
-<div class="svg-wrap">
+<div class="dir-svg-wrap">
 {topology_svg}
 </div>
-<p class="section-note">
+<p class="dir-section-note">
   An arrow from A → B means A's seen-graph
   (<code>_dnsmesh-seen.&lt;A-zone&gt;</code>) carries a verified
   heartbeat from B. This is the federation discovery view —
@@ -610,7 +597,7 @@ permalink: /directory/
 
 <h2>Public-resolver reachability <small>· can major resolvers find these nodes?</small></h2>
 {resolver_table}
-<p class="section-note">
+<p class="dir-section-note">
   Tested at build time from a GitHub Actions runner: each row is a
   curated public DNS resolver, each column is a node. A green cell
   means the resolver answered <code>_dnsmesh-heartbeat.&lt;zone&gt;</code>
@@ -657,7 +644,7 @@ def _liveness_pill(age_seconds: int, exp: int, now: int) -> Tuple[str, str]:
 
 def _render_node_cards(nodes: List[AggregatedNode], *, now: int) -> str:
     if not nodes:
-        return '<div class="card"><em>(no nodes seen)</em></div>'
+        return '<div class="dir-card"><em>(no nodes seen)</em></div>'
     out: List[str] = []
     for n in nodes:
         age = now - n.ts
@@ -678,15 +665,15 @@ def _render_node_cards(nodes: List[AggregatedNode], *, now: int) -> str:
             ]
             geo_text = ", ".join(p for p in parts if p)
         endpoint_safe = html_escape(n.endpoint)
-        out.append(f"""<div class="card">
+        out.append(f"""<div class="dir-card">
 <h3><a href="{endpoint_safe}">{endpoint_safe}</a></h3>
-<div class="row"><span class="label">Status</span><span class="val"><span class="pill {cls}">{html_escape(label)}</span></span></div>
-<div class="row"><span class="label">Version</span><span class="val">{html_escape(n.version or '?')}</span></div>
-<div class="row"><span class="label">Operator key</span><span class="val"><code>{html_escape(spk_short)}</code></span></div>
-<div class="row"><span class="label">Hosting</span><span class="val">{host_text or '<em>—</em>'}</span></div>
-<div class="row"><span class="label">Region</span><span class="val">{html_escape(geo_text) or '<em>—</em>'}</span></div>
-<div class="row"><span class="label">IP</span><span class="val"><code>{html_escape((n.host or dict()).get('ip', '') or '—')}</code></span></div>
-<div class="row"><span class="label">Heard via</span><span class="val">{', '.join(html_escape(z) for z in n.last_seen_via) or '—'}</span></div>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill {cls}">{html_escape(label)}</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">{html_escape(n.version or '?')}</span></div>
+<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>{html_escape(spk_short)}</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">{host_text or '<em>—</em>'}</span></div>
+<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">{html_escape(geo_text) or '<em>—</em>'}</span></div>
+<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>{html_escape((n.host or dict()).get('ip', '') or '—')}</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">{', '.join(html_escape(z) for z in n.last_seen_via) or '—'}</span></div>
 </div>""")
     return "\n".join(out)
 
@@ -713,12 +700,12 @@ def _render_topology_svg(
     # don't collide.
     coords: Dict[str, Tuple[int, int]] = {}
     parts: List[str] = [
-        f'<svg class="topology" width="{width}" height="{height}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">'
+        f'<svg class="dir-topology" width="{width}" height="{height}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">'
     ]
     parts.append(
         '<defs><marker id="arrowhead" viewBox="0 0 10 10" refX="9" refY="5" '
         'markerWidth="7" markerHeight="7" orient="auto-start-reverse">'
-        '<path d="M 0 0 L 10 5 L 0 10 z" class="arrow"/></marker></defs>'
+        '<path d="M 0 0 L 10 5 L 0 10 z" class="dir-arrow"/></marker></defs>'
     )
     for i, n in enumerate(nodes):
         x = int(margin_x + i * spacing) if len(nodes) > 1 else width // 2
@@ -745,12 +732,12 @@ def _render_topology_svg(
         host = urlparse(n.endpoint).hostname or n.endpoint
         country = (n.geo or {}).get("country_code") or ""
         parts.append(
-            f'<circle class="node" cx="{x}" cy="{y}" r="22"/>'
-            f'<text class="label" x="{x}" y="{y + 4}" text-anchor="middle" '
+            f'<circle class="dir-node" cx="{x}" cy="{y}" r="22"/>'
+            f'<text class="dir-svg-label" x="{x}" y="{y + 4}" text-anchor="middle" '
             f'font-size="11">{html_escape((country or "?"))}</text>'
-            f'<text class="label" x="{x}" y="{y + 42}" text-anchor="middle" '
+            f'<text class="dir-svg-label" x="{x}" y="{y + 42}" text-anchor="middle" '
             f'font-size="11">{html_escape(host)}</text>'
-            f'<text class="label" x="{x}" y="{y + 56}" text-anchor="middle" '
+            f'<text class="dir-svg-label" x="{x}" y="{y + 56}" text-anchor="middle" '
             f'font-size="10" opacity="0.7">{html_escape(n.version or "")}</text>'
         )
     parts.append("</svg>")
@@ -791,10 +778,12 @@ def _render_resolver_table(
                 continue
             if c.ok:
                 lat = f"{c.latency_ms} ms" if c.latency_ms is not None else ""
-                parts.append(f'<td class="ok">✓ <small>{html_escape(lat)}</small></td>')
+                parts.append(
+                    f'<td class="dir-ok">✓ <small>{html_escape(lat)}</small></td>'
+                )
             else:
                 parts.append(
-                    f'<td class="fail">✗ <small>{html_escape(c.detail)}</small></td>'
+                    f'<td class="dir-fail">✗ <small>{html_escape(c.detail)}</small></td>'
                 )
         parts.append("</tr>")
     parts.append("</tbody></table>")


### PR DESCRIPTION
## Summary

The Jekyll-integrated directory page (PR #29) was rendering with every row-label as a glaring blue pill badge. CSS class collision with Just-the-Docs's own \`.label\` (their pill-badge component). Defensive fix: rename every page-emitted class to a \`dir-\` prefix so the namespace is clean.


## Before / after

Before — `<span class="label">Status</span>` rendered as a Just-the-Docs blue badge component.

After — `<span class="dir-row-label">Status</span>` rendered as muted left-aligned label text, the way the original standalone page looked.

## Class renames

| Was | Now |
|---|---|
| `.cards` | `.dir-cards` |
| `.card` | `.dir-card` |
| `.row` | `.dir-row` |
| `.label` | `.dir-row-label` |
| `.val` | `.dir-row-val` |
| `.pill` | `.dir-pill` (`.fresh / .stale / .expired` stay as modifiers) |
| `.ok / .fail` | `.dir-ok / .dir-fail` |
| `.svg-wrap` | `.dir-svg-wrap` |
| `svg.topology` | `svg.dir-topology` |
| `circle.node` | `circle.dir-node` |
| SVG `.label` | `.dir-svg-label` |
| `.arrow` | `.dir-arrow` |
| `.section-note` | `.dir-section-note` |

## Visual cleanups while I was in there

- Dropped the dark-mode `@media` query + custom-property set. Just-the-Docs already has `color_scheme: dark` globally; my hardcoded variables fought that. Replaced with `currentColor` / `inherit` / `rgba(127,127,127,0.3)` neutral borders so the page follows whatever color scheme the parent theme is in. Pill + matrix accent colors stay as fixed hex (intentional — green/red semantic colors should look the same regardless of mode).
- Dropped the `.dmp-directory code` override. Just-the-Docs renders `<code>` pleasantly out of the box.
- Dropped the duplicate `<h1>DMP node directory</h1>` from the body. Just-the-Docs renders the front-matter `title` as the page heading automatically — we were getting it twice.

## Files

- `examples/directory_aggregator.py` — `_HTML_TEMPLATE`, `_render_node_cards`, `_render_topology_svg`, `_render_resolver_table` updated.
- `docs/directory/index.html` — regenerated from the live aggregator (3 nodes, 3 edges, 39/39 green resolvers).
- `docs/directory/feed.json` — refreshed alongside.

## Test plan

- [x] `python examples/directory_aggregator.py …` produces `class="dir-*"` everywhere; no plain `class="label"` / `class="row"` / etc. left
- [x] `black --check examples/directory_aggregator.py` clean
- [ ] After merge: pages.yml runs, https://dnsmeshprotocol.org/directory/ renders with cleanly muted row-labels (not blue badge spam) and reads as a continuation of the docs theme.