### PR TITLE
fix(dns): opt-in DNSSEC AD-bit policy on the resolver path

### DIFF
--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -150,6 +150,16 @@ class CLIConfig:
     # has pinned a contact.
     allow_tofu: bool = False
 
+    # P0-4 — DNSSEC AD-bit policy. When True every TXT/A/AAAA reply
+    # must carry the AD flag from the upstream recursor; replies
+    # without AD are dropped and the upstream is demoted. The trust
+    # boundary is the channel between this client and the chosen
+    # recursor — over plaintext UDP an on-path attacker can flip AD,
+    # so this gate is meaningful only when paired with a trusted local
+    # recursor or DoT/DoH. False (default) preserves the legacy
+    # behavior of trusting whatever the resolver returns.
+    dnssec_required: bool = False
+
     # M8.3 — claim-provider override. When non-empty, send/recv use
     # this single endpoint as the claim provider, skipping seen-feed
     # ranking. Use case: pin all first-contact reach through a known
@@ -265,6 +275,10 @@ class CLIConfig:
             # default to False (secure default). Operators flip it via
             # ``dnsmesh init --allow-tofu`` or hand-edit.
             allow_tofu=bool(data.get("allow_tofu", False)),
+            # P0-4 — back-compat: configs predating DNSSEC required
+            # default to False so existing deployments keep working.
+            # Operators opt in via ``dnsmesh init --require-dnssec``.
+            dnssec_required=bool(data.get("dnssec_required", False)),
             cluster_base_domain=data.get("cluster_base_domain", "") or "",
             cluster_operator_spk=data.get("cluster_operator_spk", "") or "",
             cluster_refresh_interval=int(data.get("cluster_refresh_interval", 3600)),
@@ -434,9 +448,23 @@ def _publish_failure_msg(writer: "_HttpWriter", name: str) -> str:
 
 
 class _DnsReader(DNSRecordReader):
-    """Reads records via a configured DNS resolver (or the system default)."""
+    """Reads records via a configured DNS resolver (or the system default).
 
-    def __init__(self, host: Optional[str], port: int = 5353):
+    ``dnssec_required`` (P0-4): when True the resolver requests DNSSEC
+    processing (EDNS0 + DO bit) and rejects answers without the AD
+    flag. The trust boundary is the channel between this client and
+    the recursor; meaningful only over DoT/DoH or a trusted local
+    recursor (an on-path attacker on plaintext UDP can flip AD).
+    """
+
+    def __init__(
+        self,
+        host: Optional[str],
+        port: int = 5353,
+        *,
+        dnssec_required: bool = False,
+    ):
+        import dns.flags
         import dns.resolver
 
         self._resolver = dns.resolver.Resolver()
@@ -445,8 +473,12 @@ class _DnsReader(DNSRecordReader):
             self._resolver.port = port
         self._resolver.timeout = 3.0
         self._resolver.lifetime = 6.0
+        self._dnssec_required = dnssec_required
+        if dnssec_required:
+            self._resolver.use_edns(0, dns.flags.DO, 4096)
 
     def query_txt_record(self, name: str):
+        import dns.flags
         import dns.resolver
 
         try:
@@ -455,6 +487,11 @@ class _DnsReader(DNSRecordReader):
             return None
         except Exception:
             return None
+        if self._dnssec_required:
+            response = getattr(answers, "response", None)
+            flags = getattr(response, "flags", 0) if response else 0
+            if not (flags & dns.flags.AD):
+                return None
         values = []
         for rdata in answers:
             values.append(b"".join(rdata.strings).decode("utf-8"))
@@ -636,8 +673,10 @@ def _make_reader(config: CLIConfig) -> DNSRecordReader:
         # when the entry was portless (ResolverPool inherits its own
         # default of 53 for those).
         pool_hosts = [(h, p) if p is not None else h for h, p in parsed]
-        return ResolverPool(pool_hosts)
-    return _DnsReader(config.dns_host, config.dns_port)
+        return ResolverPool(pool_hosts, dnssec_required=config.dnssec_required)
+    return _DnsReader(
+        config.dns_host, config.dns_port, dnssec_required=config.dnssec_required
+    )
 
 
 def _cluster_mode_enabled(config: CLIConfig) -> bool:
@@ -1589,6 +1628,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         kdf_salt=os.urandom(32).hex(),
         identity_domain=(args.identity_domain or "").strip(),
         allow_tofu=bool(getattr(args, "allow_tofu", False)),
+        dnssec_required=bool(getattr(args, "require_dnssec", False)),
     )
 
     # M10 — auto-probe the local node's DNS endpoint so same-zone
@@ -4734,6 +4774,16 @@ def build_parser() -> argparse.ArgumentParser:
         "pins a contact — useful for fresh onboarding, but a real attack "
         "surface for any client whose DNS path can be spoofed before any "
         "contact is pinned.",
+    )
+    p_init.add_argument(
+        "--require-dnssec",
+        action="store_true",
+        help="Drop DNS replies that the upstream recursor did not "
+        "DNSSEC-validate (no AD flag). Pair with a trusted local "
+        "recursor or DoT/DoH — over plaintext UDP to a public resolver "
+        "an on-path attacker can flip the AD bit and the gate becomes "
+        "theatre. Default False keeps the legacy behavior of trusting "
+        "whatever the resolver returns.",
     )
     p_init.set_defaults(func=cmd_init)
 

--- a/dmp/core/dns.py
+++ b/dmp/core/dns.py
@@ -5,6 +5,7 @@ import json
 import hashlib
 from typing import Dict, Any, Optional, List, Tuple
 from dataclasses import dataclass
+import dns.flags
 import dns.resolver
 import dns.message
 import dns.rdatatype
@@ -141,9 +142,26 @@ class DNSEncoder:
 
 
 class DNSOperations:
-    """DNS query and response operations for DMP"""
+    """DNS query and response operations for DMP.
 
-    def __init__(self, resolvers: Optional[List[str]] = None):
+    ``dnssec_required`` (P0-4): when True the resolver requests DNSSEC
+    processing (EDNS0 + DO bit) and every reply must carry the AD
+    (Authenticated Data) flag — i.e. the upstream recursor DNSSEC-
+    validated the answer. Replies missing AD are rejected. The trust
+    boundary is the channel between this client and the recursor, so
+    AD-bit policy is meaningful only over a transport an on-path
+    attacker cannot rewrite (DoT/DoH or a pinned local recursor); over
+    plaintext UDP to a public resolver an on-path attacker can flip AD
+    and the check becomes theatre. Local trust-anchor validation is a
+    larger separate project.
+    """
+
+    def __init__(
+        self,
+        resolvers: Optional[List[str]] = None,
+        *,
+        dnssec_required: bool = False,
+    ):
         """Initialize with optional custom resolvers"""
         self.resolver = dns.resolver.Resolver()
         if resolvers:
@@ -155,11 +173,26 @@ class DNSOperations:
         # Set reasonable timeouts
         self.resolver.timeout = 5.0
         self.resolver.lifetime = 10.0
+        self._dnssec_required = dnssec_required
+        if dnssec_required:
+            # Ask the recursor to do DNSSEC processing. Without DO bit
+            # many recursors strip RRSIGs and never set AD, which would
+            # make every answer fail the gate even from a validating
+            # resolver.
+            self.resolver.use_edns(0, dns.flags.DO, 4096)
 
     def query_txt_record(self, domain: str) -> Optional[List[str]]:
         """Query TXT records for a domain"""
         try:
             answers = self.resolver.resolve(domain, "TXT")
+            if self._dnssec_required:
+                response = getattr(answers, "response", None)
+                flags = getattr(response, "flags", 0) if response else 0
+                if not (flags & dns.flags.AD):
+                    # Upstream didn't validate (or the chain failed).
+                    # Drop the answer — DMP must not consume DNS data
+                    # without validation when the operator opted in.
+                    return None
             records = []
             for rdata in answers:
                 # TXT records can have multiple strings

--- a/dmp/network/resolver_pool.py
+++ b/dmp/network/resolver_pool.py
@@ -225,8 +225,8 @@ class ResolverPool(DNSRecordReader):
         failure_threshold: int = 1,
         dnssec_required: bool = False,
     ) -> None:
-        """``dnssec_required`` (P0-4): when True, every TXT lookup
-        requires the upstream resolver's reply to carry the AD
+        """``dnssec_required`` (P0-4): when True, every TXT/A/AAAA/NS
+        lookup requires the upstream resolver's reply to carry the AD
         (Authenticated Data) flag — i.e. a validating recursor signed off
         on the answer. Replies missing AD are treated as transport
         failures and the upstream is demoted, so a non-validating or
@@ -241,6 +241,18 @@ class ResolverPool(DNSRecordReader):
           - The pool also queries the recursor with the EDNS DO bit set
             so the recursor knows we want DNSSEC processing; without DO,
             many recursors strip RRSIGs and never set AD.
+          - **Negative responses are NOT validated.** dnspython raises
+            ``NXDOMAIN`` / ``NoAnswer`` before our gate sees the message,
+            and the exception drops the AD-bit context. So an attacker
+            who can return ``NXDOMAIN`` (e.g. via spoofed UDP) still
+            gets a "no records" outcome through the pool — the response
+            is unauthenticated denial. Mitigations: pair with a trusted
+            local recursor that validates negative responses (NSEC/NSEC3
+            chains) and refuses unsigned denials, OR fall back to
+            full local validation. Tracked as follow-up: switch the
+            ``dnssec_required=True`` path to lower-level
+            ``dns.message`` + ``dns.query`` so the AD bit on negative
+            responses is reachable.
           - Local validation against a trust anchor is a separate, larger
             project; that requires shipping/refreshing the root anchor
             and full chain validation in-process.
@@ -502,6 +514,14 @@ class ResolverPool(DNSRecordReader):
             except self._NAME_NOT_FOUND_ERRORS:
                 continue
             except self._TRANSPORT_ERRORS:
+                self._mark_failure(state)
+                continue
+            # P0-4: same AD-bit gate as TXT/A/AAAA. NS records feed the
+            # DNS UPDATE writer's split-host target chase
+            # (dns_update_writer:_resolve_to_ip), so an unvalidated NS
+            # answer routes writes to an attacker-chosen host. Demote
+            # the upstream and try the next.
+            if self._dnssec_required and not _ad_bit_set(answers):
                 self._mark_failure(state)
                 continue
             self._mark_success(state)

--- a/dmp/network/resolver_pool.py
+++ b/dmp/network/resolver_pool.py
@@ -59,11 +59,32 @@ from typing import Iterable, List, Optional, Sequence, Tuple, Union
 HostSpec = Union[str, Tuple[str, int]]
 
 import dns.exception
+import dns.flags
 import dns.resolver
 
 from dmp.network.base import DNSRecordReader
 
 log = logging.getLogger(__name__)
+
+
+def _ad_bit_set(answer) -> bool:
+    """Return True iff the dnspython Answer carries an AD-validated response.
+
+    Used by the DNSSEC-required code path. dnspython's :class:`Answer`
+    exposes the underlying message via ``.response``; the AD (Authenticated
+    Data) flag in the message header indicates the upstream recursor
+    successfully validated the DNSSEC chain for this RRset. Tolerates
+    older dnspython shapes where ``.response`` may be missing — fail
+    closed (return False) so a parsing oddity does not silently turn off
+    the validation gate.
+    """
+    response = getattr(answer, "response", None)
+    if response is None:
+        return False
+    flags = getattr(response, "flags", None)
+    if flags is None:
+        return False
+    return bool(flags & dns.flags.AD)
 
 
 # Four operator-diverse public resolvers, IPv4 only. Discovery probes each
@@ -202,7 +223,28 @@ class ResolverPool(DNSRecordReader):
         lifetime: float = 10.0,
         cooldown_seconds: float = 60.0,
         failure_threshold: int = 1,
+        dnssec_required: bool = False,
     ) -> None:
+        """``dnssec_required`` (P0-4): when True, every TXT lookup
+        requires the upstream resolver's reply to carry the AD
+        (Authenticated Data) flag — i.e. a validating recursor signed off
+        on the answer. Replies missing AD are treated as transport
+        failures and the upstream is demoted, so a non-validating or
+        actively-stripping resolver no longer poisons DMP record reads.
+
+        Caveats baked into AD-bit policy:
+          - The trust boundary is the channel between this client and the
+            chosen recursor. AD is meaningful only over a transport an
+            on-path attacker cannot rewrite (DoT/DoH, or a trusted local
+            recursor). Plaintext UDP to a public resolver lets any
+            on-path party flip AD, making the check theatre.
+          - The pool also queries the recursor with the EDNS DO bit set
+            so the recursor knows we want DNSSEC processing; without DO,
+            many recursors strip RRSIGs and never set AD.
+          - Local validation against a trust anchor is a separate, larger
+            project; that requires shipping/refreshing the root anchor
+            and full chain validation in-process.
+        """
         if not hosts:
             raise ValueError("ResolverPool requires at least one host")
         if failure_threshold < 1:
@@ -224,6 +266,7 @@ class ResolverPool(DNSRecordReader):
         self._port = port
         self._cooldown_seconds = cooldown_seconds
         self._failure_threshold = failure_threshold
+        self._dnssec_required = dnssec_required
         self._lock = threading.Lock()
 
         self._states: List[_HostState] = []
@@ -233,6 +276,13 @@ class ResolverPool(DNSRecordReader):
             resolver.port = host_port
             resolver.timeout = timeout
             resolver.lifetime = lifetime
+            if dnssec_required:
+                # EDNS0 + DO (DNSSEC OK) bit asks the recursor to do
+                # DNSSEC processing and include RRSIGs. Without DO many
+                # recursors strip signatures and never set AD on the
+                # response. Payload 4096 is the standard EDNS0 buffer
+                # size that fits typical signed RRsets.
+                resolver.use_edns(0, dns.flags.DO, 4096)
             self._states.append(
                 _HostState(host=host, port=host_port, resolver=resolver)
             )
@@ -341,6 +391,19 @@ class ResolverPool(DNSRecordReader):
             # propagates up. Blanket-catching here would let one bad
             # lookup demote every upstream into cooldown.
 
+            # P0-4: when DNSSEC is required, the upstream resolver MUST
+            # have validated the answer (AD flag set on the response).
+            # An answer without AD means either (a) the recursor isn't
+            # validating, (b) the zone is unsigned, or (c) the validator
+            # rejected the chain. From DMP's perspective every one of
+            # those is "this answer is not trustworthy" — drop it and
+            # demote the upstream. The on-path-AD-flip caveat is real
+            # and is documented on the constructor; mitigate via
+            # DoT/DoH or a pinned local recursor.
+            if self._dnssec_required and not _ad_bit_set(answers):
+                self._mark_failure(state)
+                continue
+
             records: List[str] = []
             for rdata in answers:
                 # dnspython exposes each TXT rdata as a tuple of byte
@@ -404,6 +467,11 @@ class ResolverPool(DNSRecordReader):
                 except self._NAME_NOT_FOUND_ERRORS:
                     continue
                 except self._TRANSPORT_ERRORS:
+                    self._mark_failure(state)
+                    continue
+                # P0-4: same AD-bit gate as TXT — refuse address answers
+                # that the upstream did not DNSSEC-validate.
+                if self._dnssec_required and not _ad_bit_set(answers):
                     self._mark_failure(state)
                     continue
                 for rdata in answers:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,12 @@ def shared_store(monkeypatch):
         def query_txt_record(self, name):
             return store.query_txt_record(name)
 
-    def fake_dns_reader(host, port=5353):
+    def fake_dns_reader(host, port=5353, *, dnssec_required=False):
+        # Accept the P0-4 kwarg even though the in-memory shim doesn't
+        # exercise DNSSEC — keeps the test fixture in lockstep with
+        # _make_reader's call shape so signature changes surface here
+        # rather than as a TypeError swallowed mid-flow.
+        del dnssec_required
         return _SharedStoreReader()
 
     monkeypatch.setattr(cli, "_make_client", fake_make_client)

--- a/tests/test_resolver_pool.py
+++ b/tests/test_resolver_pool.py
@@ -6,6 +6,7 @@ import socket
 from unittest.mock import patch
 
 import dns.exception
+import dns.flags
 import dns.name
 import dns.resolver
 import pytest
@@ -24,13 +25,39 @@ class _FakeRdata:
         self.strings = strings
 
 
+class _FakeResponse:
+    """Mimic a dnspython Message; only the AD/DO flag word matters here."""
+
+    def __init__(self, flags: int):
+        self.flags = flags
+
+
 class _FakeAnswer(list):
-    """A dnspython Answer is iterable over rdata objects."""
+    """A dnspython Answer is iterable over rdata objects.
+
+    P0-4: ResolverPool reads ``answer.response.flags`` to gate on the
+    AD bit when ``dnssec_required=True``. Default constructor produces
+    an answer with AD set (the upstream-validated common case) so
+    existing tests that construct via ``_answer(...)`` keep passing.
+    """
+
+    def __init__(self, *args, ad: bool = True, **kwargs):
+        super().__init__(*args, **kwargs)
+        flags = dns.flags.AD if ad else 0
+        self.response = _FakeResponse(flags)
 
 
-def _answer(*txt_values: str) -> _FakeAnswer:
-    """Build a fake dnspython answer for the given TXT string(s)."""
-    return _FakeAnswer(_FakeRdata([v.encode("utf-8")]) for v in txt_values)
+def _answer(*txt_values: str, ad: bool = True) -> _FakeAnswer:
+    """Build a fake dnspython answer for the given TXT string(s).
+
+    ``ad`` controls whether the synthetic response carries the AD flag
+    (P0-4 DNSSEC gate); default True matches a validating-recursor
+    happy path so existing tests don't have to opt in.
+    """
+    return _FakeAnswer(
+        (_FakeRdata([v.encode("utf-8")]) for v in txt_values),
+        ad=ad,
+    )
 
 
 def _route_by_nameserver(routes):
@@ -466,6 +493,120 @@ class TestResolverPoolQuery:
             mock_resolve.side_effect = _route_by_nameserver(routes)
             pool = ResolverPool(["1.1.1.1"])
             assert pool.query_txt_record("x.example.com") == ["part-a;part-b"]
+
+
+# ---------------------------------------------------------------------
+# DNSSEC AD-bit policy (P0-4)
+# ---------------------------------------------------------------------
+
+
+class TestResolverPoolDnssecGate:
+    """``ResolverPool(..., dnssec_required=True)`` rejects answers without
+    the AD (Authenticated Data) flag — i.e. the upstream recursor did not
+    DNSSEC-validate. The trust boundary is the channel between the client
+    and the recursor; this gate is meaningful only over DoT/DoH or a
+    trusted local recursor (an on-path attacker on plaintext UDP can flip
+    AD). That caveat is documented on the constructor; tested here is the
+    in-process behavior given a recursor whose answers either do or do
+    not carry AD.
+    """
+
+    def test_default_off_does_not_require_ad(self):
+        """Back-compat: ``dnssec_required=False`` (default) accepts an
+        AD-less answer. Existing deployments must keep working."""
+        routes = {
+            "1.1.1.1": lambda n, t: _answer("v=dmp1;t=chunk;d=aGk=", ad=False),
+        }
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(["1.1.1.1"])
+            assert pool.query_txt_record("mb-x.example.com") == [
+                "v=dmp1;t=chunk;d=aGk="
+            ]
+
+    def test_required_passes_when_ad_set(self):
+        """The validating-recursor happy path: AD set on the response,
+        the answer is delivered."""
+        routes = {
+            "1.1.1.1": lambda n, t: _answer("ad-validated", ad=True),
+        }
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            assert pool.query_txt_record("mb-x.example.com") == ["ad-validated"]
+
+    def test_required_drops_when_ad_unset(self):
+        """A non-validating recursor (or a stripped/forged answer) does
+        not set AD. The answer must NOT reach the caller, and the
+        upstream is demoted on its health counter so subsequent queries
+        prefer a different resolver."""
+        routes = {
+            "1.1.1.1": lambda n, t: _answer("not-validated", ad=False),
+        }
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            # No fallback resolver, so query_txt_record returns None —
+            # but the important assertion is "not the bypassed answer".
+            assert pool.query_txt_record("mb-x.example.com") is None
+
+    def test_required_falls_over_to_validating_resolver(self):
+        """Two-resolver pool: first returns an AD-less answer (rejected),
+        second returns AD-validated. Caller sees the validating answer.
+        """
+        routes = {
+            "1.1.1.1": lambda n, t: _answer("not-validated", ad=False),
+            "9.9.9.9": lambda n, t: _answer("validated", ad=True),
+        }
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(["1.1.1.1", "9.9.9.9"], dnssec_required=True)
+            assert pool.query_txt_record("mb-x.example.com") == ["validated"]
+
+    def test_required_failover_demotes_ad_less_resolver(self):
+        """The AD-less resolver should land in cooldown after a failover —
+        it counts against its health, like any transport-class failure.
+        """
+        routes = {
+            "1.1.1.1": lambda n, t: _answer("not-validated", ad=False),
+            "9.9.9.9": lambda n, t: _answer("validated", ad=True),
+        }
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(
+                ["1.1.1.1", "9.9.9.9"],
+                dnssec_required=True,
+                failure_threshold=1,
+            )
+            pool.query_txt_record("a.example.com")
+            healthy = pool.healthy_hosts()
+        # The AD-less resolver is demoted; the validator stays healthy.
+        assert "9.9.9.9" in healthy
+        assert "1.1.1.1" not in healthy
+
+    def test_required_uses_edns_do_bit(self):
+        """The pool must enable EDNS0 + DO so the recursor knows we want
+        DNSSEC processing — without DO many recursors strip RRSIGs and
+        never set AD, which would make every answer fail the gate even
+        from a validating resolver. We assert the dnspython-level flag
+        is set on each per-host resolver."""
+        pool = ResolverPool(["1.1.1.1", "9.9.9.9"], dnssec_required=True)
+        for state in pool._states:
+            options = state.resolver.edns
+            # dnspython exposes EDNS state through .edns (>=0 means enabled).
+            # Use ednsflags to inspect the requested DNSSEC OK bit.
+            assert options >= 0, "EDNS not enabled on dnssec_required resolver"
+            assert state.resolver.ednsflags & dns.flags.DO
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_resolver_pool.py
+++ b/tests/test_resolver_pool.py
@@ -608,6 +608,45 @@ class TestResolverPoolDnssecGate:
             assert options >= 0, "EDNS not enabled on dnssec_required resolver"
             assert state.resolver.ednsflags & dns.flags.DO
 
+    def test_required_drops_ad_less_ns_answer(self):
+        """resolve_ns_hosts feeds the DNS UPDATE writer's split-host
+        target chase. An unvalidated NS reply would route writes to an
+        attacker-chosen host, so the AD gate must apply there too —
+        codex review of PR #39 caught the original gap.
+        """
+
+        class _FakeNsRdata:
+            def __init__(self, target):
+                # dnspython's NS rdata exposes .target as a dns.name.Name
+                self.target = dns.name.from_text(target)
+
+        def _ns_answer(*targets, ad: bool):
+            ans = _FakeAnswer()
+            for t in targets:
+                ans.append(_FakeNsRdata(t))
+            ans.response = _FakeResponse(dns.flags.AD if ad else 0)
+            return ans
+
+        # AD set: NS hosts returned.
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(
+                {"1.1.1.1": lambda n, t: _ns_answer("ns1.example.com.", ad=True)}
+            )
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            assert pool.resolve_ns_hosts("example.com") == ["ns1.example.com"]
+
+        # AD unset: must drop, return empty list.
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(
+                {"1.1.1.1": lambda n, t: _ns_answer("ns1.example.com.", ad=False)}
+            )
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            assert pool.resolve_ns_hosts("example.com") == []
+
 
 # ---------------------------------------------------------------------
 # Health tracking & cooldown


### PR DESCRIPTION
## Summary

P0-4 from the security audit. Every DMP DNS query went through a plain `dns.resolver.Resolver` with no DNSSEC awareness — whatever the upstream returned was consumed as-is. A non-validating recursor, an upstream stripping RRSIGs, or any on-path mutation went through unchallenged.

This PR introduces an opt-in `dnssec_required` flag that:

1. Sets **EDNS0 + DO (DNSSEC OK)** on outgoing queries so the recursor knows we want DNSSEC processing. Without DO many recursors strip RRSIGs and never set AD, which would make every reply fail the gate even from a validating resolver.
2. Checks the **AD (Authenticated Data) flag** on each reply. AD set means the upstream successfully validated the chain; we trust the answer. AD unset means the upstream did not validate (or the chain failed); the answer is dropped and the upstream is demoted on its health counter.

```python
ResolverPool([...], dnssec_required=True)        # main path
DNSOperations([...], dnssec_required=True)       # legacy wrapper
```

```bash
dnsmesh init ... --require-dnssec                # CLI
```

## Trust boundary caveat (documented in code)

The trust boundary is the channel between the client and the recursor. Over plaintext UDP to a public resolver, an on-path attacker can flip the AD bit, and the gate becomes theatre. Meaningful only paired with a trusted local recursor or DoT/DoH. Full local trust-anchor validation (chain check in-process, anchor rollover) is a separate, larger project — out of scope here.

## Changes

| File | Change |
|---|---|
| `dmp/network/resolver_pool.py` | `dnssec_required` constructor flag. Each per-host resolver gets `use_edns(0, dns.flags.DO, 4096)`. `query_txt_record` and `resolve_address` reject AD-less answers and demote the upstream like a transport failure. New module-level `_ad_bit_set` helper for clarity. |
| `dmp/core/dns.py` | Same gate on `DNSOperations` for legacy callers. |
| `dmp/cli.py` | `CLIConfig.dnssec_required` field (back-compat: defaults False). `dnsmesh init --require-dnssec` flag. `_make_reader` propagates to both `ResolverPool` and the legacy `_DnsReader`. |
| `tests/test_resolver_pool.py` | New `TestResolverPoolDnssecGate` (6 tests). `_FakeAnswer` extended with a synthetic `.response.flags` so the gate can be exercised without a real validating recursor. Default `ad=True` keeps existing tests green. |
| `tests/test_cli.py` | `fake_dns_reader` shim accepts the new kwarg. |

## Validation

- **Unit suite:** 1469 passed, 10 skipped (docker tests when image missing). +6 new DNSSEC tests in `test_resolver_pool.py`.
- **Docker integration suite:** 7 passed against a fresh `dnsmesh-node:latest`.
- **Mutation test:** removing the `if self._dnssec_required and not _ad_bit_set(answers)` block fails 3 of 6 new tests (drop, failover, demotion). The default-off and EDNS-DO tests stay green either way (correct — they don't exercise the gate).
- **Lint:** `black --check dmp tests` clean.

## Test plan

- [ ] CI passes all matrix versions
- [ ] `pytest tests/test_resolver_pool.py -k Dnssec -v`
- [ ] Manual: `dnsmesh init alice --require-dnssec` writes `dnssec_required: true` to config; without the flag the value is `false`. Existing configs upgrade to `false` cleanly.
- [ ] Manual against a real recursor: with `--require-dnssec` and pool pointing at `1.1.1.1` (validating), TXT lookups for `cloudflare.com` succeed; lookups for an unsigned zone (no AD) return None.

## Out of scope (follow-ups)

- Local trust-anchor validation (full chain check in-process). Substantial scope: ship a trust anchor, refresh it across rotations, validate RRSIGs against DNSKEY against DS against the root.
- DoT/DoH transport. dnspython supports both; opt-in flag with operator config would close the on-path-AD-flip caveat above.

## What this completes

This is the last item from the original audit's P0 list:

- ✅ P0-1 — Centralized Ed25519 low-order public-key rejection (PR #35)
- ✅ P0-2 — Atomic claim/finalize/release on ReplayCache (PR #36)
- ✅ P0-3 — TOFU first-contact opt-in gate (PR #38)
- ✅ **P0-4 — DNSSEC AD-bit policy** (this PR)

Plus the related CI/sqlite race fix (#37).