### PR TITLE
feat(directory): reorder sections + drop site footer

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,12 +36,10 @@ aux_links:
     - "https://github.com/oscarvalenzuelab/DNSMeshProtocol"
 aux_links_new_tab: true
 
-# Footer content appears under the page table-of-contents on every page.
-footer_content: >-
-  Content licensed under
-  <a href="https://github.com/oscarvalenzuelab/DNSMeshProtocol/blob/main/LICENSE">
-  AGPL-3.0</a>. Non-certified, pre-audit — see
-  <a href="https://github.com/oscarvalenzuelab/DNSMeshProtocol/blob/main/SECURITY.md">SECURITY.md</a>.
+# Footer content removed — was rendering "Content licensed under AGPL-3.0.
+# Non-certified, pre-audit — see SECURITY.md." plus an <hr> separator
+# under every page. Licensing + SECURITY.md are still linked from the
+# README and the repo root, which is where most readers expect them.
 
 # Show "Edit this page on GitHub" links.
 gh_edit_link: true

--- a/docs/directory/feed.json
+++ b/docs/directory/feed.json
@@ -1,15 +1,15 @@
 {
   "version": 2,
-  "generated_at": 1777672650,
+  "generated_at": 1777674315,
   "node_count": 3,
   "nodes": [
     {
       "operator_spk_hex": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "endpoint": "https://dnsmesh.de",
       "version": "0.6.6",
-      "ts": 1777672533,
-      "exp": 1777758933,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmRl++UIFDC977dfAreU7bazW7NCi9vZnlCBH+kffTaSzdkFMC42LjYAAQ5kbXAuZG5zbWVzaC5kZQAAAABp9SFVAAAAAGn2ctWEdfkNKdc+5f6u0tsfs13MFY0sWuuDC9+rHiB54K9dtmRVISZNswFA6fkdgczOclrtzz5fgvIaCsm2rFGSXosB",
+      "ts": 1777674040,
+      "exp": 1777760440,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmRl++UIFDC977dfAreU7bazW7NCi9vZnlCBH+kffTaSzdkFMC42LjYAAQ5kbXAuZG5zbWVzaC5kZQAAAABp9Sc4AAAAAGn2eLiqUbny8ujsF+g/mnfrVyW/VVuvh9UVrAm93gfyHVc+MAJjHvNXRXIXDY7/VxpzKGvrY2UFY4wishp9AarAxCUD",
       "last_seen_via": [
         "dmp.dnsmesh.de"
       ],
@@ -36,9 +36,9 @@
       "operator_spk_hex": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
       "endpoint": "https://dnsmesh.pro",
       "version": "0.6.6",
-      "ts": 1777672527,
-      "exp": 1777758927,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwATaHR0cHM6Ly9kbnNtZXNoLnByb1XdUIW7Ftv1ra8k1ToTu9UMj5+T4CaxlAWSNaP9gr/vBTAuNi42AAEPZG1wLmRuc21lc2gucHJvAAAAAGn1IU8AAAAAafZyzyFPtFM8s0OREDZZVXkChSaCn9ZiUBlaLMX2vDkIHNfvKBFpTL7UpjLAUPvaNf3syujZoZSXOLny5uu+wmDSZQA=",
+      "ts": 1777674036,
+      "exp": 1777760436,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwATaHR0cHM6Ly9kbnNtZXNoLnByb1XdUIW7Ftv1ra8k1ToTu9UMj5+T4CaxlAWSNaP9gr/vBTAuNi42AAEPZG1wLmRuc21lc2gucHJvAAAAAGn1JzQAAAAAafZ4tETGR+dLwaHpGWgjyQGGjt6hP306SjrKKrGO9zzv4/fNuF6mtQzy2Axa3qen6BhN94EUqdonNSIAzjg0nOkxXQM=",
       "last_seen_via": [
         "dmp.dnsmesh.pro",
         "dmp.dnsmesh.de"
@@ -66,9 +66,9 @@
       "operator_spk_hex": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
       "endpoint": "https://dnsmesh.io",
       "version": "0.6.6",
-      "ts": 1777672516,
-      "exp": 1777758916,
-      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmlvwOU4XrU8HNtixcWnJvGlUkgPw0XGAMjkXy7wR/ogMsIFMC42LjYAAQ5kbXAuZG5zbWVzaC5pbwAAAABp9SFEAAAAAGn2csThdl6F0+l93aGfrIrUqXs//accs0ruDzRZUud+g/RjQ5CMiGKLNNo2a5uHgDJac09GeicScyRLzWNHNMP4naUD",
+      "ts": 1777674023,
+      "exp": 1777760423,
+      "wire": "v=dmp1;t=heartbeat;RE1QSEIwMwASaHR0cHM6Ly9kbnNtZXNoLmlvwOU4XrU8HNtixcWnJvGlUkgPw0XGAMjkXy7wR/ogMsIFMC42LjYAAQ5kbXAuZG5zbWVzaC5pbwAAAABp9ScnAAAAAGn2eKfsqaUzWESSmWkChK6UD3Smvnal0Z1Vj6hkZrJOQWV+LhrLpBHP1RLiYejaImBgutLTPuRVlyNj1qeBz4YTbGQD",
       "last_seen_via": [
         "dmp.dnsmesh.io",
         "dmp.dnsmesh.pro",
@@ -98,17 +98,17 @@
     {
       "from_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
       "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
-      "last_seen_ts": 1777672516
+      "last_seen_ts": 1777674023
     },
     {
       "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "to_spk": "55dd5085bb16dbf5adaf24d53a13bbd50c8f9f93e026b194059235a3fd82bfef",
-      "last_seen_ts": 1777672527
+      "last_seen_ts": 1777674036
     },
     {
       "from_spk": "fbe5081430bdefb75f02b794edb6b35bb3428bdbd99e50811fe91f7d3692cdd9",
       "to_spk": "c0e5385eb53c1cdb62c5c5a726f1a552480fc345c600c8e45f2ef047fa2032c2",
-      "last_seen_ts": 1777672516
+      "last_seen_ts": 1777674023
     }
   ],
   "resolvers": [
@@ -118,70 +118,70 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
+      "latency_ms": 97,
+      "detail": "ok"
+    },
+    {
+      "name": "Cloudflare",
+      "addr": "1.1.1.1",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 233,
+      "detail": "ok"
+    },
+    {
+      "name": "Cloudflare",
+      "addr": "1.1.1.1",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 330,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 92,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 153,
+      "detail": "ok"
+    },
+    {
+      "name": "Google",
+      "addr": "8.8.8.8",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
+      "ok": true,
+      "latency_ms": 326,
+      "detail": "ok"
+    },
+    {
+      "name": "Quad9",
+      "addr": "9.9.9.9",
+      "zone": "dmp.dnsmesh.io",
+      "endpoint": "https://dnsmesh.io",
+      "ok": true,
       "latency_ms": 68,
       "detail": "ok"
     },
     {
-      "name": "Cloudflare",
-      "addr": "1.1.1.1",
-      "zone": "dmp.dnsmesh.pro",
-      "endpoint": "https://dnsmesh.pro",
-      "ok": true,
-      "latency_ms": 225,
-      "detail": "ok"
-    },
-    {
-      "name": "Cloudflare",
-      "addr": "1.1.1.1",
-      "zone": "dmp.dnsmesh.de",
-      "endpoint": "https://dnsmesh.de",
-      "ok": true,
-      "latency_ms": 343,
-      "detail": "ok"
-    },
-    {
-      "name": "Google",
-      "addr": "8.8.8.8",
-      "zone": "dmp.dnsmesh.io",
-      "endpoint": "https://dnsmesh.io",
-      "ok": true,
-      "latency_ms": 35,
-      "detail": "ok"
-    },
-    {
-      "name": "Google",
-      "addr": "8.8.8.8",
-      "zone": "dmp.dnsmesh.pro",
-      "endpoint": "https://dnsmesh.pro",
-      "ok": true,
-      "latency_ms": 152,
-      "detail": "ok"
-    },
-    {
-      "name": "Google",
-      "addr": "8.8.8.8",
-      "zone": "dmp.dnsmesh.de",
-      "endpoint": "https://dnsmesh.de",
-      "ok": true,
-      "latency_ms": 318,
-      "detail": "ok"
-    },
-    {
-      "name": "Quad9",
-      "addr": "9.9.9.9",
-      "zone": "dmp.dnsmesh.io",
-      "endpoint": "https://dnsmesh.io",
-      "ok": true,
-      "latency_ms": 79,
-      "detail": "ok"
-    },
-    {
       "name": "Quad9",
       "addr": "9.9.9.9",
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 220,
+      "latency_ms": 199,
       "detail": "ok"
     },
     {
@@ -190,7 +190,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 357,
+      "latency_ms": 367,
       "detail": "ok"
     },
     {
@@ -199,7 +199,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 181,
+      "latency_ms": 107,
       "detail": "ok"
     },
     {
@@ -208,7 +208,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 370,
+      "latency_ms": 341,
       "detail": "ok"
     },
     {
@@ -217,7 +217,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 266,
+      "latency_ms": 492,
       "detail": "ok"
     },
     {
@@ -226,7 +226,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 161,
+      "latency_ms": 155,
       "detail": "ok"
     },
     {
@@ -235,7 +235,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 348,
+      "latency_ms": 606,
       "detail": "ok"
     },
     {
@@ -244,7 +244,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 337,
+      "latency_ms": 497,
       "detail": "ok"
     },
     {
@@ -262,7 +262,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 332,
+      "latency_ms": 446,
       "detail": "ok"
     },
     {
@@ -271,7 +271,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 345,
+      "latency_ms": 506,
       "detail": "ok"
     },
     {
@@ -289,7 +289,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 210,
+      "latency_ms": 209,
       "detail": "ok"
     },
     {
@@ -298,7 +298,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 161,
+      "latency_ms": 154,
       "detail": "ok"
     },
     {
@@ -307,7 +307,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 54,
+      "latency_ms": 48,
       "detail": "ok"
     },
     {
@@ -316,7 +316,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 361,
+      "latency_ms": 511,
       "detail": "ok"
     },
     {
@@ -325,7 +325,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 542,
+      "latency_ms": 366,
       "detail": "ok"
     },
     {
@@ -334,7 +334,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 113,
+      "latency_ms": 200,
       "detail": "ok"
     },
     {
@@ -343,7 +343,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 690,
+      "latency_ms": 764,
       "detail": "ok"
     },
     {
@@ -352,7 +352,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 658,
+      "latency_ms": 811,
       "detail": "ok"
     },
     {
@@ -361,7 +361,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 799,
+      "latency_ms": 683,
       "detail": "ok"
     },
     {
@@ -370,7 +370,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 805,
+      "latency_ms": 775,
       "detail": "ok"
     },
     {
@@ -379,7 +379,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 439,
+      "latency_ms": 427,
       "detail": "ok"
     },
     {
@@ -387,35 +387,35 @@
       "addr": "223.5.5.5",
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
+      "ok": true,
+      "latency_ms": 202,
+      "detail": "ok"
+    },
+    {
+      "name": "Alibaba",
+      "addr": "223.5.5.5",
+      "zone": "dmp.dnsmesh.pro",
+      "endpoint": "https://dnsmesh.pro",
+      "ok": true,
+      "latency_ms": 186,
+      "detail": "ok"
+    },
+    {
+      "name": "Alibaba",
+      "addr": "223.5.5.5",
+      "zone": "dmp.dnsmesh.de",
+      "endpoint": "https://dnsmesh.de",
       "ok": true,
       "latency_ms": 183,
       "detail": "ok"
     },
     {
-      "name": "Alibaba",
-      "addr": "223.5.5.5",
-      "zone": "dmp.dnsmesh.pro",
-      "endpoint": "https://dnsmesh.pro",
-      "ok": true,
-      "latency_ms": 184,
-      "detail": "ok"
-    },
-    {
-      "name": "Alibaba",
-      "addr": "223.5.5.5",
-      "zone": "dmp.dnsmesh.de",
-      "endpoint": "https://dnsmesh.de",
-      "ok": true,
-      "latency_ms": 566,
-      "detail": "ok"
-    },
-    {
       "name": "DNSPod",
       "addr": "119.29.29.29",
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 110,
+      "latency_ms": 94,
       "detail": "ok"
     },
     {
@@ -424,7 +424,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 565,
+      "latency_ms": 530,
       "detail": "ok"
     },
     {
@@ -433,7 +433,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 563,
+      "latency_ms": 549,
       "detail": "ok"
     },
     {
@@ -442,7 +442,7 @@
       "zone": "dmp.dnsmesh.io",
       "endpoint": "https://dnsmesh.io",
       "ok": true,
-      "latency_ms": 570,
+      "latency_ms": 504,
       "detail": "ok"
     },
     {
@@ -451,7 +451,7 @@
       "zone": "dmp.dnsmesh.pro",
       "endpoint": "https://dnsmesh.pro",
       "ok": true,
-      "latency_ms": 660,
+      "latency_ms": 740,
       "detail": "ok"
     },
     {
@@ -460,7 +460,7 @@
       "zone": "dmp.dnsmesh.de",
       "endpoint": "https://dnsmesh.de",
       "ok": true,
-      "latency_ms": 541,
+      "latency_ms": 623,
       "detail": "ok"
     }
   ]

--- a/docs/directory/index.html
+++ b/docs/directory/index.html
@@ -54,50 +54,9 @@ permalink: /directory/
 <div class="dmp-directory">
 
 <p>
-  <small>Generated 2026-05-01 21:57:30 UTC · 3 known nodes ·
+  <small>Generated 2026-05-01 22:25:15 UTC · 3 known nodes ·
   <a href="feed.json">feed.json</a> carries the raw signed wires
   for independent re-verification.</small>
-</p>
-
-<h2>Known nodes <small>· geo + hosting</small></h2>
-<div class="dir-cards">
-<div class="dir-card">
-<h3><a href="https://dnsmesh.de">https://dnsmesh.de</a></h3>
-<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">1m ago</span></span></div>
-<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
-<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>fbe50814…cdd9</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">Hetzner</span></div>
-<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Nuremberg, Bavaria, Germany</span></div>
-<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>178.104.241.208</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.de</span></div>
-</div>
-<div class="dir-card">
-<h3><a href="https://dnsmesh.pro">https://dnsmesh.pro</a></h3>
-<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">2m ago</span></span></div>
-<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
-<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>55dd5085…bfef</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">OPENCLOUD SpA</span></div>
-<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Curicó, Maule Region, Chile</span></div>
-<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>45.7.229.112</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
-</div>
-<div class="dir-card">
-<h3><a href="https://dnsmesh.io">https://dnsmesh.io</a></h3>
-<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">2m ago</span></span></div>
-<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
-<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>c0e5385e…32c2</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">DigitalOcean, LLC</span></div>
-<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Santa Clara, California, United States</span></div>
-<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>24.199.107.165</code></span></div>
-<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.io, dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
-</div>
-</div>
-<p class="dir-section-note">
-  Geo and ASN data via ip-api.com lookup at build time. Each node is
-  the same self-signed <code>HeartbeatRecord</code> wire that lives at
-  <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
-  chain — the geo block is descriptive metadata for humans and is
-  NOT signed.
 </p>
 
 <h2>Federation topology <small>· heartbeat-discovery, not message traffic</small></h2>
@@ -113,7 +72,7 @@ permalink: /directory/
 </p>
 
 <h2>Public-resolver reachability <small>· can major resolvers find these nodes?</small></h2>
-<table><thead><tr><th>Resolver</th><th>dmp.dnsmesh.de</th><th>dmp.dnsmesh.io</th><th>dmp.dnsmesh.pro</th></tr></thead><tbody><tr><td><strong>Cloudflare</strong> <small><code>1.1.1.1</code></small></td><td class="dir-ok">✓ <small>343 ms</small></td><td class="dir-ok">✓ <small>68 ms</small></td><td class="dir-ok">✓ <small>225 ms</small></td></tr><tr><td><strong>Google</strong> <small><code>8.8.8.8</code></small></td><td class="dir-ok">✓ <small>318 ms</small></td><td class="dir-ok">✓ <small>35 ms</small></td><td class="dir-ok">✓ <small>152 ms</small></td></tr><tr><td><strong>Quad9</strong> <small><code>9.9.9.9</code></small></td><td class="dir-ok">✓ <small>357 ms</small></td><td class="dir-ok">✓ <small>79 ms</small></td><td class="dir-ok">✓ <small>220 ms</small></td></tr><tr><td><strong>OpenDNS</strong> <small><code>208.67.222.222</code></small></td><td class="dir-ok">✓ <small>266 ms</small></td><td class="dir-ok">✓ <small>181 ms</small></td><td class="dir-ok">✓ <small>370 ms</small></td></tr><tr><td><strong>Comodo</strong> <small><code>8.26.56.26</code></small></td><td class="dir-ok">✓ <small>337 ms</small></td><td class="dir-ok">✓ <small>161 ms</small></td><td class="dir-ok">✓ <small>348 ms</small></td></tr><tr><td><strong>Level3</strong> <small><code>4.2.2.1</code></small></td><td class="dir-ok">✓ <small>345 ms</small></td><td class="dir-fail">✗ <small>empty answer</small></td><td class="dir-ok">✓ <small>332 ms</small></td></tr><tr><td><strong>Hurricane Electric</strong> <small><code>74.82.42.42</code></small></td><td class="dir-ok">✓ <small>161 ms</small></td><td class="dir-ok">✓ <small>33 ms</small></td><td class="dir-ok">✓ <small>210 ms</small></td></tr><tr><td><strong>Verisign</strong> <small><code>64.6.64.6</code></small></td><td class="dir-ok">✓ <small>542 ms</small></td><td class="dir-ok">✓ <small>54 ms</small></td><td class="dir-ok">✓ <small>361 ms</small></td></tr><tr><td><strong>AdGuard</strong> <small><code>94.140.14.14</code></small></td><td class="dir-ok">✓ <small>658 ms</small></td><td class="dir-ok">✓ <small>113 ms</small></td><td class="dir-ok">✓ <small>690 ms</small></td></tr><tr><td><strong>Yandex</strong> <small><code>77.88.8.8</code></small></td><td class="dir-ok">✓ <small>439 ms</small></td><td class="dir-ok">✓ <small>799 ms</small></td><td class="dir-ok">✓ <small>805 ms</small></td></tr><tr><td><strong>Alibaba</strong> <small><code>223.5.5.5</code></small></td><td class="dir-ok">✓ <small>566 ms</small></td><td class="dir-ok">✓ <small>183 ms</small></td><td class="dir-ok">✓ <small>184 ms</small></td></tr><tr><td><strong>DNSPod</strong> <small><code>119.29.29.29</code></small></td><td class="dir-ok">✓ <small>563 ms</small></td><td class="dir-ok">✓ <small>110 ms</small></td><td class="dir-ok">✓ <small>565 ms</small></td></tr><tr><td><strong>KT Korea</strong> <small><code>168.126.63.1</code></small></td><td class="dir-ok">✓ <small>541 ms</small></td><td class="dir-ok">✓ <small>570 ms</small></td><td class="dir-ok">✓ <small>660 ms</small></td></tr></tbody></table>
+<table><thead><tr><th>Resolver</th><th>dmp.dnsmesh.de</th><th>dmp.dnsmesh.io</th><th>dmp.dnsmesh.pro</th></tr></thead><tbody><tr><td><strong>Cloudflare</strong> <small><code>1.1.1.1</code></small></td><td class="dir-ok">✓ <small>330 ms</small></td><td class="dir-ok">✓ <small>97 ms</small></td><td class="dir-ok">✓ <small>233 ms</small></td></tr><tr><td><strong>Google</strong> <small><code>8.8.8.8</code></small></td><td class="dir-ok">✓ <small>326 ms</small></td><td class="dir-ok">✓ <small>92 ms</small></td><td class="dir-ok">✓ <small>153 ms</small></td></tr><tr><td><strong>Quad9</strong> <small><code>9.9.9.9</code></small></td><td class="dir-ok">✓ <small>367 ms</small></td><td class="dir-ok">✓ <small>68 ms</small></td><td class="dir-ok">✓ <small>199 ms</small></td></tr><tr><td><strong>OpenDNS</strong> <small><code>208.67.222.222</code></small></td><td class="dir-ok">✓ <small>492 ms</small></td><td class="dir-ok">✓ <small>107 ms</small></td><td class="dir-ok">✓ <small>341 ms</small></td></tr><tr><td><strong>Comodo</strong> <small><code>8.26.56.26</code></small></td><td class="dir-ok">✓ <small>497 ms</small></td><td class="dir-ok">✓ <small>155 ms</small></td><td class="dir-ok">✓ <small>606 ms</small></td></tr><tr><td><strong>Level3</strong> <small><code>4.2.2.1</code></small></td><td class="dir-ok">✓ <small>506 ms</small></td><td class="dir-fail">✗ <small>empty answer</small></td><td class="dir-ok">✓ <small>446 ms</small></td></tr><tr><td><strong>Hurricane Electric</strong> <small><code>74.82.42.42</code></small></td><td class="dir-ok">✓ <small>154 ms</small></td><td class="dir-ok">✓ <small>33 ms</small></td><td class="dir-ok">✓ <small>209 ms</small></td></tr><tr><td><strong>Verisign</strong> <small><code>64.6.64.6</code></small></td><td class="dir-ok">✓ <small>366 ms</small></td><td class="dir-ok">✓ <small>48 ms</small></td><td class="dir-ok">✓ <small>511 ms</small></td></tr><tr><td><strong>AdGuard</strong> <small><code>94.140.14.14</code></small></td><td class="dir-ok">✓ <small>811 ms</small></td><td class="dir-ok">✓ <small>200 ms</small></td><td class="dir-ok">✓ <small>764 ms</small></td></tr><tr><td><strong>Yandex</strong> <small><code>77.88.8.8</code></small></td><td class="dir-ok">✓ <small>427 ms</small></td><td class="dir-ok">✓ <small>683 ms</small></td><td class="dir-ok">✓ <small>775 ms</small></td></tr><tr><td><strong>Alibaba</strong> <small><code>223.5.5.5</code></small></td><td class="dir-ok">✓ <small>183 ms</small></td><td class="dir-ok">✓ <small>202 ms</small></td><td class="dir-ok">✓ <small>186 ms</small></td></tr><tr><td><strong>DNSPod</strong> <small><code>119.29.29.29</code></small></td><td class="dir-ok">✓ <small>549 ms</small></td><td class="dir-ok">✓ <small>94 ms</small></td><td class="dir-ok">✓ <small>530 ms</small></td></tr><tr><td><strong>KT Korea</strong> <small><code>168.126.63.1</code></small></td><td class="dir-ok">✓ <small>623 ms</small></td><td class="dir-ok">✓ <small>504 ms</small></td><td class="dir-ok">✓ <small>740 ms</small></td></tr></tbody></table>
 <p class="dir-section-note">
   Tested at build time from a GitHub Actions runner: each row is a
   curated public DNS resolver, each column is a node. A green cell
@@ -121,6 +80,47 @@ permalink: /directory/
   with a wire that verifies under Ed25519. Your client can do the
   same lookup with the same result. The list is illustrative — every
   internet-connected DNS resolver can perform the same query.
+</p>
+
+<h2>Known nodes <small>· geo + hosting</small></h2>
+<div class="dir-cards">
+<div class="dir-card">
+<h3><a href="https://dnsmesh.de">https://dnsmesh.de</a></h3>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">4m ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
+<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>fbe50814…cdd9</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">Hetzner</span></div>
+<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Nuremberg, Bavaria, Germany</span></div>
+<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>178.104.241.208</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.de</span></div>
+</div>
+<div class="dir-card">
+<h3><a href="https://dnsmesh.pro">https://dnsmesh.pro</a></h3>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">4m ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
+<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>55dd5085…bfef</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">OPENCLOUD SpA</span></div>
+<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Curicó, Maule Region, Chile</span></div>
+<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>45.7.229.112</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
+</div>
+<div class="dir-card">
+<h3><a href="https://dnsmesh.io">https://dnsmesh.io</a></h3>
+<div class="dir-row"><span class="dir-row-label">Status</span><span class="dir-row-val"><span class="dir-pill fresh">4m ago</span></span></div>
+<div class="dir-row"><span class="dir-row-label">Version</span><span class="dir-row-val">0.6.6</span></div>
+<div class="dir-row"><span class="dir-row-label">Operator key</span><span class="dir-row-val"><code>c0e5385e…32c2</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Hosting</span><span class="dir-row-val">DigitalOcean, LLC</span></div>
+<div class="dir-row"><span class="dir-row-label">Region</span><span class="dir-row-val">Santa Clara, California, United States</span></div>
+<div class="dir-row"><span class="dir-row-label">IP</span><span class="dir-row-val"><code>24.199.107.165</code></span></div>
+<div class="dir-row"><span class="dir-row-label">Heard via</span><span class="dir-row-val">dmp.dnsmesh.io, dmp.dnsmesh.pro, dmp.dnsmesh.de</span></div>
+</div>
+</div>
+<p class="dir-section-note">
+  Geo and ASN data via ip-api.com lookup at build time. Each node is
+  the same self-signed <code>HeartbeatRecord</code> wire that lives at
+  <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
+  chain — the geo block is descriptive metadata for humans and is
+  NOT signed.
 </p>
 
 </div>

--- a/examples/directory_aggregator.py
+++ b/examples/directory_aggregator.py
@@ -571,18 +571,6 @@ permalink: /directory/
   for independent re-verification.</small>
 </p>
 
-<h2>Known nodes <small>· geo + hosting</small></h2>
-<div class="dir-cards">
-{node_cards}
-</div>
-<p class="dir-section-note">
-  Geo and ASN data via ip-api.com lookup at build time. Each node is
-  the same self-signed <code>HeartbeatRecord</code> wire that lives at
-  <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
-  chain — the geo block is descriptive metadata for humans and is
-  NOT signed.
-</p>
-
 <h2>Federation topology <small>· heartbeat-discovery, not message traffic</small></h2>
 <div class="dir-svg-wrap">
 {topology_svg}
@@ -604,6 +592,18 @@ permalink: /directory/
   with a wire that verifies under Ed25519. Your client can do the
   same lookup with the same result. The list is illustrative — every
   internet-connected DNS resolver can perform the same query.
+</p>
+
+<h2>Known nodes <small>· geo + hosting</small></h2>
+<div class="dir-cards">
+{node_cards}
+</div>
+<p class="dir-section-note">
+  Geo and ASN data via ip-api.com lookup at build time. Each node is
+  the same self-signed <code>HeartbeatRecord</code> wire that lives at
+  <code>_dnsmesh-heartbeat.&lt;zone&gt;</code> on the public DNS
+  chain — the geo block is descriptive metadata for humans and is
+  NOT signed.
 </p>
 
 </div>


### PR DESCRIPTION
## Summary

Two visual cleanups on the directory page:

1. **Reorder sections.** The page now leads with what a reader actually wants to see — the topology picture and the "does this work for me?" matrix — with the per-node cards as reference at the bottom.

   - Before: Known nodes → Federation topology → Public-resolver reachability
   - After: Federation topology → Public-resolver reachability → Known nodes

2. **Removed `footer_content` from `docs/_config.yml`.** Was rendering "Content licensed under AGPL-3.0. Non-certified, pre-audit — see SECURITY.md." plus an `<hr>` separator under EVERY page. Licensing + SECURITY.md are still linked from the README and the repo root, which is where most readers expect them. The per-page repeat was noise.

## Files

- `examples/directory_aggregator.py` — `_HTML_TEMPLATE` reordered
- `docs/_config.yml` — `footer_content` block removed
- `docs/directory/index.html` — regenerated in-tree fallback to match
- `docs/directory/feed.json` — refreshed alongside

## Test plan

- [x] Local regen: section order is Federation topology → Public-resolver reachability → Known nodes
- [x] black-check clean
- [ ] After merge: pages.yml runs, sections in new order, no AGPL footer or `<hr>` on any page (confirmed via DOM check on directory page)