### PR TITLE
fix(directory): trim Hosting to just the org name

### DIFF
--- a/docs/directory/feed.json
+++ b/docs/directory/feed.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
-  "generated_at": 1777672277,
+  "generated_at": 1777672650,
   "node_count": 3,
   "nodes": [
     {
       "operator_spk_hex": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "endpoint": "https://dnsmesh.de",
       "version": "0.6.6",
-      "ts": 1777672232,
-      "exp": 1777758632,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmRl++UIFDC977dfAreU7bazW7NCi9vZnlCBH+kffTaSzdkFMC42LjYAAQ5kbXAuZG5zbWVzaC5kZQAAAABp9SAoAAAAAGn2cahC+3bho0jbQz9d2WLb0kIxVPBMwrcGgUqqw5aVaHxSw/9SpfeJwh2lXUsVeQNRl8r2aya1ABHVhIm6pTR6jugL",
+      "ts": 1777672533,
+      "exp": 1777758933,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmRl++UIFDC977dfAreU7bazW7NCi9vZnlCBH+kffTaSzdkFMC42LjYAAQ5kbXAuZG5zbWVzaC5kZQAAAABp9SFVAAAAAGn2ctWEdfkNKdc+5f6u0tsfs13MFY0sWuuDC9+rHiB54K9dtmRVISZNswFA6fkdgczOclrtzz5fgvIaCsm2rFGSXosB",
       "last_seen_via": [
         "dmp.dnsmesh.de"
       ],
@@ -36,9 +36,9 @@
       "operator_spk_hex": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
       "endpoint": "https://dnsmesh.pro",
       "version": "0.6.6",
-      "ts": 1777672227,
-      "exp": 1777758627,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwATaHR0cHM6Ly9kbnNtZXNoLnByb1XdUIW7Ftv1ra8k1ToTu9UMj5+T4CaxlAWSNaP9gr/vBTAuNi42AAEPZG1wLmRuc21lc2gucHJvAAAAAGn1ICMAAAAAafZxo+BTZEBhhn6+cxYiorGbzRouxpxolsgR0m6I7r6AssKz/h4gBV+w649W2wAxvqUHWzgKhXJ4K62qrZJ0Jp3QRwE=",
+      "ts": 1777672527,
+      "exp": 1777758927,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwATaHR0cHM6Ly9kbnNtZXNoLnByb1XdUIW7Ftv1ra8k1ToTu9UMj5+T4CaxlAWSNaP9gr/vBTAuNi42AAEPZG1wLmRuc21lc2gucHJvAAAAAGn1IU8AAAAAafZyzyFPtFM8s0OREDZZVXkChSaCn9ZiUBlaLMX2vDkIHNfvKBFpTL7UpjLAUPvaNf3syujZoZSXOLny5uu+wmDSZQA=",
       "last_seen_via": [
         "dmp.dnsmesh.pro",
         "dmp.dnsmesh.de"
@@ -66,9 +66,9 @@
       "operator_spk_hex": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
       "endpoint": "https://dnsmesh.io",
       "version": "0.6.6",
-      "ts": 1777672215,
-      "exp": 1777758615,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmlvwOU4XrU8HNtixcWnJvGlUkgPw0XGAMjkXy7wR/ogMsIFMC42LjYAAQ5kbXAuZG5zbWVzaC5pbwAAAABp9SAXAAAAAGn2cZcSD58hBWXil6yFGN/FKfr5yWxpyGdvXo6QWPJ3FoLTQ1rY0mdl9u2g/PW7d9GrjVrT86Mbh6lZoPPDF8Qd6PUM",
+      "ts": 1777672516,
+      "exp": 1777758916,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmlvwOU4XrU8HNtixcWnJvGlUkgPw0XGAMjkXy7wR/ogMsIFMC42LjYAAQ5kbXAuZG5zbWVzaC5pbwAAAABp9SFEAAAAAGn2csThdl6F0+l93aGfrIrUqXs//accs0ruDzRZUud+g/RjQ5CMiGKLNNo2a5uHgDJac09GeicScyRLzWNHNMP4naUD",
       "last_seen_via": [
         "dmp.dnsmesh.io",
         "dmp.dnsmesh.pro",
@@ -98,17 +98,17 @@
     {
       "from_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
       "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
-      "last_seen_ts": 1777672215
+      "last_seen_ts": 1777672516
     },
     {
       "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "to_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
-      "last_seen_ts": 1777672227
+      "last_seen_ts": 1777672527
     },
     {
       "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
-      "last_seen_ts": 1777672215
+      "last_seen_ts": 1777672516
     }
   ],
   "resolvers": [
@@ -127,7 +127,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 178,
+      "latency_ms": 225,
       "detail": "ok"
     },
     {
@@ -136,34 +136,34 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 336,
-      "detail": "ok"
-    },
-    {
-      "name": "Google",
-      "addr": "8.8.8.8",
-      "zone": "dmp.dnsmesh.io",
-      "endpoint": "https://dnsmesh.io",
-      "ok": true,
-      "latency_ms": 104,
-      "detail": "ok"
-    },
-    {
-      "name": "Google",
-      "addr": "8.8.8.8",
-      "zone": "dmp.dnsmesh.pro",
-      "endpoint": "https://dnsmesh.pro",
-      "ok": true,
       "latency_ms": 343,
       "detail": "ok"
     },
     {
       "name": "Google",
       "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 35,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 152,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 157,
+      "latency_ms": 318,
       "detail": "ok"
     },
     {
@@ -172,7 +172,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 78,
+      "latency_ms": 79,
       "detail": "ok"
     },
     {
@@ -181,7 +181,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 215,
+      "latency_ms": 220,
       "detail": "ok"
     },
     {
@@ -190,7 +190,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 364,
+      "latency_ms": 357,
       "detail": "ok"
     },
     {
@@ -199,7 +199,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 81,
+      "latency_ms": 181,
       "detail": "ok"
     },
     {
@@ -208,7 +208,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 332,
+      "latency_ms": 370,
       "detail": "ok"
     },
     {
@@ -217,7 +217,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 349,
+      "latency_ms": 266,
       "detail": "ok"
     },
     {
@@ -226,7 +226,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 55,
+      "latency_ms": 161,
       "detail": "ok"
     },
     {
@@ -235,7 +235,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 350,
+      "latency_ms": 348,
       "detail": "ok"
     },
     {
@@ -244,7 +244,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 354,
+      "latency_ms": 337,
       "detail": "ok"
     },
     {
@@ -262,7 +262,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 330,
+      "latency_ms": 332,
       "detail": "ok"
     },
     {
@@ -271,7 +271,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 349,
+      "latency_ms": 345,
       "detail": "ok"
     },
     {
@@ -280,7 +280,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 35,
+      "latency_ms": 33,
       "detail": "ok"
     },
     {
@@ -298,7 +298,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 153,
+      "latency_ms": 161,
       "detail": "ok"
     },
     {
@@ -307,7 +307,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 42,
+      "latency_ms": 54,
       "detail": "ok"
     },
     {
@@ -316,7 +316,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 365,
+      "latency_ms": 361,
       "detail": "ok"
     },
     {
@@ -325,7 +325,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 481,
+      "latency_ms": 542,
       "detail": "ok"
     },
     {
@@ -334,7 +334,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 266,
+      "latency_ms": 113,
       "detail": "ok"
     },
     {
@@ -343,7 +343,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 808,
+      "latency_ms": 690,
       "detail": "ok"
     },
     {
@@ -352,7 +352,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 666,
+      "latency_ms": 658,
       "detail": "ok"
     },
     {
@@ -361,7 +361,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 677,
+      "latency_ms": 799,
       "detail": "ok"
     },
     {
@@ -370,7 +370,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 856,
+      "latency_ms": 805,
       "detail": "ok"
     },
     {
@@ -379,7 +379,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 442,
+      "latency_ms": 439,
       "detail": "ok"
     },
     {
@@ -387,15 +387,6 @@
       "addr": "223.5.5.5",
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
-      "ok": true,
-      "latency_ms": 184,
-      "detail": "ok"
-    },
-    {
-      "name": "Alibaba",
-      "addr": "223.5.5.5",
-      "zone": "dmp.dnsmesh.pro",
-      "endpoint": "https://dnsmesh.pro",
       "ok": true,
       "latency_ms": 183,
       "detail": "ok"
@@ -403,10 +394,19 @@
     {
       "name": "Alibaba",
       "addr": "223.5.5.5",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 184,
+      "detail": "ok"
+    },
+    {
+      "name": "Alibaba",
+      "addr": "223.5.5.5",
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 189,
+      "latency_ms": 566,
       "detail": "ok"
     },
     {
@@ -415,7 +415,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 111,
+      "latency_ms": 110,
       "detail": "ok"
     },
     {
@@ -424,7 +424,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 569,
+      "latency_ms": 565,
       "detail": "ok"
     },
     {
@@ -433,7 +433,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 574,
+      "latency_ms": 563,
       "detail": "ok"
     },
     {
@@ -442,7 +442,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 484,
+      "latency_ms": 570,
       "detail": "ok"
     },
     {
@@ -451,7 +451,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 757,
+      "latency_ms": 660,
       "detail": "ok"
     },
     {
@@ -460,7 +460,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 535,
+      "latency_ms": 541,
       "detail": "ok"
     }
   ]

--- a/docs/directory/index.html
+++ b/docs/directory/index.html
@@ -54,7 +54,7 @@ permalink: /directory/
 <div class="dmp-directory">
 
 <p>
-  <small>Generated 2026-05-01 21:51:17 UTC · 3 known nodes ·
+  <small>Generated 2026-05-01 21:57:30 UTC · 3 known nodes ·
   <a href="feed.json">feed.json</a> carries the raw signed wires
   for independent re-verification.</small>
 </p>
@@ -63,30 +63,30 @@ permalink: /directory/
 <div class="dir-cards">
 <div class="dir-card">
 <h3><a href="https://dnsmesh.de">https://dnsmesh.de</a></h3>
-<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">45s ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">1m ago</span></span></div>
 <div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
 <div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>fbe50814…cdd9</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">Hetzner <small>(AS24940 Hetzner Online GmbH)</small></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">Hetzner</span></div>
 <div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Nuremberg, Bavaria, Germany</span></div>
 <div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>178.104.241.208</code></span></div>
 <div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.de</span></div>
 </div>
 <div class="dir-card">
 <h3><a href="https://dnsmesh.pro">https://dnsmesh.pro</a></h3>
-<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">50s ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">2m ago</span></span></div>
 <div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
 <div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>55dd5085…bfef</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">OPENCLOUD SpA <small>(AS52368 ZAM LTDA.)</small></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">OPENCLOUD SpA</span></div>
 <div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Curicó, Maule Region, Chile</span></div>
 <div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>45.7.229.112</code></span></div>
 <div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
 </div>
 <div class="dir-card">
 <h3><a href="https://dnsmesh.io">https://dnsmesh.io</a></h3>
-<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">1m ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">2m ago</span></span></div>
 <div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
 <div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>c0e5385e…32c2</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">DigitalOcean, LLC <small>(AS14061 DigitalOcean, LLC)</small></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">DigitalOcean, LLC</span></div>
 <div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Santa Clara, California, United States</span></div>
 <div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>24.199.107.165</code></span></div>
 <div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.io, dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
@@ -113,7 +113,7 @@ permalink: /directory/
 </p>
 
 <h2>Public-resolver reachability <small>· can major resolvers find these nodes?</small></h2>
-<table><thead><tr><th>Resolver</th><th>dmp.dnsmesh.de</th><th>dmp.dnsmesh.io</th><th>dmp.dnsmesh.pro</th></tr></thead><tbody><tr><td><strong>Cloudflare</strong> <small><code>1.1.1.1</code></small></td><td class="dir-ok">✓ <small>336 ms</small></td><td class="dir-ok">✓ <small>68 ms</small></td><td class="dir-ok">✓ <small>178 ms</small></td></tr><tr><td><strong>Google</strong> <small><code>8.8.8.8</code></small></td><td class="dir-ok">✓ <small>157 ms</small></td><td class="dir-ok">✓ <small>104 ms</small></td><td class="dir-ok">✓ <small>343 ms</small></td></tr><tr><td><strong>Quad9</strong> <small><code>9.9.9.9</code></small></td><td class="dir-ok">✓ <small>364 ms</small></td><td class="dir-ok">✓ <small>78 ms</small></td><td class="dir-ok">✓ <small>215 ms</small></td></tr><tr><td><strong>OpenDNS</strong> <small><code>208.67.222.222</code></small></td><td class="dir-ok">✓ <small>349 ms</small></td><td class="dir-ok">✓ <small>81 ms</small></td><td class="dir-ok">✓ <small>332 ms</small></td></tr><tr><td><strong>Comodo</strong> <small><code>8.26.56.26</code></small></td><td class="dir-ok">✓ <small>354 ms</small></td><td class="dir-ok">✓ <small>55 ms</small></td><td class="dir-ok">✓ <small>350 ms</small></td></tr><tr><td><strong>Level3</strong> <small><code>4.2.2.1</code></small></td><td class="dir-ok">✓ <small>349 ms</small></td><td class="dir-fail">✗ <small>empty answer</small></td><td class="dir-ok">✓ <small>330 ms</small></td></tr><tr><td><strong>Hurricane Electric</strong> <small><code>74.82.42.42</code></small></td><td class="dir-ok">✓ <small>153 ms</small></td><td class="dir-ok">✓ <small>35 ms</small></td><td class="dir-ok">✓ <small>210 ms</small></td></tr><tr><td><strong>Verisign</strong> <small><code>64.6.64.6</code></small></td><td class="dir-ok">✓ <small>481 ms</small></td><td class="dir-ok">✓ <small>42 ms</small></td><td class="dir-ok">✓ <small>365 ms</small></td></tr><tr><td><strong>AdGuard</strong> <small><code>94.140.14.14</code></small></td><td class="dir-ok">✓ <small>666 ms</small></td><td class="dir-ok">✓ <small>266 ms</small></td><td class="dir-ok">✓ <small>808 ms</small></td></tr><tr><td><strong>Yandex</strong> <small><code>77.88.8.8</code></small></td><td class="dir-ok">✓ <small>442 ms</small></td><td class="dir-ok">✓ <small>677 ms</small></td><td class="dir-ok">✓ <small>856 ms</small></td></tr><tr><td><strong>Alibaba</strong> <small><code>223.5.5.5</code></small></td><td class="dir-ok">✓ <small>189 ms</small></td><td class="dir-ok">✓ <small>184 ms</small></td><td class="dir-ok">✓ <small>183 ms</small></td></tr><tr><td><strong>DNSPod</strong> <small><code>119.29.29.29</code></small></td><td class="dir-ok">✓ <small>574 ms</small></td><td class="dir-ok">✓ <small>111 ms</small></td><td class="dir-ok">✓ <small>569 ms</small></td></tr><tr><td><strong>KT Korea</strong> <small><code>168.126.63.1</code></small></td><td class="dir-ok">✓ <small>535 ms</small></td><td class="dir-ok">✓ <small>484 ms</small></td><td class="dir-ok">✓ <small>757 ms</small></td></tr></tbody></table>
+<table><thead><tr><th>Resolver</th><th>dmp.dnsmesh.de</th><th>dmp.dnsmesh.io</th><th>dmp.dnsmesh.pro</th></tr></thead><tbody><tr><td><strong>Cloudflare</strong> <small><code>1.1.1.1</code></small></td><td class="dir-ok">✓ <small>343 ms</small></td><td class="dir-ok">✓ <small>68 ms</small></td><td class="dir-ok">✓ <small>225 ms</small></td></tr><tr><td><strong>Google</strong> <small><code>8.8.8.8</code></small></td><td class="dir-ok">✓ <small>318 ms</small></td><td class="dir-ok">✓ <small>35 ms</small></td><td class="dir-ok">✓ <small>152 ms</small></td></tr><tr><td><strong>Quad9</strong> <small><code>9.9.9.9</code></small></td><td class="dir-ok">✓ <small>357 ms</small></td><td class="dir-ok">✓ <small>79 ms</small></td><td class="dir-ok">✓ <small>220 ms</small></td></tr><tr><td><strong>OpenDNS</strong> <small><code>208.67.222.222</code></small></td><td class="dir-ok">✓ <small>266 ms</small></td><td class="dir-ok">✓ <small>181 ms</small></td><td class="dir-ok">✓ <small>370 ms</small></td></tr><tr><td><strong>Comodo</strong> <small><code>8.26.56.26</code></small></td><td class="dir-ok">✓ <small>337 ms</small></td><td class="dir-ok">✓ <small>161 ms</small></td><td class="dir-ok">✓ <small>348 ms</small></td></tr><tr><td><strong>Level3</strong> <small><code>4.2.2.1</code></small></td><td class="dir-ok">✓ <small>345 ms</small></td><td class="dir-fail">✗ <small>empty answer</small></td><td class="dir-ok">✓ <small>332 ms</small></td></tr><tr><td><strong>Hurricane Electric</strong> <small><code>74.82.42.42</code></small></td><td class="dir-ok">✓ <small>161 ms</small></td><td class="dir-ok">✓ <small>33 ms</small></td><td class="dir-ok">✓ <small>210 ms</small></td></tr><tr><td><strong>Verisign</strong> <small><code>64.6.64.6</code></small></td><td class="dir-ok">✓ <small>542 ms</small></td><td class="dir-ok">✓ <small>54 ms</small></td><td class="dir-ok">✓ <small>361 ms</small></td></tr><tr><td><strong>AdGuard</strong> <small><code>94.140.14.14</code></small></td><td class="dir-ok">✓ <small>658 ms</small></td><td class="dir-ok">✓ <small>113 ms</small></td><td class="dir-ok">✓ <small>690 ms</small></td></tr><tr><td><strong>Yandex</strong> <small><code>77.88.8.8</code></small></td><td class="dir-ok">✓ <small>439 ms</small></td><td class="dir-ok">✓ <small>799 ms</small></td><td class="dir-ok">✓ <small>805 ms</small></td></tr><tr><td><strong>Alibaba</strong> <small><code>223.5.5.5</code></small></td><td class="dir-ok">✓ <small>566 ms</small></td><td class="dir-ok">✓ <small>183 ms</small></td><td class="dir-ok">✓ <small>184 ms</small></td></tr><tr><td><strong>DNSPod</strong> <small><code>119.29.29.29</code></small></td><td class="dir-ok">✓ <small>563 ms</small></td><td class="dir-ok">✓ <small>110 ms</small></td><td class="dir-ok">✓ <small>565 ms</small></td></tr><tr><td><strong>KT Korea</strong> <small><code>168.126.63.1</code></small></td><td class="dir-ok">✓ <small>541 ms</small></td><td class="dir-ok">✓ <small>570 ms</small></td><td class="dir-ok">✓ <small>660 ms</small></td></tr></tbody></table>
 <p class="dir-section-note">
   Tested at build time from a GitHub Actions runner: each row is a
   curated public DNS resolver, each column is a node. A green cell

--- a/examples/directory_aggregator.py
+++ b/examples/directory_aggregator.py
@@ -652,10 +652,11 @@ def _render_node_cards(nodes: List[AggregatedNode], *, now: int) -> str:
         spk_short = n.operator_spk_hex[:8] + "…" + n.operator_spk_hex[-4:]
         host_text = ""
         if n.host:
-            host_text = f"{html_escape(n.host.get('org') or n.host.get('isp') or '')}"
-            asn = n.host.get("asn") or ""
-            if asn:
-                host_text += f" <small>({html_escape(asn)})</small>"
+            # Just the short org / ISP name. The ASN block (e.g.
+            # "AS24940 Hetzner Online GmbH") was visually noisy and
+            # didn't add information beyond the short name. Operators
+            # who want the full ASN can pull it from feed.json.
+            host_text = html_escape(n.host.get("org") or n.host.get("isp") or "")
         geo_text = ""
         if n.geo:
             parts = [


### PR DESCRIPTION
## Summary

Hosting rows were rendering as \`Hetzner (AS24940 Hetzner Online GmbH)\` — the AS-block was visual noise that didn't add information past the short name. Now: just \`Hetzner\` / \`OPENCLOUD SpA\` / \`DigitalOcean, LLC\`. The full ASN remains in \`feed.json\` (\`host.asn\` field) for anyone who wants it.

## Files

- \`examples/directory_aggregator.py\` — drop the \` <small>(asn)</small>\` appendage in \`_render_node_cards\`
- \`docs/directory/index.html\` — regenerated in-tree fallback
- \`docs/directory/feed.json\` — refreshed alongside

## Test plan

- [x] Local regen produces clean Hosting cells (Hetzner / OPENCLOUD SpA / DigitalOcean, LLC)
- [x] black-check clean
- [ ] After merge: pages.yml runs, https://dnsmeshprotocol.org/directory/ shows trimmed Hosting field