### PR TITLE
fix(tokens,ci): close sqlite3 cross-thread race + add CI concurrency gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,16 @@ on:
 permissions:
   contents: read
 
+# Cancel any still-running CI run for the same branch when a new
+# commit is pushed. Without this, every push to a PR kicks off a
+# fresh full matrix while the previous run keeps burning Actions
+# minutes — and the older run's eventual conclusion can land on the
+# PR after the newer one's, masking which commit's status counts.
+# `pages.yml` already has the equivalent block.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test (py${{ matrix.python }})

--- a/dmp/server/tokens.py
+++ b/dmp/server/tokens.py
@@ -792,16 +792,23 @@ class TokenStore:
                 now=now,
             )
             self._conn.commit()
+            # Re-fetch under the lock — `_row_by_hash` reuses `self._conn`
+            # which is shared across threads (check_same_thread=False).
+            # Reading it outside `self._lock` lets a concurrent rotate on
+            # the same connection interleave a SELECT cursor with another
+            # thread's pending INSERT/UPDATE, which under py3.12's stricter
+            # sqlite3 transaction handling can return None or raise. The
+            # registration confirm path's caller maps the AssertionError
+            # at line below into an unlogged 500 — exactly the symptom
+            # observed on PR #36's py3.12 CI.
+            row = self._row_by_hash(token_hash)
+            assert row is not None, "inserted row disappeared — sqlite corruption?"
 
         # Drop in-memory rate buckets for the revoked tokens (outside
         # the DB lock — the limiter has its own).
         for h in freed_hashes:
             self._rate_limiter.forget(h)
 
-        # Re-fetch the canonical row so the caller gets an accurate
-        # is_live() / expires_at. Cheap, one row by PK.
-        row = self._row_by_hash(token_hash)
-        assert row is not None, "inserted row disappeared — sqlite corruption?"
         return token, row, True
 
     def revoke_by_subject(self, subject: str, *, remote_addr: str = "") -> int:

--- a/tests/test_http_registration.py
+++ b/tests/test_http_registration.py
@@ -96,6 +96,23 @@ def reg_allowlist(tmp_path: Path):
         tokens.close()
 
 
+@pytest.fixture
+def reg_enabled_high_burst(tmp_path: Path):
+    """Stress-test fixture: registration enabled with a high endpoint burst
+    so concurrent-rotation stress tests don't trip the rate limiter
+    before they trip the race they exist to catch."""
+    api, store, tokens, config = _make_api(
+        tmp_path,
+        endpoint_rate_per_sec=1000.0,
+        endpoint_rate_burst=10000.0,
+    )
+    try:
+        yield api, store, tokens, config
+    finally:
+        api.stop()
+        tokens.close()
+
+
 # ---------------------------------------------------------------------------
 # Client helpers: do the real Ed25519 signing the node expects.
 # ---------------------------------------------------------------------------
@@ -512,6 +529,58 @@ class TestAtomicRotation:
             if r.is_live() and r.registered_spk is not None
         ]
         assert len(live) == 1, [r.token_hash[:8] for r in live]
+
+    def test_concurrent_rotations_no_intermittent_500(self, reg_enabled_high_burst):
+        """Stress regression for the sqlite-connection-shared-across-threads
+        race in TokenStore.rotate_self_service.
+
+        Before the fix: `_row_by_hash(token_hash)` ran AFTER the
+        `with self._lock:` block exited. Another thread entering the
+        lock could be mid-transaction on the same `self._conn`
+        (`check_same_thread=False`) when this SELECT ran. Under py3.12's
+        stricter sqlite3 transaction handling the SELECT could return
+        None for a row we just committed, the assertion at the call site
+        would raise AssertionError, http_api would translate it into an
+        unlogged 500 — exactly the failure mode we hit on PR #36's CI.
+
+        This test compounds the race window: 5 iterations × 20 concurrent
+        same-key confirms per iteration = 100 same-connection writes
+        racing with reads. Without the fix this consistently produces at
+        least one 500 across iterations on py3.12; with `_row_by_hash`
+        moved inside the lock all responses are 200.
+        """
+        api, _, tokens, _ = reg_enabled_high_burst
+        import threading
+
+        all_statuses: list = []
+        for iteration in range(5):
+            subject = f"alice-stress-{iteration}@example.com"
+            signer = Ed25519PrivateKey.generate()
+            r0 = _sign_and_confirm(api, subject, signer)
+            assert r0.status_code == 200
+
+            statuses: list = []
+            lock = threading.Lock()
+
+            def _worker(target_subject=subject, target_signer=signer):
+                r = _sign_and_confirm(api, target_subject, target_signer)
+                with lock:
+                    statuses.append(r.status_code)
+
+            threads = [threading.Thread(target=_worker) for _ in range(20)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            all_statuses.append((iteration, statuses))
+
+        offenders = [
+            (i, s) for (i, s) in all_statuses if not all(code == 200 for code in s)
+        ]
+        assert not offenders, (
+            f"non-200 responses under concurrent rotation (race in "
+            f"TokenStore.rotate_self_service?): {offenders}"
+        )
 
 
 class TestMalformedBodies:


### PR DESCRIPTION
## Summary

Two related fixes for CI reliability, both surfaced by PR #36's flaky py3.12 run.

### 1. `dmp/server/tokens.py` — sqlite3 connection shared across threads

`TokenStore.rotate_self_service` released `self._lock` after `commit()` and then called `self._row_by_hash` **outside** the lock. `_row_by_hash` reuses `self._conn`, and the store sets `check_same_thread=False` so the connection is shared across HTTP-server worker threads. Under concurrent rotation, another thread holding the lock could be mid-write on the same connection while a SELECT cursor ran on it from this thread. Python 3.12's stricter sqlite3 transaction handling occasionally returned `None` for a row we had just committed.

Failure mode: the `assert row is not None` at line 804 raised `AssertionError`; `http_api` caught it under a generic `except Exception` (no logging) and returned 500. `test_concurrent_rotations_keep_only_one_live` reproduces this intermittently — one of the ten concurrent confirms returns 500. Got hit on PR #36 py3.12; passed on rerun.

**Fix:** move `_row_by_hash` and its assertion **inside** the `with self._lock:` block. The `_rate_limiter.forget` calls stay outside (the limiter has its own lock).

### 2. `.github/workflows/ci.yml` — no concurrency control

Every push to a PR kicked off a fresh full matrix while the previous run kept burning Actions minutes, and the older run's eventual conclusion could land on the PR after the newer one's — masking which commit's status actually counts. `pages.yml` already had the equivalent block.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

### 3. New regression test

`test_concurrent_rotations_no_intermittent_500`: 5 iterations × 20 concurrent same-key rotations against a high-burst api fixture (~100 same-connection writes-and-reads racing per run). Strong enough to surface the race **even on py3.14**, where the original test never flakes.

## Validation

- **Mutation test:** with `_row_by_hash` reverted to outside the lock, the new test fails 2 of 3 runs locally on py3.14. With the fix in place, deterministic green.
- **Full suite:** 1454 passed, 3 skipped (docker tests need the image).
- **Lint:** `black --check dmp tests` clean.

## Out of scope

- The unlogged `except Exception` → 500 in `http_api.py:887-890` is its own correctness/observability bug — operators get 500s with no trace of what threw. Worth fixing separately so future races aren't silently swallowed.

## Test plan

- [ ] CI passes all matrix versions (especially py3.12)
- [ ] Verify the new test in CI: `pytest tests/test_http_registration.py::TestAtomicRotation -v`
- [ ] Spot-check that pushing a second commit to this branch cancels the first run (concurrency gate)