### PR TITLE
fix(docs): hide layout-inserted <hr> above per-page footer

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,9 @@
+// Just-the-Docs picks up `_sass/custom/custom.scss` automatically and
+// compiles it into the main CSS bundle. Site-wide overrides go here.
+
+// Hide the `<hr>` separator the default layout inserts between the main
+// page content and the per-page footer row (the "Edit this page on
+// GitHub" link). The visual break wasn't adding information.
+#main-content > hr {
+    display: none;
+}


### PR DESCRIPTION
## Summary

After PR #32 dropped \`footer_content\`, Just-the-Docs's layout still inserted an \`<hr>\` between the page content and the per-page footer row (the "Edit this page on GitHub" link) — a visual break with nothing on either side of it. Hide it via the standard \`_sass/custom/custom.scss\` hook (Just-the-Docs picks it up automatically and compiles into the main CSS bundle).

The actual \`<footer>\` element with the edit-on-GitHub link stays — operators editing the docs still want it.

## Files

- \`docs/_sass/custom/custom.scss\` — new file, single rule:

  \`\`\`scss
  #main-content > hr { display: none; }
  \`\`\`

## Test plan

- [x] DOM probe on the directory page shows \`<hr>\` is present today (the layout's separator)
- [ ] After merge: same probe returns 0 \`<hr>\` site-wide