### PR TITLE
fix(replay): atomic claim/finalize/release on ReplayCache to close TOCTOU race

### DIFF
--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -987,17 +987,26 @@ class DMPClient:
                     # identical behavior.
                     elif self._rotation_manifest_revoked(manifest.sender_spk):
                         continue
-                    # Check-only here; we record in the replay cache *after*
-                    # we actually decode the message. Otherwise a transient
-                    # DNS miss during chunk fetch would permanently suppress
-                    # a still-valid manifest on later polls.
-                    if self.replay_cache.has_seen(manifest.sender_spk, manifest.msg_id):
+                    # Atomic claim across the decrypt window: only one worker
+                    # can decrypt+deliver a given (sender_spk, msg_id) pair.
+                    # claim_for_decode returns False if the slot is already
+                    # in `seen` or held by another worker's still-fresh
+                    # in-flight claim. release() frees the slot on transient
+                    # decrypt failure so a later poll can retry; finalize()
+                    # promotes it to `seen` on success. The previous
+                    # has_seen → decrypt → record sequence let two
+                    # concurrent receive workers double-deliver the same
+                    # message.
+                    if not self.replay_cache.claim_for_decode(
+                        manifest.sender_spk, manifest.msg_id, manifest.exp
+                    ):
                         continue
                     decoded = self._fetch_and_decrypt(manifest, source_zone=zone)
                     if decoded is None:
+                        self.replay_cache.release(manifest.sender_spk, manifest.msg_id)
                         continue
                     plaintext, ts, msg_id = decoded
-                    self.replay_cache.record(
+                    self.replay_cache.finalize(
                         manifest.sender_spk, manifest.msg_id, manifest.exp
                     )
                     results.append(
@@ -1304,17 +1313,25 @@ class DMPClient:
                     if self._rotation_manifest_revoked(manifest.sender_spk):
                         _drop("revoked")
                         continue
+                    # Atomic claim across decrypt — same race-prevention as
+                    # receive_messages. The has_seen check above is a fast-
+                    # path skip to avoid the manifest+chunk fetch cost; this
+                    # is the actual concurrency gate. A loser of the race
+                    # gets False and skips without re-delivering.
+                    if not self.replay_cache.claim_for_decode(
+                        manifest.sender_spk, manifest.msg_id, manifest.exp
+                    ):
+                        _drop("replay")
+                        continue
                     decoded = self._fetch_and_decrypt(
                         manifest, source_zone=claim.sender_mailbox_domain
                     )
                     if decoded is None:
+                        self.replay_cache.release(manifest.sender_spk, manifest.msg_id)
                         _drop("decrypt-failed")
                         continue
                     plaintext, ts, msg_id = decoded
-                    # Record in replay cache only after successful
-                    # decrypt — a transient chunk fetch miss must not
-                    # permanently suppress this claim.
-                    self.replay_cache.record(
+                    self.replay_cache.finalize(
                         manifest.sender_spk, manifest.msg_id, manifest.exp
                     )
 

--- a/dmp/core/manifest.py
+++ b/dmp/core/manifest.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Tuple
@@ -180,27 +181,59 @@ class SlotManifest:
 class ReplayCache:
     """Reject re-publication of already-seen (sender_spk, msg_id) pairs.
 
-    Split API:
-      has_seen(spk, msg_id)  — read-only check; safe to call before fetch.
-      record(spk, msg_id, exp) — commit the pair to the seen set.
+    Atomic claim/finalize/release API for the receive path:
+      claim_for_decode(spk, msg_id, exp) — returns True if the caller now
+        owns the (spk, msg_id) slot; False if it is already in `seen` or
+        another worker holds an in-flight claim within the TTL. On True the
+        caller MUST follow up with either:
+          finalize(spk, msg_id, exp) — promote the slot to `seen` after a
+            successful decrypt+deliver.
+          release(spk, msg_id) — free the slot after a transient decrypt
+            failure (DNS miss, malformed ciphertext, etc.) so a later poll
+            can retry.
 
-    The caller is responsible for only calling `record()` once a message has
-    been successfully decoded, so a transient DNS miss during chunk fetch
-    doesn't permanently blacklist a valid manifest.
+    Why a separate in-flight set instead of just check-and-record on entry:
+    a transient chunk-fetch miss must not permanently blacklist a still-valid
+    manifest. The split lets the caller hold the slot only for the duration
+    of the actual decrypt attempt.
 
-    Optionally persists to disk at `persist_path`. Each `record()` rewrites
-    the file atomically (write to `<path>.tmp`, rename into place) so a
-    crash mid-write leaves either the old or the new state, never a torn
-    file. If `persist_path` is None the cache is purely in-memory and
-    resets on process restart.
+    Why this matters: the previous split-API
+      `if has_seen(): skip; decrypt(); record()` is non-atomic. Two
+    concurrent workers (threads, async loops, or repeated calls to
+    receive_messages) can both pass the has_seen gate, both decrypt the
+    same message, and both deliver the same plaintext to the inbox.
 
-    Format: JSON array of `[sender_spk_hex, msg_id_hex, expiry_unix]`.
-    Expired entries are dropped on load, on every query, and on every record.
+    Legacy single-step `check_and_record(...)` is kept for callers that
+    don't have a separate decrypt phase; they get the atomic seen-set
+    update without using the in-flight set.
+
+    Concurrency: a single `threading.RLock` covers seen, in_flight, and the
+    persistence file write. Within-process workers are serialized; cross-
+    process safety relies on the atomic `os.replace` (last writer wins).
+
+    Crashed-worker recovery: in-flight claims older than
+    `in_flight_ttl_seconds` are reclaimed on the next `claim_for_decode`,
+    so a worker that crashed between claim and finalize/release does not
+    permanently block the slot.
+
+    Persistence: optional, at `persist_path`. Only `seen` is persisted —
+    in-flight claims are intentionally in-memory only (process restart
+    clears them). Each finalize/record rewrites the file atomically
+    (`<path>.tmp` → rename). Format: JSON array of
+    `[sender_spk_hex, msg_id_hex, expiry_unix]`. Expired entries are
+    dropped on load, on every query, and on every write.
     """
 
     default_ttl: int = 3600
     persist_path: Optional[str] = None
+    in_flight_ttl_seconds: int = 300
     _seen: Dict[Tuple[bytes, bytes], int] = field(default_factory=dict)
+    _in_flight: Dict[Tuple[bytes, bytes], int] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _lock: threading.RLock = field(
+        default_factory=threading.RLock, init=False, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         if self.persist_path:
@@ -232,6 +265,7 @@ class ReplayCache:
         self._seen = loaded
 
     def _save(self) -> None:
+        # Caller holds _lock. Only `seen` persists; in-flight is in-memory.
         if not self.persist_path:
             return
         data = [[spk.hex(), mid.hex(), exp] for (spk, mid), exp in self._seen.items()]
@@ -245,8 +279,9 @@ class ReplayCache:
     # ---- public API --------------------------------------------------------
 
     def has_seen(self, sender_spk: bytes, msg_id: bytes) -> bool:
-        self._purge()
-        return (bytes(sender_spk), bytes(msg_id)) in self._seen
+        with self._lock:
+            self._purge()
+            return (bytes(sender_spk), bytes(msg_id)) in self._seen
 
     def record(
         self,
@@ -254,12 +289,14 @@ class ReplayCache:
         msg_id: bytes,
         expiry: Optional[int] = None,
     ) -> None:
-        self._purge()
-        key = (bytes(sender_spk), bytes(msg_id))
-        self._seen[key] = (
-            expiry if expiry is not None else int(time.time()) + self.default_ttl
-        )
-        self._save()
+        with self._lock:
+            self._purge()
+            key = (bytes(sender_spk), bytes(msg_id))
+            self._seen[key] = (
+                expiry if expiry is not None else int(time.time()) + self.default_ttl
+            )
+            self._in_flight.pop(key, None)
+            self._save()
 
     def check_and_record(
         self,
@@ -267,19 +304,74 @@ class ReplayCache:
         msg_id: bytes,
         expiry: Optional[int] = None,
     ) -> bool:
-        """Atomically check-then-record.
+        """Atomically check-then-record without using the in-flight set.
 
         Returns True if the pair is fresh (and records it); False on replay.
-        Kept for callers that genuinely want the old single-step semantics.
-        New code should prefer `has_seen` + `record` around the work that
-        proves the message was actually delivered.
+        For receive paths that have a distinct decrypt phase, prefer
+        `claim_for_decode` + `finalize` / `release` so a transient decrypt
+        failure does not permanently consume the slot.
         """
-        if self.has_seen(sender_spk, msg_id):
-            return False
+        with self._lock:
+            if self.has_seen(sender_spk, msg_id):
+                return False
+            self.record(sender_spk, msg_id, expiry)
+            return True
+
+    def claim_for_decode(
+        self,
+        sender_spk: bytes,
+        msg_id: bytes,
+        expiry: Optional[int] = None,
+    ) -> bool:
+        """Atomically reserve a slot for a decrypt attempt.
+
+        Returns True iff this caller now owns the (sender_spk, msg_id)
+        slot — neither in the seen set nor held by another worker's still-
+        fresh in-flight claim. Caller MUST follow with `finalize(...)` on
+        successful decrypt or `release(...)` on failure.
+
+        Stale in-flight claims older than `in_flight_ttl_seconds` are
+        reclaimed here so a crashed worker does not permanently block the
+        slot.
+        """
+        with self._lock:
+            self._purge()
+            self._purge_stale_in_flight()
+            key = (bytes(sender_spk), bytes(msg_id))
+            if key in self._seen or key in self._in_flight:
+                return False
+            self._in_flight[key] = int(time.time())
+            return True
+
+    def finalize(
+        self,
+        sender_spk: bytes,
+        msg_id: bytes,
+        expiry: Optional[int] = None,
+    ) -> None:
+        """Promote an in-flight claim to seen. Pairs with claim_for_decode."""
         self.record(sender_spk, msg_id, expiry)
-        return True
+
+    def release(self, sender_spk: bytes, msg_id: bytes) -> None:
+        """Release an in-flight claim without recording it as seen.
+
+        Used when decrypt fails so a later poll can retry the same slot.
+        Idempotent: releasing an already-released or never-claimed slot
+        is a no-op.
+        """
+        with self._lock:
+            key = (bytes(sender_spk), bytes(msg_id))
+            self._in_flight.pop(key, None)
+
+    def _purge_stale_in_flight(self) -> None:
+        # Caller holds _lock.
+        cutoff = int(time.time()) - self.in_flight_ttl_seconds
+        stale = [k for k, claimed_at in self._in_flight.items() if claimed_at < cutoff]
+        for k in stale:
+            self._in_flight.pop(k, None)
 
     def _purge(self) -> None:
+        # Caller holds _lock.
         now = int(time.time())
         expired = [k for k, exp in self._seen.items() if now > exp]
         if not expired:
@@ -289,5 +381,6 @@ class ReplayCache:
         self._save()
 
     def size(self) -> int:
-        self._purge()
-        return len(self._seen)
+        with self._lock:
+            self._purge()
+            return len(self._seen)

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -588,3 +588,99 @@ def test_container_rotation_compromise_revokes_old_key(node_container):
         SUBJECT_TYPE_USER_IDENTITY,
     )
     assert resolved is None
+
+
+def test_container_concurrent_receive_delivers_exactly_once(node_container):
+    """Atomic claim_for_decode prevents duplicate delivery under concurrent
+    receive workers (P0-2).
+
+    Setup: alice sends ONE message via a real dnsmesh-node container. Bob
+    has a single DMPClient (one shared in-memory ReplayCache) and spawns
+    16 threads that all call receive_messages() simultaneously against the
+    same DNS+HTTP backend.
+
+    Without the atomic claim/finalize/release on ReplayCache, all 16
+    threads pass `has_seen` (still False), all 16 fetch+decrypt, all 16
+    append the same plaintext to their result list, and the user observes
+    duplicate delivery. With the fix, exactly one thread wins the
+    claim_for_decode race and the rest see False and skip without
+    decrypting.
+
+    This is the end-to-end equivalent of the unit test
+    test_concurrent_claims_only_one_wins, but exercises the real
+    receive_messages pipeline (DNS query, manifest verify, chunk fetch,
+    AEAD decrypt) against a real container — proves the wiring at the
+    call site in client.py is correct, not just the ReplayCache primitive.
+    """
+    import threading
+
+    from dmp.client.client import DMPClient
+
+    writer = _HttpWriter(node_container["http_base"])
+    reader = _DnsReader("127.0.0.1", node_container["dns_port"])
+
+    alice = DMPClient(
+        "alice-conc",
+        "alice-conc-pass",
+        domain="mesh.docker",
+        writer=writer,
+        reader=reader,
+    )
+    bob = DMPClient(
+        "bob-conc",
+        "bob-conc-pass",
+        domain="mesh.docker",
+        writer=writer,
+        reader=reader,
+    )
+    alice.add_contact("bob-conc", bob.get_public_key_hex())
+
+    # Single message — exactly-once delivery is the property under test.
+    payload = "concurrent-receive payload for the race test"
+    payload_bytes = payload.encode("utf-8")
+    assert alice.send_message("bob-conc", payload)
+
+    # Confirm a single-threaded receive sees the message before we race —
+    # otherwise a "0 winners" outcome could be misread as the property
+    # holding when in fact the message just isn't there.
+    sanity = bob.receive_messages()
+    assert len(sanity) == 1, "sanity precheck: single-threaded recv saw nothing"
+    assert sanity[0].plaintext == payload_bytes
+    # That receive consumed the slot; re-publish to give the race something
+    # to fight over.
+    assert alice.send_message("bob-conc", payload)
+
+    results: list = []
+    results_lock = threading.Lock()
+    start = threading.Event()
+    errors: list = []
+
+    def worker():
+        start.wait()
+        try:
+            inbox = bob.receive_messages()
+        except Exception as exc:  # bubble unexpected exceptions to the test
+            with results_lock:
+                errors.append(exc)
+            return
+        with results_lock:
+            results.extend(inbox)
+
+    threads = [threading.Thread(target=worker) for _ in range(16)]
+    for t in threads:
+        t.start()
+    start.set()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not errors, f"workers raised: {errors}"
+    # Total delivered messages across ALL threads must be exactly 1, even
+    # though 16 threads raced to the same (sender_spk, msg_id).
+    delivered_payloads = [m.plaintext for m in results]
+    assert len(delivered_payloads) == 1, (
+        f"duplicate delivery: 16 concurrent receivers produced "
+        f"{len(delivered_payloads)} messages (expected 1)"
+    )
+    assert delivered_payloads[0] == payload_bytes
+    # The seen set should now contain exactly the one (spk, msg_id).
+    assert bob.replay_cache.size() == 2  # the precheck-delivered + the raced one

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -161,6 +161,117 @@ class TestReplayCache:
         assert cache.size() == 2
 
 
+class TestReplayCacheClaim:
+    """Atomic claim/finalize/release prevents two concurrent receive workers
+    from both decrypting and delivering the same (sender_spk, msg_id) pair.
+    The previous split-API (`has_seen` -> decrypt -> `record`) had a TOCTOU
+    window during the decrypt phase. claim_for_decode closes that window.
+    """
+
+    def test_claim_first_caller_wins(self):
+        cache = ReplayCache()
+        spk, mid = b"A" * 32, b"M" * 16
+        assert cache.claim_for_decode(spk, mid) is True
+        assert cache.claim_for_decode(spk, mid) is False
+
+    def test_claim_then_finalize_blocks_future_claims(self):
+        cache = ReplayCache()
+        spk, mid = b"A" * 32, b"M" * 16
+        assert cache.claim_for_decode(spk, mid) is True
+        cache.finalize(spk, mid, expiry=int(time.time()) + 300)
+        # Now in `seen`; no further claim possible regardless of in-flight.
+        assert cache.has_seen(spk, mid)
+        assert cache.claim_for_decode(spk, mid) is False
+
+    def test_release_frees_slot_for_retry(self):
+        """Decrypt failure releases the slot so a later poll can retry the
+        same manifest — the whole point of the in-flight split is to avoid
+        permanent blacklisting on transient errors."""
+        cache = ReplayCache()
+        spk, mid = b"A" * 32, b"M" * 16
+        assert cache.claim_for_decode(spk, mid) is True
+        cache.release(spk, mid)
+        # Slot is free again; a retry can claim it.
+        assert cache.claim_for_decode(spk, mid) is True
+        assert not cache.has_seen(spk, mid)
+
+    def test_release_is_idempotent(self):
+        cache = ReplayCache()
+        spk, mid = b"A" * 32, b"M" * 16
+        # No prior claim — release is a no-op, no exception.
+        cache.release(spk, mid)
+        cache.claim_for_decode(spk, mid)
+        cache.release(spk, mid)
+        cache.release(spk, mid)  # double-release is fine.
+
+    def test_stale_in_flight_claim_reclaimed_after_ttl(self):
+        """Worker that crashes between claim and finalize/release would
+        otherwise block the slot forever. claim_for_decode purges in-flight
+        entries older than in_flight_ttl_seconds so the slot is reusable."""
+        cache = ReplayCache(in_flight_ttl_seconds=1)
+        spk, mid = b"A" * 32, b"M" * 16
+        assert cache.claim_for_decode(spk, mid) is True
+        # Backdate the claim past the TTL.
+        cache._in_flight[(spk, mid)] = int(time.time()) - 10
+        # Next claim purges stale entries and succeeds.
+        assert cache.claim_for_decode(spk, mid) is True
+
+    def test_concurrent_claims_only_one_wins(self):
+        """Real-thread concurrency test: 16 threads race to claim the same
+        (spk, msg_id) pair. Exactly one must win; the rest must observe
+        False. Without the lock + in-flight check, multiple workers would
+        all see has_seen=False and proceed to decrypt+deliver in parallel.
+        """
+        import threading
+
+        cache = ReplayCache()
+        spk, mid = b"A" * 32, b"M" * 16
+        winners = []
+        winners_lock = threading.Lock()
+        start = threading.Event()
+
+        def worker():
+            start.wait()
+            if cache.claim_for_decode(spk, mid):
+                with winners_lock:
+                    winners.append(threading.get_ident())
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join()
+
+        assert (
+            len(winners) == 1
+        ), f"expected exactly one winner of the claim race, got {len(winners)}"
+
+    def test_in_flight_does_not_persist_across_instances(self, tmp_path):
+        """Persistence covers `seen` only. In-flight claims are intentionally
+        in-memory: a process restart should not leave a slot blocked
+        forever just because the previous process held an in-flight claim
+        when it died."""
+        path = str(tmp_path / "replay.json")
+        c1 = ReplayCache(persist_path=path)
+        spk, mid = b"A" * 32, b"M" * 16
+        assert c1.claim_for_decode(spk, mid) is True
+        # Simulate process restart — same path, fresh instance.
+        c2 = ReplayCache(persist_path=path)
+        assert c2.claim_for_decode(spk, mid) is True
+        assert not c2.has_seen(spk, mid)
+
+    def test_finalize_persists_to_seen(self, tmp_path):
+        path = str(tmp_path / "replay.json")
+        c1 = ReplayCache(persist_path=path)
+        spk, mid = b"A" * 32, b"M" * 16
+        assert c1.claim_for_decode(spk, mid) is True
+        c1.finalize(spk, mid, expiry=int(time.time()) + 300)
+        # New instance reads `seen` from disk; the slot stays blocked.
+        c2 = ReplayCache(persist_path=path)
+        assert c2.has_seen(spk, mid)
+
+
 class TestReplayCachePersistence:
     def test_record_persists_across_instances(self, tmp_path):
         path = str(tmp_path / "replay.json")


### PR DESCRIPTION
## Summary

P0-2 from the security audit. `receive_messages` and `receive_claims` previously had a TOCTOU window where two concurrent receive workers could both pass `has_seen`, both decrypt, and both deliver the same plaintext to the inbox.

```python
# Before — non-atomic
if self.replay_cache.has_seen(spk, msg_id): continue
decoded = self._fetch_and_decrypt(...)            # race window
if decoded is None: continue
self.replay_cache.record(spk, msg_id, exp)
```

This PR introduces a separate `in_flight` set on `ReplayCache` and a `claim_for_decode` / `finalize` / `release` API that closes the window without sacrificing the original transient-failure resilience (a single chunk-fetch miss must not permanently blacklist a still-valid manifest).

```python
# After — atomic
if not self.replay_cache.claim_for_decode(spk, msg_id, exp): continue
decoded = self._fetch_and_decrypt(...)
if decoded is None:
    self.replay_cache.release(spk, msg_id)        # retry-friendly
    continue
self.replay_cache.finalize(spk, msg_id, exp)      # promotes to seen
```

## Changes

- **`dmp/core/manifest.py`** — `ReplayCache` gets `_in_flight`, `threading.RLock`, the three new methods, and a stale-claim TTL purge (default 300s) so a crashed worker doesn't permanently block the slot. `has_seen`, `record`, `check_and_record`, `_purge`, `size` all acquire the lock; existing semantics unchanged.
- **`dmp/client/client.py`** — `receive_messages` (~L994) and `receive_claims` (~L1318) swap `has_seen → record` for `claim_for_decode → finalize` with `release` on transient decrypt failure. The cheap `has_seen` at the top of `receive_claims` stays as a fast-path skip to avoid the manifest+chunk fetch cost on the common case.
- **`tests/test_manifest.py`** — `TestReplayCacheClaim` covers: single-caller win, finalize→seen transition, release→retry, idempotent release, stale-TTL reclaim, 16-thread concurrent claim race, no-persist for in_flight across instances, persist for finalize.
- **`tests/test_docker_integration.py`** — `test_container_concurrent_receive_delivers_exactly_once` boots a real `dnsmesh-node` container and runs 16 concurrent `bob.receive_messages()` threads against the same `Client` after alice sends one message. Verifies exactly-once delivery through the real DNS + chunk-fetch + AEAD pipeline.

## Validation

- **Mutation test (unit):** removing the `in_flight` check from `claim_for_decode` produces 16 winners in `test_concurrent_claims_only_one_wins`. With fix restored, exactly 1 winner.
- **Mutation test (docker e2e):** same mutation against a real container produces **16 duplicate deliveries** of one message. With fix restored, exactly 1 delivery. End-to-end validation that the fix matters at the wire path level, not just the primitive.
- **Full suite:** 1471 passed (was 1462 pre-P0-2). All 9 previously-docker-skipped tests now run too.
- **Codex review:** attempted but the codex CLI hung silently on three retry attempts with the long prompt; falling back to docker-based e2e validation as the equivalent independent signal.

## Out of scope (tracked separately)

- **Cross-process atomicity** — the lock is in-process only. Two CLI invocations sharing a `persist_path` can still race on the JSON file (last-writer-wins). P0-3 in the audit plan moves the cache to SQLite for cross-process atomicity.

## Test plan

- [ ] CI passes `pytest tests/`
- [ ] Lint: `black --check dmp tests`
- [ ] Spot-check the docker e2e under load: `pytest tests/test_docker_integration.py::test_container_concurrent_receive_delivers_exactly_once -v`