### PR TITLE
fix(crypto): centralize Ed25519 low-order pubkey rejection in verify_signature

### DIFF
--- a/dmp/core/claim.py
+++ b/dmp/core/claim.py
@@ -86,7 +86,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 from dmp.core.crypto import DMPCrypto
-from dmp.core.ed25519_points import is_low_order as _is_low_order
 
 RECORD_PREFIX = "v=dmp1;t=claim;"
 
@@ -328,13 +327,8 @@ class ClaimRecord:
         except ValueError:
             return None
 
-        # Low-order Ed25519 pubkey guard — same defense as heartbeat
-        # / registration. The identity point (01 00..00) verifies
-        # every message under permissive RFC 8032 implementations;
-        # other small-order points permit grinding forgeries.
-        if _is_low_order(bytes(record.sender_spk)):
-            return None
-
+        # Low-order Ed25519 pubkey rejection is centralized inside
+        # DMPCrypto.verify_signature (see dmp.core.ed25519_points).
         if not DMPCrypto.verify_signature(body, sig, bytes(record.sender_spk)):
             return None
 

--- a/dmp/core/crypto.py
+++ b/dmp/core/crypto.py
@@ -28,6 +28,8 @@ from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.backends import default_backend
 
+from dmp.core.ed25519_points import is_low_order as _is_low_order_ed25519
+
 # Argon2id parameters for passphrase → 32-byte X25519 seed.
 # Tuned for ~20ms on a modern laptop. Still orders of magnitude more
 # resistant to offline brute force than the previous PBKDF2-SHA256 at
@@ -274,15 +276,30 @@ class DMPCrypto:
         """Verify an Ed25519 signature.
 
         Accepts either an Ed25519PublicKey instance or raw 32 pubkey bytes.
+        Public keys in the small-subgroup / low-order set are rejected here
+        before delegating to the underlying verify; see
+        ``dmp.core.ed25519_points`` for the rationale (identity-point forgery
+        and grindable small-order forgeries against permissive verifiers).
         """
         if isinstance(signing_public_key, (bytes, bytearray)):
-            if len(signing_public_key) != 32:
+            pub_bytes = bytes(signing_public_key)
+            if len(pub_bytes) != 32:
+                return False
+            if _is_low_order_ed25519(pub_bytes):
                 return False
             try:
-                signing_public_key = Ed25519PublicKey.from_public_bytes(
-                    bytes(signing_public_key)
+                signing_public_key = Ed25519PublicKey.from_public_bytes(pub_bytes)
+            except Exception:
+                return False
+        else:
+            try:
+                pub_bytes = signing_public_key.public_bytes(
+                    encoding=serialization.Encoding.Raw,
+                    format=serialization.PublicFormat.Raw,
                 )
             except Exception:
+                return False
+            if _is_low_order_ed25519(pub_bytes):
                 return False
         try:
             signing_public_key.verify(signature, data)

--- a/dmp/core/heartbeat.py
+++ b/dmp/core/heartbeat.py
@@ -66,7 +66,6 @@ from typing import Optional
 from urllib.parse import urlsplit
 
 from dmp.core.crypto import DMPCrypto
-from dmp.core.ed25519_points import is_low_order as _is_low_order
 
 # Wire prefix. v1 because the whole family of signed DMP records uses
 # v=dmp1; jumping to v=dmp2 is a flag day across everything post-audit.
@@ -515,13 +514,8 @@ class HeartbeatRecord:
         except ValueError:
             return None
 
-        # Low-order pubkey guard — identity point (01 00..00) with
-        # any sig verifies every message under permissive RFC 8032;
-        # other small-order points allow grinding forgeries on subsets.
-        # Shared block list with dmp.server.registration.
-        if _is_low_order(bytes(record.operator_spk)):
-            return None
-
+        # Low-order Ed25519 pubkey rejection is centralized inside
+        # DMPCrypto.verify_signature (see dmp.core.ed25519_points).
         if not DMPCrypto.verify_signature(body, sig, bytes(record.operator_spk)):
             return None
 

--- a/dmp/server/registration.py
+++ b/dmp/server/registration.py
@@ -34,8 +34,7 @@ import time
 from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple
 
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from dmp.core.crypto import DMPCrypto
 
 from dmp.server.tokens import (
     DEFAULT_RATE_BURST,
@@ -45,13 +44,6 @@ from dmp.server.tokens import (
     _SubjectLocked,
     canonicalize_subject,
 )
-
-# Low-order Ed25519 block list — shared source of truth at
-# dmp.core.ed25519_points so registration, heartbeat, and any future
-# signed-record consumer all stay in sync.
-from dmp.core.ed25519_points import (
-    LOW_ORDER_ED25519_PUBKEYS as _LOW_ORDER_ED25519_PUBKEYS,
-)  # noqa: E402,F401
 
 # Version byte embedded in the signed message. Bump if we change the
 # signing-payload layout so old and new signatures can't collide.
@@ -406,23 +398,6 @@ def confirm_registration(
     # Challenge is a 32-byte nonce; verify shape before any DB ops.
     _parse_hex(challenge_hex, 32, "challenge")
 
-    # Reject Ed25519 low-order / small-subgroup public keys. With
-    # the identity point (01 00..00) as A and sig = identity || 00*32,
-    # Ed25519 verification succeeds on EVERY message — a complete
-    # signature-forgery bypass that lets an attacker reach the
-    # anti-takeover / allowlist policy layer without holding any
-    # private key. Other small-order points (orders 2 / 4 / 8) allow
-    # forgery on subsets of messages, which is still grindable.
-    # cryptography's Ed25519PublicKey.from_public_bytes does NOT
-    # reject these — the cryptography lib's default verify is the
-    # permissive (non-cofactored) algorithm per RFC 8032.
-    #
-    # The block set is the canonical + non-canonical low-order
-    # encodings. References: RFC 8032,
-    # https://pkg.go.dev/c2sp.org/CCTV/ed25519.
-    if spk_bytes in _LOW_ORDER_ED25519_PUBKEYS:
-        raise SignatureInvalid("low-order public key rejected")
-
     # Single-use challenge. Raises ChallengeExpired on miss/expired.
     pc = challenges.consume(challenge_hex, now=now)
 
@@ -434,11 +409,15 @@ def confirm_registration(
     # allowlisted". After reordering, an attacker without the
     # private key sees only 401 (or 400 on parse failures) and
     # cannot distinguish 403 / 409.
+    #
+    # DMPCrypto.verify_signature centralizes the Ed25519 low-order /
+    # small-subgroup block list (see dmp.core.ed25519_points). With
+    # the identity point as A and sig = identity || 00*32 the
+    # permissive RFC-8032 verify accepts on every message, which
+    # would let an unauthenticated attacker mint tokens.
     payload = _build_signing_payload(challenge_hex, subject, pc.node)
-    try:
-        Ed25519PublicKey.from_public_bytes(spk_bytes).verify(sig_bytes, payload)
-    except InvalidSignature as exc:
-        raise SignatureInvalid() from exc
+    if not DMPCrypto.verify_signature(payload, sig_bytes, spk_bytes):
+        raise SignatureInvalid()
 
     # The signer proved key control. Now apply policy.
     if not _domain_allowed(subject, config.allowlist):
@@ -738,16 +717,11 @@ def mint_tsig_via_registration(
     sig_bytes = _parse_hex(signature_hex, 64, "signature")
     _parse_hex(challenge_hex, 32, "challenge")
 
-    if spk_bytes in _LOW_ORDER_ED25519_PUBKEYS:
-        raise SignatureInvalid("low-order public key rejected")
-
     pc = challenges.consume(challenge_hex, now=now)
 
     payload = _build_signing_payload(challenge_hex, subject, pc.node)
-    try:
-        Ed25519PublicKey.from_public_bytes(spk_bytes).verify(sig_bytes, payload)
-    except InvalidSignature as exc:
-        raise SignatureInvalid() from exc
+    if not DMPCrypto.verify_signature(payload, sig_bytes, spk_bytes):
+        raise SignatureInvalid()
 
     if not _domain_allowed(subject, config.allowlist):
         raise SubjectNotAllowed()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -244,9 +244,9 @@ class TestDMPCrypto:
         # Must be rejected against any message — pick a few representative
         # payloads to make the "every message" property visible in the test.
         for msg in (b"", b"forgery target", b"\x00" * 1024, os.urandom(64)):
-            assert not DMPCrypto.verify_signature(msg, forgery_sig, identity_pub), (
-                f"identity-point forgery accepted on message of len {len(msg)}"
-            )
+            assert not DMPCrypto.verify_signature(
+                msg, forgery_sig, identity_pub
+            ), f"identity-point forgery accepted on message of len {len(msg)}"
 
     def test_verify_signature_rejects_low_order_vectors_bytes(self):
         """Each known low-order encoding must be rejected when passed as raw
@@ -259,12 +259,12 @@ class TestDMPCrypto:
         zero_sig = b"\x00" * 64
         for hex_pub in self._LOW_ORDER_VECTORS:
             pub_bytes = bytes.fromhex(hex_pub)
-            assert not DMPCrypto.verify_signature(msg, forgery_sig, pub_bytes), (
-                f"low-order pubkey {hex_pub} accepted with identity-forgery sig"
-            )
-            assert not DMPCrypto.verify_signature(msg, zero_sig, pub_bytes), (
-                f"low-order pubkey {hex_pub} accepted with zero sig"
-            )
+            assert not DMPCrypto.verify_signature(
+                msg, forgery_sig, pub_bytes
+            ), f"low-order pubkey {hex_pub} accepted with identity-forgery sig"
+            assert not DMPCrypto.verify_signature(
+                msg, zero_sig, pub_bytes
+            ), f"low-order pubkey {hex_pub} accepted with zero sig"
 
     def test_verify_signature_rejects_low_order_vectors_instance(self):
         """Same rejection when an Ed25519PublicKey instance is passed instead
@@ -281,9 +281,9 @@ class TestDMPCrypto:
                 # time by the underlying library; the bytes-form test above
                 # already exercises those.
                 continue
-            assert not DMPCrypto.verify_signature(msg, forgery_sig, pk_instance), (
-                f"low-order pubkey instance {hex_pub} accepted"
-            )
+            assert not DMPCrypto.verify_signature(
+                msg, forgery_sig, pk_instance
+            ), f"low-order pubkey instance {hex_pub} accepted"
 
     def test_verify_signature_block_list_includes_all_known_vectors(self):
         """The independent vector list MUST be a subset of the production
@@ -293,9 +293,9 @@ class TestDMPCrypto:
         """
         for hex_pub in self._LOW_ORDER_VECTORS:
             pub_bytes = bytes.fromhex(hex_pub)
-            assert pub_bytes in LOW_ORDER_ED25519_PUBKEYS, (
-                f"vector {hex_pub} missing from LOW_ORDER_ED25519_PUBKEYS"
-            )
+            assert (
+                pub_bytes in LOW_ORDER_ED25519_PUBKEYS
+            ), f"vector {hex_pub} missing from LOW_ORDER_ED25519_PUBKEYS"
 
     def test_verify_signature_wrong_length_pubkey_rejected(self):
         """Defense in depth: bytes pubkeys of the wrong length must fail

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -3,9 +3,11 @@
 import pytest
 import os
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.exceptions import InvalidTag
 
 from dmp.core.crypto import DMPCrypto, EncryptedMessage, MessageEncryption
+from dmp.core.ed25519_points import LOW_ORDER_ED25519_PUBKEYS
 
 
 class TestDMPCrypto:
@@ -203,6 +205,106 @@ class TestDMPCrypto:
         # Wrong signer fails
         other = DMPCrypto()
         assert not DMPCrypto.verify_signature(data, signature, other.signing_public_key)
+
+    # Independent hard-coded low-order Ed25519 encoding fixtures. These
+    # MUST NOT be derived from dmp.core.ed25519_points.LOW_ORDER_ED25519_PUBKEYS
+    # — if an entry were accidentally deleted from the production set, a test
+    # that imports the same set would silently stop checking it. Source:
+    # https://pkg.go.dev/c2sp.org/CCTV/ed25519 + RFC 8032 small-subgroup
+    # canonical encodings.
+    _IDENTITY_POINT_HEX = (
+        "0100000000000000000000000000000000000000000000000000000000000000"
+    )
+    _LOW_ORDER_VECTORS = (
+        # order 1 — identity point. With sig = identity || 0^32, permissive
+        # RFC-8032 verify accepts on every message (full forgery).
+        _IDENTITY_POINT_HEX,
+        # order 2
+        "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+        # order 4 — both encodings
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000000000000080",
+        # order 8 — canonical
+        "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a",
+        "26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc05",
+        # non-canonical aliases the cryptography library still parses
+        "0100000000000000000000000000000000000000000000000000000000000080",
+        "edffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+    )
+
+    def test_verify_signature_rejects_identity_point_forgery(self):
+        """The canonical Ed25519 forgery against the identity public key:
+        sig = identity_pub || 0^32 verifies on every message under permissive
+        RFC-8032 verifiers. This is the worst-case attack — full signature
+        forgery without holding any private key. The central guard inside
+        DMPCrypto.verify_signature must reject it before .verify() runs.
+        """
+        identity_pub = bytes.fromhex(self._IDENTITY_POINT_HEX)
+        forgery_sig = identity_pub + b"\x00" * 32
+        # Must be rejected against any message — pick a few representative
+        # payloads to make the "every message" property visible in the test.
+        for msg in (b"", b"forgery target", b"\x00" * 1024, os.urandom(64)):
+            assert not DMPCrypto.verify_signature(msg, forgery_sig, identity_pub), (
+                f"identity-point forgery accepted on message of len {len(msg)}"
+            )
+
+    def test_verify_signature_rejects_low_order_vectors_bytes(self):
+        """Each known low-order encoding must be rejected when passed as raw
+        bytes, regardless of signature shape. Uses independent hard-coded
+        vectors so an accidental deletion from the production block list
+        would not silently disable this check.
+        """
+        msg = b"forgery target"
+        forgery_sig = bytes.fromhex(self._IDENTITY_POINT_HEX) + b"\x00" * 32
+        zero_sig = b"\x00" * 64
+        for hex_pub in self._LOW_ORDER_VECTORS:
+            pub_bytes = bytes.fromhex(hex_pub)
+            assert not DMPCrypto.verify_signature(msg, forgery_sig, pub_bytes), (
+                f"low-order pubkey {hex_pub} accepted with identity-forgery sig"
+            )
+            assert not DMPCrypto.verify_signature(msg, zero_sig, pub_bytes), (
+                f"low-order pubkey {hex_pub} accepted with zero sig"
+            )
+
+    def test_verify_signature_rejects_low_order_vectors_instance(self):
+        """Same rejection when an Ed25519PublicKey instance is passed instead
+        of raw bytes. Callers that cache parsed keys must not bypass the guard.
+        """
+        msg = b"forgery target"
+        forgery_sig = bytes.fromhex(self._IDENTITY_POINT_HEX) + b"\x00" * 32
+        for hex_pub in self._LOW_ORDER_VECTORS:
+            pub_bytes = bytes.fromhex(hex_pub)
+            try:
+                pk_instance = Ed25519PublicKey.from_public_bytes(pub_bytes)
+            except Exception:
+                # Some non-canonical encodings are rejected at construction
+                # time by the underlying library; the bytes-form test above
+                # already exercises those.
+                continue
+            assert not DMPCrypto.verify_signature(msg, forgery_sig, pk_instance), (
+                f"low-order pubkey instance {hex_pub} accepted"
+            )
+
+    def test_verify_signature_block_list_includes_all_known_vectors(self):
+        """The independent vector list MUST be a subset of the production
+        block list. If this test fails, the production list has lost an entry
+        that this test still expects to be rejected — investigate before
+        adding/removing vectors on either side.
+        """
+        for hex_pub in self._LOW_ORDER_VECTORS:
+            pub_bytes = bytes.fromhex(hex_pub)
+            assert pub_bytes in LOW_ORDER_ED25519_PUBKEYS, (
+                f"vector {hex_pub} missing from LOW_ORDER_ED25519_PUBKEYS"
+            )
+
+    def test_verify_signature_wrong_length_pubkey_rejected(self):
+        """Defense in depth: bytes pubkeys of the wrong length must fail
+        closed rather than raising or being silently coerced."""
+        data = b"x"
+        sig = b"\x00" * 64
+        assert not DMPCrypto.verify_signature(data, sig, b"\x00" * 31)
+        assert not DMPCrypto.verify_signature(data, sig, b"\x00" * 33)
+        assert not DMPCrypto.verify_signature(data, sig, b"")
 
     def test_signing_key_deterministic_from_passphrase(self):
         """Same passphrase produces the same Ed25519 signing key."""


### PR DESCRIPTION
## Summary

P0-1 from the security audit: centralize Ed25519 low-order / small-subgroup public-key rejection inside `DMPCrypto.verify_signature` so every signature-verification call path inherits the guard automatically.

The block list at `dmp.core.ed25519_points` was previously enforced inline at only 4 of 11 Ed25519-verification call sites. The remaining 7 — `bootstrap.py`, `cluster.py`, `identity.py`, `manifest.py`, `prekeys.py`, and 3 in `rotation.py` — relied on the (incorrect) assumption that the underlying `cryptography` library rejects these encodings. It doesn't: with the identity point as `A` and `sig = identity || 0^32`, the permissive RFC-8032 verify accepts every message — full signature forgery without holding any private key.

## Changes

- **`dmp/core/crypto.py`** — `verify_signature` now checks both raw 32-byte input and `Ed25519PublicKey` instances against the block list before delegating to `.verify()`. Instance form extracts raw bytes via `public_bytes(Raw, Raw)` to run the same check.
- **`dmp/server/registration.py`** — replaced two direct `Ed25519PublicKey.from_public_bytes(...).verify(...)` calls (confirm + bind handlers) with `DMPCrypto.verify_signature`. Removed redundant inline block-list checks and the now-unused `InvalidSignature` / `Ed25519PublicKey` / `LOW_ORDER_ED25519_PUBKEYS` imports.
- **`dmp/core/claim.py`, `dmp/core/heartbeat.py`** — removed redundant inline `is_low_order` checks now that the central path covers them. Mixed inline-vs-central is the worst of both for future readers.
- **`tests/test_crypto.py`** — five stronger tests replace the three originally added:
  - Independent hard-coded low-order vectors (not derived from `LOW_ORDER_ED25519_PUBKEYS`) so accidental deletion from the production set cannot silently disable test coverage.
  - Actual documented identity-point forgery signature (`identity_pub || 0^32`, not just `b"\x00"*64`) tested against multiple message lengths to make the "every message" property visible.
  - Block-list-includes-known-vectors sanity check.

## Validation

- **Mutation test:** with the central guard removed, the three forgery tests fail as expected; with the guard in place, all pass. Confirms the tests aren't false-positives.
- **Full suite:** 1453 passed, 9 skipped (pre-existing). Net +2 tests vs. baseline.
- **Coverage check:** `grep` confirms zero direct `Ed25519PublicKey.verify()` call sites remain in `dmp/`. The only `.verify()` call left is inside the centralized guard at `crypto.py:305`.
- **Codex review:** PASS post-revisions. Initial verdict was NEEDS-WORK on `registration.py` centralization and test strength; both addressed in this PR.

## Test plan

- [ ] CI passes `pytest tests/`
- [ ] Verify no test imports the production `LOW_ORDER_ED25519_PUBKEYS` set in a way that could mask coverage gaps
- [ ] Spot-check one consumer (e.g. claim.py) still rejects a forged manifest with an identity-point sender_spk