### PR TITLE
fix(client,cli): require explicit opt-in for TOFU first-contact delivery

### DIFF
--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -140,6 +140,16 @@ class CLIConfig:
     # `_make_client` call. Updated by `dnsmesh identity rotate`.
     verify_pubkey: str = ""
 
+    # P0-3 — first-contact / TOFU opt-in. When False (default), the
+    # slot-walk receive path drops every signature-valid manifest if
+    # the operator has zero pinned signing keys. Set True via
+    # ``dnsmesh init --allow-tofu`` (or by editing the config) to opt
+    # back into the legacy "deliver any signature-valid manifest until
+    # you pin someone" behavior. Useful for fresh onboarding; risky
+    # for any client whose DNS path can be spoofed before the user
+    # has pinned a contact.
+    allow_tofu: bool = False
+
     # M8.3 — claim-provider override. When non-empty, send/recv use
     # this single endpoint as the claim provider, skipping seen-feed
     # ranking. Use case: pin all first-contact reach through a known
@@ -251,6 +261,10 @@ class CLIConfig:
             kdf_salt=data.get("kdf_salt", ""),
             verify_pubkey=data.get("verify_pubkey", "") or "",
             identity_domain=data.get("identity_domain", ""),
+            # P0-3 — back-compat: configs predating the TOFU opt-in
+            # default to False (secure default). Operators flip it via
+            # ``dnsmesh init --allow-tofu`` or hand-edit.
+            allow_tofu=bool(data.get("allow_tofu", False)),
             cluster_base_domain=data.get("cluster_base_domain", "") or "",
             cluster_operator_spk=data.get("cluster_operator_spk", "") or "",
             cluster_refresh_interval=int(data.get("cluster_refresh_interval", 3600)),
@@ -991,6 +1005,7 @@ def _make_client(
         kdf_salt=kdf_salt,
         prekey_store_path=prekey_path,
         intro_queue_path=intro_queue_path,
+        allow_tofu=config.allow_tofu,
     )
     # Attach the cluster handle (if any) so the CLI can close it at
     # exit. Setting an attribute on DMPClient after construction is
@@ -1573,6 +1588,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         # minimum (8) and matches our key length.
         kdf_salt=os.urandom(32).hex(),
         identity_domain=(args.identity_domain or "").strip(),
+        allow_tofu=bool(getattr(args, "allow_tofu", False)),
     )
 
     # M10 — auto-probe the local node's DNS endpoint so same-zone
@@ -4707,6 +4723,17 @@ def build_parser() -> argparse.ArgumentParser:
         "is split-host or when init is offline; you can set "
         "local_node_dns_server / local_node_dns_port manually or run "
         "`dnsmesh doctor` later.",
+    )
+    p_init.add_argument(
+        "--allow-tofu",
+        action="store_true",
+        help="Opt into Trust-On-First-Use receive on the slot-walk path. "
+        "Without this, the receiver drops every signature-valid manifest "
+        "when it has zero pinned signing keys (the secure default). With "
+        "it, any signature-valid manifest is delivered until the user "
+        "pins a contact — useful for fresh onboarding, but a real attack "
+        "surface for any client whose DNS path can be spoofed before any "
+        "contact is pinned.",
     )
     p_init.set_defaults(func=cmd_init)
 

--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -245,6 +245,7 @@ class DMPClient:
         prekey_store_path: Optional[str] = None,
         rotation_chain_enabled: bool = False,
         intro_queue_path: Optional[str] = None,
+        allow_tofu: bool = False,
     ):
         if store is not None:
             if writer is None:
@@ -277,6 +278,16 @@ class DMPClient:
         self.prekey_store = PrekeyStore(prekey_store_path or ":memory:")
 
         self.contacts: Dict[str, Contact] = {}
+
+        # First-contact / TOFU opt-in. The slot-walk receive path
+        # (receive_messages) silently delivers any signature-valid manifest
+        # when the receiver has zero pinned signing keys. That is useful
+        # for fresh onboarding but also lets anyone who can spoof DNS to
+        # a pristine client be accepted as the contact. Default False
+        # makes this an explicit opt-in; callers with a real onboarding
+        # flow set ``allow_tofu=True`` (or call ``enable_tofu(...)``) to
+        # accept first-contact deliveries until the user pins someone.
+        self.allow_tofu = allow_tofu
 
         # EXPERIMENTAL (M5.4): rotation-chain walking on verify failure.
         # Default False preserves byte-identical legacy behavior. Wire
@@ -363,9 +374,12 @@ class DMPClient:
         their zone), but ``send_message`` refuses (no ECDH target).
 
         `signing_key_hex` is optional for back-compat with configs that
-        predate Ed25519 pinning. When empty, incoming manifests from any
-        signer will be accepted on first delivery (TOFU); when present,
-        only manifests whose `sender_spk` matches are delivered.
+        predate Ed25519 pinning. When omitted on every contact, the
+        receiver's pinned-signer set is empty and ``receive_messages``
+        drops every manifest by default (TOFU is now opt-in via the
+        ``allow_tofu=True`` constructor flag or ``enable_tofu()``).
+        When present, only manifests whose ``sender_spk`` matches a
+        pinned key are delivered.
         """
         # Allow an empty `public_key_hex` only when the caller has at
         # least pinned a signing key — otherwise this is just a name
@@ -412,6 +426,22 @@ class DMPClient:
         return {
             c.signing_key_bytes for c in self.contacts.values() if c.signing_key_bytes
         }
+
+    def enable_tofu(self) -> None:
+        """Opt back into Trust-On-First-Use delivery on the slot-walk path.
+
+        With no pinned signing keys (``_known_signing_keys()`` empty),
+        ``receive_messages`` would otherwise drop every manifest. Calling
+        this lets an onboarding flow accept first-contact deliveries until
+        the user pins someone. This is symmetric with the constructor
+        ``allow_tofu=True`` flag — useful when the client is constructed
+        before the operator decides whether to allow TOFU.
+        """
+        self.allow_tofu = True
+
+    def disable_tofu(self) -> None:
+        """Disable TOFU delivery (the secure default). Pair with ``enable_tofu``."""
+        self.allow_tofu = False
 
     def _rotation_manifest_revoked(self, sender_spk: bytes) -> bool:
         """EXPERIMENTAL (M5.4): return True iff ``sender_spk`` matches a
@@ -896,10 +926,15 @@ class DMPClient:
 
         Returns the list of newly-delivered messages. Replay-cache rejections,
         signature failures, and manifests from un-pinned senders are silently
-        skipped. If the client has no pinned Ed25519 contacts at all, receive
-        falls back to TOFU and delivers any signature-valid manifest — useful
-        for fresh onboarding, but users should pin contacts before treating
-        delivered messages as authenticated.
+        skipped.
+
+        TOFU semantics: if the client has no pinned Ed25519 contacts at
+        all, the slot-walk path drops every signature-valid manifest by
+        default. Pass ``allow_tofu=True`` to ``DMPClient`` (or call
+        ``enable_tofu()``) to opt back into the legacy "deliver any
+        signature-valid manifest until you pin someone" behavior — useful
+        for fresh onboarding but a real attack surface for any client whose
+        DNS path can be spoofed before the user has pinned a contact.
 
         M10 — two-phase scheduling.
 
@@ -962,21 +997,29 @@ class DMPClient:
                         continue
                     if manifest.is_expired():
                         continue
-                    # If the user has pinned any signing keys, only accept
-                    # manifests from those senders. Unknown signers are dropped.
-                    if known_spks and manifest.sender_spk not in known_spks:
-                        # EXPERIMENTAL (M5.4): if rotation-chain walking is
-                        # enabled, try walking each pinned contact's chain
-                        # forward to see if the manifest's sender_spk is the
-                        # current head of a rotation. A valid walk means the
-                        # contact rotated their identity key; we extend the
-                        # accepted set for this receive pass. If the walk
-                        # fails or aborts (revocation, ambiguity, max_hops),
-                        # the manifest stays dropped. Never modifies
-                        # self.contacts — a rotation-chain walk is a
-                        # per-receive trust decision, not a permanent re-pin.
-                        if not self._rotation_manifest_accepted(manifest.sender_spk):
-                            continue
+                    # Pinned signers gate. Three paths:
+                    #   1) known_spks non-empty + match  → accept (fall through)
+                    #   2) known_spks non-empty + miss   → drop (or rotation walk)
+                    #   3) known_spks EMPTY              → drop unless allow_tofu
+                    #
+                    # Path 3 is the default-deny TOFU gate. The legacy
+                    # behavior was to silently accept any signature-valid
+                    # manifest when the receiver had zero pins, which is
+                    # useful for onboarding but lets anyone spoofing DNS to
+                    # a pristine client get accepted as the contact.
+                    if known_spks:
+                        if manifest.sender_spk not in known_spks:
+                            # EXPERIMENTAL (M5.4): rotation-chain walking on
+                            # verify failure. If a pinned contact rotated to
+                            # a new key, the new key is accepted for this
+                            # receive pass without permanently re-pinning.
+                            # Never modifies self.contacts.
+                            if not self._rotation_manifest_accepted(
+                                manifest.sender_spk
+                            ):
+                                continue
+                    elif not self.allow_tofu:
+                        continue
                     # EXPERIMENTAL (M5.4): cross-check that a PINNED
                     # signing key hasn't itself been revoked. Without this,
                     # a sender who published (rotation A→B) + (revocation of

--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -997,18 +997,29 @@ class DMPClient:
                         continue
                     if manifest.is_expired():
                         continue
-                    # Pinned signers gate. Three paths:
-                    #   1) known_spks non-empty + match  → accept (fall through)
-                    #   2) known_spks non-empty + miss   → drop (or rotation walk)
-                    #   3) known_spks EMPTY              → drop unless allow_tofu
-                    #
-                    # Path 3 is the default-deny TOFU gate. The legacy
-                    # behavior was to silently accept any signature-valid
-                    # manifest when the receiver had zero pins, which is
-                    # useful for onboarding but lets anyone spoofing DNS to
-                    # a pristine client get accepted as the contact.
+                    # Pinned signers gate + revocation check. Cases:
+                    #   1) known_spks non-empty + match → check revocation
+                    #      (a pinned key that was later revoked by its
+                    #      owner via rotate-then-revoke must drop).
+                    #   2) known_spks non-empty + miss → rotation-walk.
+                    #      No revocation check on the new head — that's
+                    #      a different key, and chain-walk acceptance
+                    #      already verified its current trust state.
+                    #   3) known_spks EMPTY + allow_tofu → check revocation
+                    #      (TOFU still respects revoked-by-issuer).
+                    #   4) known_spks EMPTY + not allow_tofu → drop.
+                    #      Default-deny first-contact gate (P0-3).
                     if known_spks:
-                        if manifest.sender_spk not in known_spks:
+                        if manifest.sender_spk in known_spks:
+                            # EXPERIMENTAL (M5.4): a sender who published
+                            # (rotation A→B) + (revocation of A) would
+                            # otherwise have manifests signed by A still
+                            # accepted by every contact that pinned A —
+                            # defeating revocation. Skipped without
+                            # rotation_chain_enabled (legacy behavior).
+                            if self._rotation_manifest_revoked(manifest.sender_spk):
+                                continue
+                        else:
                             # EXPERIMENTAL (M5.4): rotation-chain walking on
                             # verify failure. If a pinned contact rotated to
                             # a new key, the new key is accepted for this
@@ -1020,14 +1031,6 @@ class DMPClient:
                                 continue
                     elif not self.allow_tofu:
                         continue
-                    # EXPERIMENTAL (M5.4): cross-check that a PINNED
-                    # signing key hasn't itself been revoked. Without this,
-                    # a sender who published (rotation A→B) + (revocation of
-                    # A) would still have manifests signed by A accepted by
-                    # every contact that pinned A — defeating the whole
-                    # point of revocation. Only fires when rotation chain
-                    # walking is enabled; legacy clients keep their byte-
-                    # identical behavior.
                     elif self._rotation_manifest_revoked(manifest.sender_spk):
                         continue
                     # Atomic claim across the decrypt window: only one worker

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,7 @@ def shared_store(monkeypatch):
             domain=config.domain,
             store=store,
             replay_cache_path=replay_path,
+            allow_tofu=config.allow_tofu,
         )
         for name, entry in config.contacts.items():
             # Mirror the real _make_client: use the persisted
@@ -1265,7 +1266,11 @@ class TestSendRecv:
         assert rc == 0
         assert "sent" in capsys.readouterr().out
 
-        # Switch "identity" to bob and read.
+        # Switch "identity" to bob and read. Bob has no pinned signing
+        # keys yet (fresh init), so opt into TOFU explicitly to receive
+        # alice's first-contact manifest. Real onboarding flows would
+        # use ``dnsmesh contacts add alice <pub> --signing-key <spk>``
+        # instead.
         cli.main(
             [
                 "init",
@@ -1274,6 +1279,7 @@ class TestSendRecv:
                 "--endpoint",
                 "http://x",
                 "--force",
+                "--allow-tofu",
             ]
         )
         monkeypatch.setenv("DMP_PASSPHRASE", "bob-pass")
@@ -1313,7 +1319,9 @@ class TestSendRecv:
         cli.main(["send", "bob", "only-once"])
         capsys.readouterr()
 
-        # bob's CLI reads once
+        # bob's CLI reads once. --allow-tofu is required because bob's
+        # fresh init has no pinned contacts; without it the slot walk
+        # drops alice's manifest as a default-deny first-contact.
         cli.main(
             [
                 "init",
@@ -1322,6 +1330,7 @@ class TestSendRecv:
                 "--endpoint",
                 "http://x",
                 "--force",
+                "--allow-tofu",
             ]
         )
         monkeypatch.setenv("DMP_PASSPHRASE", "bob-pass")
@@ -1627,6 +1636,7 @@ class TestDnsResolvers:
                 "--endpoint",
                 "http://x",
                 "--force",
+                "--allow-tofu",
             ]
         )
         monkeypatch.setenv("DMP_PASSPHRASE", "bob-pass")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,8 +11,19 @@ from dmp.network.memory import InMemoryDNSStore
 def _pair(store: InMemoryDNSStore, domain: str = "mesh.test"):
     alice = DMPClient("alice", "alice-pass", domain=domain, store=store)
     bob = DMPClient("bob", "bob-pass", domain=domain, store=store)
-    alice.add_contact("bob", bob.get_public_key_hex())
-    bob.add_contact("alice", alice.get_public_key_hex())
+    # Pin signing keys mutually — the secure default. Without
+    # signing_key_hex the receiver's known_spks is empty and
+    # receive_messages drops every manifest unless ``allow_tofu=True``.
+    alice.add_contact(
+        "bob",
+        bob.get_public_key_hex(),
+        signing_key_hex=bob.get_signing_public_key_hex(),
+    )
+    bob.add_contact(
+        "alice",
+        alice.get_public_key_hex(),
+        signing_key_hex=alice.get_signing_public_key_hex(),
+    )
     return alice, bob
 
 
@@ -132,7 +143,18 @@ class TestSendReceive:
         store = InMemoryDNSStore()
         alice, bob = _pair(store)
         eve = DMPClient("eve", "eve-pass", domain="mesh.test", store=store)
-        eve.add_contact("bob", bob.get_public_key_hex())
+        eve.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+        # Bob must pin Eve too — the test exercises bob delivering
+        # messages from BOTH alice and eve, not just one of them.
+        bob.add_contact(
+            "eve",
+            eve.get_public_key_hex(),
+            signing_key_hex=eve.get_signing_public_key_hex(),
+        )
 
         # Two different senders, two back-to-back messages to bob. With 10
         # empty slots available, the first-empty scan should deposit them in
@@ -182,18 +204,55 @@ class TestSendReceive:
         assert inbox[0].plaintext == b"bob is pinned"
         assert inbox[0].sender_signing_pk == bob.crypto.get_signing_public_key_bytes()
 
-    def test_tofu_delivery_when_no_contacts_pinned(self):
-        """Without any pinned signing keys, receive falls back to TOFU —
-        any signature-valid manifest for us is delivered. This keeps the
-        initial 'publish your identity, exchange keys, pin' workflow
-        working at all."""
+    def test_tofu_delivery_requires_explicit_opt_in(self):
+        """The slot-walk receive path is default-deny when the receiver
+        has no pinned signing keys. ``allow_tofu=True`` re-enables the
+        legacy "deliver any signature-valid manifest until you pin
+        someone" behavior, which is useful for the initial onboarding
+        flow but a real attack surface for a pristine client whose DNS
+        path can be spoofed.
+        """
+        store = InMemoryDNSStore()
+        alice = DMPClient(
+            "alice", "alice-pass", domain="mesh.test", store=store, allow_tofu=True
+        )
+        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        # alice has no pinned signing keys at all — pure TOFU receive.
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
+        assert bob.send_message("alice", "first contact")
+
+        inbox = alice.receive_messages()
+        assert len(inbox) == 1
+        assert inbox[0].plaintext == b"first contact"
+
+    def test_tofu_dropped_by_default_when_no_contacts_pinned(self):
+        """The opposite of the test above: with the secure default
+        (``allow_tofu=False``), an empty pinned-signer set causes every
+        signature-valid manifest to be silently dropped on the slot
+        walk. Operators that want first-contact delivery must opt in
+        explicitly via ``allow_tofu=True`` or ``enable_tofu()``.
+        """
         store = InMemoryDNSStore()
         alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
         bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
-        # alice has no contacts at all — no pins yet.
-        bob.add_contact("alice", alice.get_public_key_hex())
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
         assert bob.send_message("alice", "first contact")
 
+        # alice has no pins → default-deny drops the manifest.
+        assert alice.receive_messages() == []
+
+        # Flipping the gate at runtime delivers the still-published
+        # manifest on the next poll. Symmetric with passing
+        # ``allow_tofu=True`` to the constructor.
+        alice.enable_tofu()
         inbox = alice.receive_messages()
         assert len(inbox) == 1
         assert inbox[0].plaintext == b"first contact"
@@ -261,7 +320,11 @@ class TestSendReceive:
         long-term X25519 key (no FS) rather than failing to send."""
         store = InMemoryDNSStore()
         alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        # bob receives via TOFU because no contact pins HIM — explicit
+        # opt-in is required after P0-3.
+        bob = DMPClient(
+            "bob", "bob-pass", domain="mesh.test", store=store, allow_tofu=True
+        )
         # NOTE: no signing_key_hex — alice can't verify any prekey signature.
         alice.add_contact("bob", bob.get_public_key_hex())
 
@@ -302,7 +365,11 @@ class TestSendReceive:
         """
         store = InMemoryDNSStore()
         alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        # bob has no pinned contacts in this test — receive falls back to
+        # TOFU which is opt-in after P0-3.
+        bob = DMPClient(
+            "bob", "bob-pass", domain="mesh.test", store=store, allow_tofu=True
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -450,7 +517,9 @@ class TestSendReceive:
 
         store = InMemoryDNSStore()
         alice, bob = _pair(store)
-        bob.add_contact("alice", alice.get_public_key_hex())
+        # `_pair` already pinned alice's signing key on bob — the legacy
+        # extra add_contact below was a no-op that wiped the pin (older
+        # signature without signing_key_hex). Removed.
 
         # alice sends normally so the chunks land with the *real* msg_id
         # embedded in the inner header.
@@ -794,10 +863,16 @@ class TestCrossZoneReceive:
         without an explicit `domain=` (the legacy `dnsmesh contacts add`
         path), `Contact.domain` falls back to `self.domain` — both
         zones collapse and `_zones_to_poll()` returns a single entry.
+
+        These legacy adds also omit ``signing_key_hex``, so bob has no
+        pinned signers and receives via TOFU. After P0-3 that requires
+        explicit ``allow_tofu=True``.
         """
         store = InMemoryDNSStore()
         alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        bob = DMPClient(
+            "bob", "bob-pass", domain="mesh.test", store=store, allow_tofu=True
+        )
         # Legacy add — no domain= passed, no signing key (TOFU mode).
         alice.add_contact("bob", bob.get_public_key_hex())
         bob.add_contact("alice", alice.get_public_key_hex())

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -204,7 +204,18 @@ def test_container_roundtrip(node_container):
         writer=writer,
         reader=reader,
     )
-    alice.add_contact("bob", bob.get_public_key_hex())
+    alice.add_contact(
+        "bob",
+        bob.get_public_key_hex(),
+        signing_key_hex=bob.get_signing_public_key_hex(),
+    )
+    # bob must pin alice's signing key so receive_messages doesn't fall
+    # into TOFU (default-deny after P0-3).
+    bob.add_contact(
+        "alice",
+        alice.get_public_key_hex(),
+        signing_key_hex=alice.get_signing_public_key_hex(),
+    )
 
     assert alice.send_message("bob", "hello from a real container")
 
@@ -228,25 +239,33 @@ def test_container_survives_client_restart(node_container):
         writer=writer,
         reader=reader,
     )
-    # Grab bob's pubkey without retaining the client instance.
-    bob_pubkey = DMPClient(
+    # Grab bob's pub + spk without retaining the client instance.
+    _bob_for_keys = DMPClient(
         "bob",
         "bob-pass",
         domain="mesh.docker",
         writer=writer,
         reader=reader,
-    ).get_public_key_hex()
-    alice.add_contact("bob", bob_pubkey)
+    )
+    bob_pubkey = _bob_for_keys.get_public_key_hex()
+    bob_spk = _bob_for_keys.get_signing_public_key_hex()
+    alice_spk = alice.get_signing_public_key_hex()
+    alice.add_contact("bob", bob_pubkey, signing_key_hex=bob_spk)
 
     assert alice.send_message("bob", "delivered after restart")
 
     # A brand-new Bob process (fresh ReplayCache, no prior state) reads.
+    # Bob must pin alice for the slot walk to deliver — same default-deny
+    # gate as test_container_roundtrip.
     bob_fresh = DMPClient(
         "bob",
         "bob-pass",
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+    )
+    bob_fresh.add_contact(
+        "alice", alice.get_public_key_hex(), signing_key_hex=alice_spk
     )
     inbox = bob_fresh.receive_messages()
     assert len(inbox) == 1
@@ -294,6 +313,13 @@ def test_container_forward_secrecy_end_to_end(node_container, tmp_path):
         "bob-fs",
         bob.get_public_key_hex(),
         signing_key_hex=bob.get_signing_public_key_hex(),
+    )
+    # Bob pins alice — required so receive_messages doesn't drop her
+    # manifest as TOFU under the new default-deny gate.
+    bob.add_contact(
+        "alice-fs",
+        alice.get_public_key_hex(),
+        signing_key_hex=alice.get_signing_public_key_hex(),
     )
 
     # Bob seeds a small prekey pool (5 keys, 1 hr TTL).
@@ -633,7 +659,18 @@ def test_container_concurrent_receive_delivers_exactly_once(node_container):
         writer=writer,
         reader=reader,
     )
-    alice.add_contact("bob-conc", bob.get_public_key_hex())
+    alice.add_contact(
+        "bob-conc",
+        bob.get_public_key_hex(),
+        signing_key_hex=bob.get_signing_public_key_hex(),
+    )
+    # Bob pins alice — receive_messages drops manifests from unpinned
+    # signers when not in TOFU mode.
+    bob.add_contact(
+        "alice-conc",
+        alice.get_public_key_hex(),
+        signing_key_hex=alice.get_signing_public_key_hex(),
+    )
 
     # Single message — exactly-once delivery is the property under test.
     payload = "concurrent-receive payload for the race test"

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -80,7 +80,18 @@ class TestDMPNode:
         # real persistent store behind the same API the DNS + HTTP layers use.
         alice = DMPClient("alice", "apass", domain="mesh.test", store=node.store)
         bob = DMPClient("bob", "bpass", domain="mesh.test", store=node.store)
-        alice.add_contact("bob", bob.get_public_key_hex())
+        alice.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+        # bob must pin alice so receive_messages doesn't fall into TOFU
+        # (default-deny after P0-3).
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
 
         assert alice.send_message("bob", "via node store")
         inbox = bob.receive_messages()

--- a/tests/test_resolver_failover.py
+++ b/tests/test_resolver_failover.py
@@ -211,8 +211,16 @@ class TestResolverFailoverAcceptance:
             writer=shared_store,
             reader=pool,
         )
-        alice.add_contact("bob", bob.get_public_key_hex())
-        bob.add_contact("alice", alice.get_public_key_hex())
+        alice.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
 
         assert alice.send_message("bob", "hello over failover")
 

--- a/tests/test_rotation_chain.py
+++ b/tests/test_rotation_chain.py
@@ -636,6 +636,51 @@ class TestDMPClientRotationChainIntegration:
             alice.get_signing_public_key_hex()
         )
 
+    def test_opt_in_rejects_when_pinned_key_directly_revoked(self):
+        """Codex regression catch (P0-3 review): a sender who publishes
+        a self-revocation of a key the receiver has PINNED must have
+        their manifests signed by that revoked key dropped on the slot
+        walk. Earlier the P0-3 TOFU restructuring chained revocation
+        off the new ``elif`` and the pinned branch silently skipped it.
+        """
+        from dmp.client.client import DMPClient
+        from dmp.core.rotation import rotation_rrset_name_user_identity
+        from dmp.network.memory import InMemoryDNSStore
+
+        store = InMemoryDNSStore()
+        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            rotation_chain_enabled=True,
+        )
+        # Pin alice with her CURRENT signing key (no rotation yet).
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
+        alice.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+
+        # Alice self-revokes her pinned key (no rotation, no successor).
+        rrset = rotation_rrset_name_user_identity("alice", "mesh.test")
+        store.publish_txt_record(
+            rrset,
+            _sign_revocation(revoked=alice.crypto, subject="alice@mesh.test"),
+        )
+
+        # Sender still tries to deliver under the now-revoked key.
+        alice.send_message("bob", "compromised key still trying")
+        # Must drop — pinned + revoked is the precise hole the P0-3
+        # restructuring opened.
+        assert bob.receive_messages() == []
+
     def test_opt_in_rejects_when_revoked(self):
         """Rotation + revocation → manifest still dropped."""
         from dmp.client.client import DMPClient

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -143,8 +143,16 @@ class TestClientOverSqlite:
         try:
             alice = DMPClient("alice", "apass", domain="mesh.test", store=store)
             bob = DMPClient("bob", "bpass", domain="mesh.test", store=store)
-            alice.add_contact("bob", bob.get_public_key_hex())
-            bob.add_contact("alice", alice.get_public_key_hex())
+            alice.add_contact(
+                "bob",
+                bob.get_public_key_hex(),
+                signing_key_hex=bob.get_signing_public_key_hex(),
+            )
+            bob.add_contact(
+                "alice",
+                alice.get_public_key_hex(),
+                signing_key_hex=alice.get_signing_public_key_hex(),
+            )
 
             assert alice.send_message("bob", "hello from sqlite")
             inbox = bob.receive_messages()
@@ -162,14 +170,25 @@ class TestClientOverSqlite:
         store1 = SqliteMailboxStore(db)
         alice = DMPClient("alice", "apass", domain="mesh.test", store=store1)
         bob_for_keys = DMPClient("bob", "bpass", domain="mesh.test", store=store1)
-        alice.add_contact("bob", bob_for_keys.get_public_key_hex())
+        alice.add_contact(
+            "bob",
+            bob_for_keys.get_public_key_hex(),
+            signing_key_hex=bob_for_keys.get_signing_public_key_hex(),
+        )
         assert alice.send_message("bob", "picked up after restart")
         store1.close()
 
         # Phase 2: new process, new store handle, new bob client reads.
+        # bob must pin alice — without a pin, the slot walk drops every
+        # manifest unless ``allow_tofu=True`` (P0-3 default-deny).
         store2 = SqliteMailboxStore(db)
         try:
             bob = DMPClient("bob", "bpass", domain="mesh.test", store=store2)
+            bob.add_contact(
+                "alice",
+                alice.get_public_key_hex(),
+                signing_key_hex=alice.get_signing_public_key_hex(),
+            )
             inbox = bob.receive_messages()
             assert len(inbox) == 1
             assert inbox[0].plaintext == b"picked up after restart"


### PR DESCRIPTION
## Summary

P0-3 from the security audit. `DMPClient.receive_messages` silently delivered any signature-valid manifest when the receiver had zero pinned signing keys — useful for fresh onboarding, but lets anyone who can spoof DNS to a pristine client win the first-contact slot.

After this PR the slot-walk drops every signature-valid manifest by default when the pinned-signer set is empty. Opt-in is explicit:

```python
DMPClient(..., allow_tofu=True)        # constructor
client.enable_tofu() / disable_tofu()  # runtime toggle
```

```bash
dnsmesh init ... --allow-tofu          # CLI
```

The `receive_claims` path is unchanged — it already quarantines unknown senders to the intro queue rather than auto-delivering, so it was never the TOFU surface.

## Changes

### `dmp/client/client.py`
- `DMPClient.__init__` takes `allow_tofu: bool = False`.
- Slot-walk gate at `receive_messages` becomes:
  ```python
  if known_spks:
      accept-or-rotation-walk      # unchanged
  elif not self.allow_tofu:
      drop                         # NEW default-deny
  else:
      fall through                 # legacy TOFU, opt-in only
  ```
- `enable_tofu()` / `disable_tofu()` helpers for runtime flips.
- `add_contact()` docstring updated to flag the new default.

### `dmp/cli.py`
- `CLIConfig` grows `allow_tofu: bool = False`. Configs predating the flag default to False (the secure default applies on upgrade).
- `dnsmesh init --allow-tofu` opt-in flag.
- `_make_client` propagates `config.allow_tofu` into the `DMPClient` constructor.

### Tests
- `tests/test_client.py`:
  - `_pair` helper now mutually pins `signing_key_hex` — exercises the secure default.
  - Old `test_tofu_delivery_when_no_contacts_pinned` is renamed `test_tofu_delivery_requires_explicit_opt_in` (sets `allow_tofu=True` on the receiver).
  - New companion `test_tofu_dropped_by_default_when_no_contacts_pinned` asserts the default-deny behavior + the `enable_tofu()` runtime flip works.
- `tests/test_cli.py`:
  - `shared_store` fixture propagates `allow_tofu` into its fake `_make_client`.
  - Recv-after-fresh-init tests pass `--allow-tofu` (bob's reinitialized config has no contacts).
- `tests/test_docker_integration.py`: roundtrip / FS / restart tests mutually pin signing keys; concurrent-receive test pins eve's counterpart so bob's pinned-signer set isn't empty.
- `tests/test_node.py`, `test_resolver_failover.py`, `test_sqlite_store.py`: each receiver pins the sender's spk.

## Validation

- **Unit suite:** 1463 passed, 3 skipped (docker tests when image missing).
- **Docker integration suite:** 7 passed against a fresh `dnsmesh-node:latest` build.
- **Full suite:** 1473 passed, 0 skipped.
- **Lint:** `black --check dmp tests` clean.

## Test plan

- [ ] CI passes all matrix versions
- [ ] Spot-check the new tests:
      `pytest tests/test_client.py -k tofu -v`
- [ ] Manual: `dnsmesh init alice --allow-tofu` should write `allow_tofu: true` to config; without the flag the value is `false`.

## Out of scope (future work)

The slot-walk drop is silent. A natural follow-up is to route unpinned-signer manifests into the `intro_queue` (mirroring `receive_claims`) so operators can see first-contact opportunities and explicitly accept or reject them. That is a UX improvement on top of this default-deny gate, not a security fix.

Next on the audit plan: **P0-4 (DNSSEC validation)**.