### PR TITLE
fix(docs): hide layout <hr> via head_custom.html (remote_theme-compatible)

### DIFF
--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,17 @@
+{% comment %}
+  Just-the-Docs ships an empty `head_custom.html` that gets injected into
+  every page's `<head>`. Drop site-wide CSS overrides here. Using this
+  include rather than `_sass/custom/custom.scss` because we run
+  Just-the-Docs as a `remote_theme` — the SCSS pipeline doesn't pick up
+  custom partials in that mode, but `<head>` includes are honored.
+
+  Currently:
+    - Hides the `<hr>` separator the default layout drops between the
+      page content and the per-page footer row (the "Edit this page on
+      GitHub" link). After we removed `footer_content` from the site
+      config the `<hr>` was a visual break with nothing on either side
+      of it.
+{% endcomment %}
+<style>
+  #main-content > hr { display: none; }
+</style>

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,9 +1,0 @@
-// Just-the-Docs picks up `_sass/custom/custom.scss` automatically and
-// compiles it into the main CSS bundle. Site-wide overrides go here.
-
-// Hide the `<hr>` separator the default layout inserts between the main
-// page content and the per-page footer row (the "Edit this page on
-// GitHub" link). The visual break wasn't adding information.
-#main-content > hr {
-    display: none;
-}


### PR DESCRIPTION
## Summary

PR #33's \`_sass/custom/custom.scss\` rule wasn't taking effect — confirmed via DOM probe after the deploy: \`<hr>\` was still visible. Cause: we use \`remote_theme: just-the-docs/just-the-docs\` in \`_config.yml\`, and the SCSS-partial pipeline doesn't pick up custom files in that mode. Just-the-Docs's \`_sass/custom/\` convention only works when the theme is installed locally.

Switch to \`_includes/head_custom.html\`, which Just-the-Docs unconditionally injects into every page's \`<head>\` regardless of how the theme is delivered.

## Files

- \`docs/_includes/head_custom.html\` — new file, single one-rule \`<style>\`:
  \`\`\`css
  #main-content > hr { display: none; }
  \`\`\`
- \`docs/_sass/custom/custom.scss\` — removed (non-functional under \`remote_theme\`)

## Test plan

- [x] DOM probe shows the <hr> still rendering after PR #33 — confirming the SCSS path doesn't take under \`remote_theme\`
- [ ] After merge: same probe should show \`visible_hr_count: 0\`