### PR TITLE
feat(storage): version IntroQueue + PrekeyStore schemas via PRAGMA user_version

### DIFF
--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -1034,18 +1034,26 @@ def _make_client(
     # zone — fetching the cluster manifest from foo.com but then writing
     # mailbox records under mesh.local would break send/recv entirely.
     effective_domain = _effective_domain(config)
-    client = DMPClient(
-        config.username,
-        passphrase,
-        domain=effective_domain,
-        writer=writer,
-        reader=reader,
-        replay_cache_path=replay_path,
-        kdf_salt=kdf_salt,
-        prekey_store_path=prekey_path,
-        intro_queue_path=intro_queue_path,
-        allow_tofu=config.allow_tofu,
-    )
+    try:
+        client = DMPClient(
+            config.username,
+            passphrase,
+            domain=effective_domain,
+            writer=writer,
+            reader=reader,
+            replay_cache_path=replay_path,
+            kdf_salt=kdf_salt,
+            prekey_store_path=prekey_path,
+            intro_queue_path=intro_queue_path,
+            allow_tofu=config.allow_tofu,
+        )
+    except RuntimeError as exc:
+        # Schema-version refusal from prekey/intro stores: surface as a
+        # friendly CLI error rather than a Python traceback. The
+        # exception text already names the file and the version
+        # mismatch, which is what the operator needs to act on
+        # (downgrade the binary or migrate the data file).
+        _die(1, f"{exc}")
     # Attach the cluster handle (if any) so the CLI can close it at
     # exit. Setting an attribute on DMPClient after construction is
     # intentionally unintrusive — we do not modify DMPClient itself,

--- a/dmp/client/intro_queue.py
+++ b/dmp/client/intro_queue.py
@@ -60,9 +60,16 @@ class IntroQueue:
 
     Pass ``":memory:"`` for tests; pass a real path in CLI use so
     pending intros survive across CLI invocations.
+
+    Schema versioning (P1): the schema is stamped via
+    ``PRAGMA user_version``. Each schema bump appends a step to
+    ``_migrate`` and increments ``_SCHEMA_VERSION``. Opening a
+    database whose stored version is HIGHER than this code knows
+    raises — refusing a silent downgrade prevents data loss when an
+    older binary points at a newer database.
     """
 
-    _SCHEMA = """
+    _SCHEMA_V1 = """
         CREATE TABLE IF NOT EXISTS intros (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             sender_spk BLOB NOT NULL,
@@ -82,6 +89,10 @@ class IntroQueue:
             note TEXT NOT NULL DEFAULT ''
         );
     """
+
+    # Latest schema version this code understands. Bump on every
+    # schema-affecting change and append the migration to ``_MIGRATIONS``.
+    _SCHEMA_VERSION = 1
 
     def __init__(self, path: str = ":memory:") -> None:
         self._path = path
@@ -110,7 +121,7 @@ class IntroQueue:
             check_same_thread=False,
             isolation_level=None,  # autocommit
         )
-        self._conn.executescript(self._SCHEMA)
+        self._migrate()
         if path != ":memory:":
             try:
                 self._conn.execute("PRAGMA journal_mode=WAL")
@@ -125,6 +136,34 @@ class IntroQueue:
                         os.chmod(sibling, 0o600)
                 except OSError:
                     pass
+
+    def _migrate(self) -> None:
+        """Apply schema migrations idempotently and stamp ``user_version``.
+
+        Reads the current ``PRAGMA user_version`` (0 for fresh databases
+        and for older databases that predate this versioning scheme).
+        The v0→v1 step is a CREATE TABLE IF NOT EXISTS pass — idempotent
+        for both cases — and stamps ``user_version=1``. Future schema
+        changes append a v1→v2 step (etc.) and bump ``_SCHEMA_VERSION``.
+
+        Refuses to open a database whose stored version is higher than
+        ``_SCHEMA_VERSION``: that means an older binary opened a
+        newer-schema file, and silently doing nothing would risk
+        downgrading the schema (or worse, writing old-shape rows into
+        a newer-shape table).
+        """
+        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if cur_version > self._SCHEMA_VERSION:
+            raise RuntimeError(
+                f"intro_queue at {self._path!r} has schema version "
+                f"{cur_version}, but this binary only understands up to "
+                f"{self._SCHEMA_VERSION}. Refusing to open — using an "
+                f"older client against a newer database would risk "
+                f"silently dropping fields."
+            )
+        if cur_version < 1:
+            self._conn.executescript(self._SCHEMA_V1)
+            self._conn.execute(f"PRAGMA user_version = 1")
 
     def close(self) -> None:
         try:

--- a/dmp/client/intro_queue.py
+++ b/dmp/client/intro_queue.py
@@ -69,7 +69,12 @@ class IntroQueue:
     older binary points at a newer database.
     """
 
-    _SCHEMA_V1 = """
+    # Schema v1 as individual statements (NOT a script). ``executescript``
+    # does an implicit COMMIT before running, which would end the
+    # ``BEGIN IMMEDIATE`` transaction in ``_migrate``. Issue each
+    # statement via ``execute`` to stay inside the explicit transaction.
+    _SCHEMA_V1_STATEMENTS = (
+        """
         CREATE TABLE IF NOT EXISTS intros (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             sender_spk BLOB NOT NULL,
@@ -80,15 +85,20 @@ class IntroQueue:
             received_at INTEGER NOT NULL,
             msg_exp INTEGER NOT NULL,
             UNIQUE(sender_spk, msg_id)
-        );
+        )
+        """,
+        """
         CREATE INDEX IF NOT EXISTS idx_intros_received_at
-            ON intros(received_at DESC);
+            ON intros(received_at DESC)
+        """,
+        """
         CREATE TABLE IF NOT EXISTS denylist (
             sender_spk BLOB PRIMARY KEY,
             blocked_at INTEGER NOT NULL,
             note TEXT NOT NULL DEFAULT ''
-        );
-    """
+        )
+        """,
+    )
 
     # Latest schema version this code understands. Bump on every
     # schema-affecting change and append the migration to ``_MIGRATIONS``.
@@ -138,7 +148,7 @@ class IntroQueue:
                     pass
 
     def _migrate(self) -> None:
-        """Apply schema migrations idempotently and stamp ``user_version``.
+        """Apply schema migrations atomically and stamp ``user_version``.
 
         Reads the current ``PRAGMA user_version`` (0 for fresh databases
         and for older databases that predate this versioning scheme).
@@ -151,19 +161,33 @@ class IntroQueue:
         newer-schema file, and silently doing nothing would risk
         downgrading the schema (or worse, writing old-shape rows into
         a newer-shape table).
+
+        Concurrency: ``BEGIN IMMEDIATE`` makes the read-then-write
+        atomic against another connection on the same file. The current
+        v0→v1 step is idempotent so two racers wouldn't corrupt each
+        other today, but future migrations that ALTER columns would,
+        so the lock is in place from the start.
         """
-        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
-        if cur_version > self._SCHEMA_VERSION:
-            raise RuntimeError(
-                f"intro_queue at {self._path!r} has schema version "
-                f"{cur_version}, but this binary only understands up to "
-                f"{self._SCHEMA_VERSION}. Refusing to open — using an "
-                f"older client against a newer database would risk "
-                f"silently dropping fields."
-            )
-        if cur_version < 1:
-            self._conn.executescript(self._SCHEMA_V1)
-            self._conn.execute(f"PRAGMA user_version = 1")
+        # autocommit isolation_level=None means we drive txs explicitly.
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+            if cur_version > self._SCHEMA_VERSION:
+                raise RuntimeError(
+                    f"intro_queue at {self._path!r} has schema version "
+                    f"{cur_version}, but this binary only understands up to "
+                    f"{self._SCHEMA_VERSION}. Refusing to open — using an "
+                    f"older client against a newer database would risk "
+                    f"silently dropping fields."
+                )
+            if cur_version < 1:
+                for stmt in self._SCHEMA_V1_STATEMENTS:
+                    self._conn.execute(stmt)
+                self._conn.execute("PRAGMA user_version = 1")
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
 
     def close(self) -> None:
         try:

--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -134,16 +134,23 @@ class Prekey:
         return now > self.exp
 
 
-_SCHEMA_V1 = """
-CREATE TABLE IF NOT EXISTS prekeys (
-    prekey_id INTEGER PRIMARY KEY,
-    private_key BLOB NOT NULL,
-    public_key BLOB NOT NULL,
-    exp INTEGER NOT NULL,
-    created_at INTEGER NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_prekeys_exp ON prekeys(exp);
-"""
+# Schema v1 as individual statements (NOT a script). ``executescript``
+# does an implicit COMMIT before running, which would end the
+# ``BEGIN IMMEDIATE`` transaction in ``_migrate`` and let two concurrent
+# migrations race the ALTER. We issue each statement via ``execute`` to
+# stay inside the explicit transaction.
+_SCHEMA_V1_STATEMENTS: Tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS prekeys (
+        prekey_id INTEGER PRIMARY KEY,
+        private_key BLOB NOT NULL,
+        public_key BLOB NOT NULL,
+        exp INTEGER NOT NULL,
+        created_at INTEGER NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_prekeys_exp ON prekeys(exp)",
+)
 
 # v1 → v2: add wire_record so the client can DELETE the published
 # prekey_pub from DNS when its sk is consumed. Without this, the
@@ -179,8 +186,16 @@ class PrekeyStore:
         parent = os.path.dirname(db_path) or "."
         os.makedirs(parent, exist_ok=True)
         self._lock = RLock()
+        # 30s busy-timeout: ``_migrate`` takes a reserved write lock via
+        # ``BEGIN IMMEDIATE`` so concurrent opens on the same file
+        # serialize. The default sqlite3 timeout (5s) is too tight under
+        # load — when many other sqlite stores in the same process are
+        # also active (test suite, busy CI), threads waiting on the
+        # migration lock can hit ``database is locked`` before the
+        # leader's transaction completes. 30s leaves headroom without
+        # masking real deadlocks.
         self._conn = sqlite3.connect(
-            db_path, isolation_level=None, check_same_thread=False
+            db_path, isolation_level=None, check_same_thread=False, timeout=30.0
         )
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
@@ -191,7 +206,7 @@ class PrekeyStore:
             pass
 
     def _migrate(self) -> None:
-        """Apply schema migrations idempotently.
+        """Apply schema migrations atomically and idempotently.
 
         Versions:
           0 → 1: create the v1 schema (or no-op if tables already exist
@@ -204,34 +219,59 @@ class PrekeyStore:
                  stamp version 2.
 
         Future schema bumps add v(N) → v(N+1) steps below.
+
+        Concurrency: the per-instance ``RLock`` serializes within ONE
+        ``PrekeyStore`` instance, but two instances on the same db file
+        share nothing in-process. Without ``BEGIN IMMEDIATE`` below,
+        both can read ``user_version=0``, both check ``wire_record``
+        not present, and both attempt the ALTER — sqlite raises
+        ``duplicate column name`` on the second. ``BEGIN IMMEDIATE``
+        takes a sqlite-level reserved write lock, so concurrent
+        migrations serialize via the file lock; the second connection
+        waits, then sees the post-migration version and no-ops.
         """
-        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
-        if cur_version > _SCHEMA_VERSION:
-            raise RuntimeError(
-                f"prekey store at {self.db_path!r} has schema version "
-                f"{cur_version}, but this binary only understands up to "
-                f"{_SCHEMA_VERSION}. Refusing to open — using an older "
-                f"client against a newer database would risk silently "
-                f"dropping fields."
-            )
-        # v0 → v1: ensure the v1 tables exist. Idempotent against either
-        # a brand-new file OR an existing v0/v1/v2 file (CREATE TABLE IF
-        # NOT EXISTS is a no-op when the table is there).
-        if cur_version < 1:
-            self._conn.executescript(_SCHEMA_V1)
-            cur_version = 1
-        # v1 → v2: add wire_record. Some pre-versioning databases will
-        # already have this column from the old in-place migration — in
-        # that case skip the ALTER but still stamp the version.
-        if cur_version < 2:
-            cols = {
-                row[1]
-                for row in self._conn.execute("PRAGMA table_info(prekeys)").fetchall()
-            }
-            if "wire_record" not in cols:
-                self._conn.execute(_MIGRATION_V1_TO_V2)
-            cur_version = 2
-        self._conn.execute(f"PRAGMA user_version = {cur_version}")
+        # autocommit (isolation_level=None) means we drive transactions
+        # explicitly. BEGIN IMMEDIATE acquires the reserved lock now,
+        # which is what makes read-then-write atomic against other
+        # connections. A DEFERRED begin would let two transactions both
+        # read user_version=0 and race the ALTER.
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+            if cur_version > _SCHEMA_VERSION:
+                raise RuntimeError(
+                    f"prekey store at {self.db_path!r} has schema version "
+                    f"{cur_version}, but this binary only understands up to "
+                    f"{_SCHEMA_VERSION}. Refusing to open — using an older "
+                    f"client against a newer database would risk silently "
+                    f"dropping fields."
+                )
+            # v0 → v1: ensure the v1 tables exist. Idempotent against
+            # either a brand-new file OR an existing v0/v1/v2 file
+            # (CREATE TABLE IF NOT EXISTS is a no-op when the table is
+            # there).
+            if cur_version < 1:
+                for stmt in _SCHEMA_V1_STATEMENTS:
+                    self._conn.execute(stmt)
+                cur_version = 1
+            # v1 → v2: add wire_record. Some pre-versioning databases
+            # already have this column from the old in-place migration
+            # — in that case skip the ALTER but still stamp the version.
+            if cur_version < 2:
+                cols = {
+                    row[1]
+                    for row in self._conn.execute(
+                        "PRAGMA table_info(prekeys)"
+                    ).fetchall()
+                }
+                if "wire_record" not in cols:
+                    self._conn.execute(_MIGRATION_V1_TO_V2)
+                cur_version = 2
+            self._conn.execute(f"PRAGMA user_version = {cur_version}")
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
 
     def close(self) -> None:
         with self._lock:

--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -134,24 +134,26 @@ class Prekey:
         return now > self.exp
 
 
-_SCHEMA = """
+_SCHEMA_V1 = """
 CREATE TABLE IF NOT EXISTS prekeys (
     prekey_id INTEGER PRIMARY KEY,
     private_key BLOB NOT NULL,
     public_key BLOB NOT NULL,
     exp INTEGER NOT NULL,
-    created_at INTEGER NOT NULL,
-    wire_record TEXT DEFAULT ''
+    created_at INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_prekeys_exp ON prekeys(exp);
 """
 
-# For upgrading existing databases that predate wire_record. Sqlite ignores
-# the ALTER if the column already exists? No — sqlite raises "duplicate
-# column name". Guard with a check on columns.
-_WIRE_RECORD_COLUMN_MIGRATION = (
-    "ALTER TABLE prekeys ADD COLUMN wire_record TEXT DEFAULT ''"
-)
+# v1 → v2: add wire_record so the client can DELETE the published
+# prekey_pub from DNS when its sk is consumed. Without this, the
+# published RRset would rot in DNS — senders keep picking sks that
+# the recipient has already eaten.
+_MIGRATION_V1_TO_V2 = "ALTER TABLE prekeys ADD COLUMN wire_record TEXT DEFAULT ''"
+
+# Latest schema version this code understands. Bump on every schema-
+# affecting change and add a v(N-1) → v(N) step in ``_migrate``.
+_SCHEMA_VERSION = 2
 
 
 class PrekeyStore:
@@ -164,6 +166,12 @@ class PrekeyStore:
     The prekey_sk rows are the forward-secrecy secret. Protect the sqlite
     file with the same filesystem perms as the identity passphrase file
     (the CLI's `_make_client` wires them both out of `$DMP_CONFIG_HOME`).
+
+    Schema versioning (P1): tracked via ``PRAGMA user_version``. Each
+    bump adds a step to ``_migrate`` and increments ``_SCHEMA_VERSION``.
+    Refuses to open databases stamped at a HIGHER version than this code
+    knows — silently downgrading would risk dropping fields a newer
+    binary added.
     """
 
     def __init__(self, db_path: str) -> None:
@@ -176,20 +184,54 @@ class PrekeyStore:
         )
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
-        self._conn.executescript(_SCHEMA)
-        # Migrate older databases that lacked wire_record. Needed so a
-        # client upgraded in place can still delete its published prekeys
-        # on consume — without this, the published record rots in DNS.
-        cols = {
-            row[1]
-            for row in self._conn.execute("PRAGMA table_info(prekeys)").fetchall()
-        }
-        if "wire_record" not in cols:
-            self._conn.execute(_WIRE_RECORD_COLUMN_MIGRATION)
+        self._migrate()
         try:
             os.chmod(db_path, 0o600)
         except OSError:
             pass
+
+    def _migrate(self) -> None:
+        """Apply schema migrations idempotently.
+
+        Versions:
+          0 → 1: create the v1 schema (or no-op if tables already exist
+                 from a pre-versioning binary; the original schema bytes
+                 match the v1 definition).
+          1 → 2: ADD COLUMN wire_record so consume-on-decrypt can DELETE
+                 the published prekey_pub. Pre-existing v0 (unstamped)
+                 databases that already have wire_record (from the
+                 previous in-place migration) skip the ALTER and just
+                 stamp version 2.
+
+        Future schema bumps add v(N) → v(N+1) steps below.
+        """
+        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if cur_version > _SCHEMA_VERSION:
+            raise RuntimeError(
+                f"prekey store at {self.db_path!r} has schema version "
+                f"{cur_version}, but this binary only understands up to "
+                f"{_SCHEMA_VERSION}. Refusing to open — using an older "
+                f"client against a newer database would risk silently "
+                f"dropping fields."
+            )
+        # v0 → v1: ensure the v1 tables exist. Idempotent against either
+        # a brand-new file OR an existing v0/v1/v2 file (CREATE TABLE IF
+        # NOT EXISTS is a no-op when the table is there).
+        if cur_version < 1:
+            self._conn.executescript(_SCHEMA_V1)
+            cur_version = 1
+        # v1 → v2: add wire_record. Some pre-versioning databases will
+        # already have this column from the old in-place migration — in
+        # that case skip the ALTER but still stamp the version.
+        if cur_version < 2:
+            cols = {
+                row[1]
+                for row in self._conn.execute("PRAGMA table_info(prekeys)").fetchall()
+            }
+            if "wire_record" not in cols:
+                self._conn.execute(_MIGRATION_V1_TO_V2)
+            cur_version = 2
+        self._conn.execute(f"PRAGMA user_version = {cur_version}")
 
     def close(self) -> None:
         with self._lock:

--- a/tests/test_intro_queue.py
+++ b/tests/test_intro_queue.py
@@ -142,3 +142,93 @@ class TestPersistence:
         # should be set (0o600).
         mode = stat.S_IMODE(os.stat(path).st_mode)
         assert mode & 0o077 == 0, f"intros.db is too permissive: 0o{mode:o}"
+
+
+class TestSchemaVersioning:
+    """``PRAGMA user_version`` migration ladder. Without versioning, a
+    schema bump that adds a column (or worse, drops one) silently
+    misalligns deployed databases against the running code. The
+    versioning makes upgrades + downgrades explicit failures."""
+
+    def test_fresh_db_is_stamped_at_current_version(self, tmp_path):
+        """A brand-new database lands at the latest schema version, so
+        future migrations know they only need to apply the v(N→N+1) step
+        rather than re-running the v0→v1 baseline."""
+        import sqlite3
+
+        path = str(tmp_path / "fresh.db")
+        q = IntroQueue(path)
+        try:
+            stored = q._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == IntroQueue._SCHEMA_VERSION
+        finally:
+            q.close()
+
+    def test_legacy_unversioned_db_migrates_to_current(self, tmp_path):
+        """An existing database created by a pre-versioning binary
+        (user_version=0, bare CREATE TABLE schema) opens cleanly: the
+        v0→v1 step re-runs CREATE TABLE IF NOT EXISTS (idempotent) and
+        stamps the version. Existing rows are preserved.
+        """
+        import sqlite3
+
+        path = str(tmp_path / "legacy.db")
+        # Simulate the pre-versioning shape: bare schema, user_version
+        # never stamped (still 0, sqlite default).
+        legacy = sqlite3.connect(path, isolation_level=None)
+        legacy.executescript(IntroQueue._SCHEMA_V1)
+        legacy.execute(
+            "INSERT INTO intros(sender_spk, msg_id, plaintext, "
+            "sender_mailbox_domain, received_at, msg_exp) "
+            "VALUES(?, ?, ?, ?, ?, ?)",
+            (b"\xaa" * 32, b"\xbb" * 16, b"legacy intro", "old.host", 100, 200),
+        )
+        legacy.close()
+
+        q = IntroQueue(path)
+        try:
+            stored = q._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 1
+            rows = q.list_intros()
+            assert len(rows) == 1
+            assert rows[0].plaintext == b"legacy intro"
+        finally:
+            q.close()
+
+    def test_future_version_db_refuses_to_open(self, tmp_path):
+        """A database whose stored version is HIGHER than this code
+        understands must NOT open silently — running an older binary
+        against a newer schema would risk dropping fields the binary
+        doesn't know about. Hard error with the version mismatch.
+        """
+        import sqlite3
+
+        path = str(tmp_path / "future.db")
+        future = sqlite3.connect(path, isolation_level=None)
+        future.executescript(IntroQueue._SCHEMA_V1)
+        # Stamp a version higher than the code knows.
+        future.execute(f"PRAGMA user_version = {IntroQueue._SCHEMA_VERSION + 5}")
+        future.close()
+
+        with pytest.raises(RuntimeError, match="schema version"):
+            IntroQueue(path)
+
+    def test_reopen_existing_versioned_db_is_idempotent(self, tmp_path):
+        """A database already at the current version opens without
+        re-running migrations or bumping the stamp."""
+        path = str(tmp_path / "stable.db")
+        q1 = IntroQueue(path)
+        intro_id = _seed(q1)
+        v_after_first = q1._conn.execute("PRAGMA user_version").fetchone()[0]
+        q1.close()
+
+        q2 = IntroQueue(path)
+        try:
+            v_after_reopen = q2._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert v_after_reopen == v_after_first
+            # Data intact.
+            rows = q2.list_intros()
+            assert len(rows) == 1
+            assert rows[0].intro_id == intro_id
+        finally:
+            q2.close()

--- a/tests/test_intro_queue.py
+++ b/tests/test_intro_queue.py
@@ -176,7 +176,8 @@ class TestSchemaVersioning:
         # Simulate the pre-versioning shape: bare schema, user_version
         # never stamped (still 0, sqlite default).
         legacy = sqlite3.connect(path, isolation_level=None)
-        legacy.executescript(IntroQueue._SCHEMA_V1)
+        for stmt in IntroQueue._SCHEMA_V1_STATEMENTS:
+            legacy.execute(stmt)
         legacy.execute(
             "INSERT INTO intros(sender_spk, msg_id, plaintext, "
             "sender_mailbox_domain, received_at, msg_exp) "
@@ -205,7 +206,8 @@ class TestSchemaVersioning:
 
         path = str(tmp_path / "future.db")
         future = sqlite3.connect(path, isolation_level=None)
-        future.executescript(IntroQueue._SCHEMA_V1)
+        for stmt in IntroQueue._SCHEMA_V1_STATEMENTS:
+            future.execute(stmt)
         # Stamp a version higher than the code knows.
         future.execute(f"PRAGMA user_version = {IntroQueue._SCHEMA_VERSION + 5}")
         future.close()

--- a/tests/test_prekeys.py
+++ b/tests/test_prekeys.py
@@ -165,6 +165,121 @@ class TestPrekeyStore:
             s2.close()
 
 
+class TestPrekeyStoreSchemaVersioning:
+    """``PRAGMA user_version`` migration ladder for the prekey store.
+
+    Pre-versioning binaries left ``user_version=0`` and ran an inline
+    column-presence check to add ``wire_record`` for v1→v2. The new
+    versioning makes that step explicit and stamps the version so future
+    bumps don't have to re-derive the schema state from PRAGMA
+    table_info every open.
+    """
+
+    def test_fresh_db_is_stamped_at_current_version(self, tmp_path):
+        from dmp.core.prekeys import _SCHEMA_VERSION
+
+        db = str(tmp_path / "fresh.db")
+        store = PrekeyStore(db)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == _SCHEMA_VERSION
+        finally:
+            store.close()
+
+    def test_legacy_pre_wire_record_db_migrates_to_v2(self, tmp_path):
+        """A db created by the very first prekey-store binary (no
+        wire_record column, user_version unstamped) opens cleanly: the
+        v1→v2 step adds the column and stamps the version. Existing
+        rows are preserved."""
+        import sqlite3
+
+        db = str(tmp_path / "legacy.db")
+        # Mimic the original v1 schema: no wire_record column.
+        legacy = sqlite3.connect(db, isolation_level=None)
+        legacy.executescript("""
+            CREATE TABLE prekeys (
+                prekey_id INTEGER PRIMARY KEY,
+                private_key BLOB NOT NULL,
+                public_key BLOB NOT NULL,
+                exp INTEGER NOT NULL,
+                created_at INTEGER NOT NULL
+            );
+            """)
+        legacy.execute(
+            "INSERT INTO prekeys(prekey_id, private_key, public_key, "
+            "exp, created_at) VALUES(?, ?, ?, ?, ?)",
+            (42, b"\x01" * 32, b"\x02" * 32, 9_999_999_999, 100),
+        )
+        legacy.close()
+
+        store = PrekeyStore(db)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 2
+            cols = {
+                row[1]
+                for row in store._conn.execute("PRAGMA table_info(prekeys)").fetchall()
+            }
+            assert "wire_record" in cols
+            # Old row still findable. get_private_key returns the
+            # constructed X25519PrivateKey, not raw bytes; existence is
+            # what the migration test cares about.
+            assert store.get_private_key(42) is not None
+        finally:
+            store.close()
+
+    def test_legacy_v1_5_with_wire_record_but_unstamped(self, tmp_path):
+        """Some pre-versioning binaries DID add wire_record via the old
+        inline migration but never stamped user_version. The v1→v2 step
+        must skip the duplicate ALTER (sqlite would raise) and just
+        stamp the version."""
+        import sqlite3
+
+        db = str(tmp_path / "legacy_with_wr.db")
+        legacy = sqlite3.connect(db, isolation_level=None)
+        legacy.executescript("""
+            CREATE TABLE prekeys (
+                prekey_id INTEGER PRIMARY KEY,
+                private_key BLOB NOT NULL,
+                public_key BLOB NOT NULL,
+                exp INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                wire_record TEXT DEFAULT ''
+            );
+            """)
+        legacy.close()
+
+        store = PrekeyStore(db)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 2
+        finally:
+            store.close()
+
+    def test_future_version_db_refuses_to_open(self, tmp_path):
+        import sqlite3
+
+        from dmp.core.prekeys import _SCHEMA_VERSION
+
+        db = str(tmp_path / "future.db")
+        future = sqlite3.connect(db, isolation_level=None)
+        future.executescript("""
+            CREATE TABLE prekeys (
+                prekey_id INTEGER PRIMARY KEY,
+                private_key BLOB NOT NULL,
+                public_key BLOB NOT NULL,
+                exp INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                wire_record TEXT DEFAULT ''
+            );
+            """)
+        future.execute(f"PRAGMA user_version = {_SCHEMA_VERSION + 5}")
+        future.close()
+
+        with pytest.raises(RuntimeError, match="schema version"):
+            PrekeyStore(db)
+
+
 class TestRrsetNaming:
     def test_hashed_label(self):
         name = prekey_rrset_name("alice", "mesh.example.com")

--- a/tests/test_prekeys.py
+++ b/tests/test_prekeys.py
@@ -279,6 +279,69 @@ class TestPrekeyStoreSchemaVersioning:
         with pytest.raises(RuntimeError, match="schema version"):
             PrekeyStore(db)
 
+    def test_concurrent_migrations_do_not_race(self, tmp_path):
+        """Two PrekeyStore instances opening the SAME legacy
+        (no-wire_record, unstamped) db file simultaneously must not
+        race each other's ALTER. Without BEGIN IMMEDIATE both can read
+        user_version=0, both observe wire_record absent, both attempt
+        the column add — sqlite raises ``duplicate column name`` on
+        the second. With the explicit reserved-lock transaction, the
+        second waits for the first to commit and then sees the
+        post-migration state.
+        """
+        import sqlite3
+        import threading
+
+        db = str(tmp_path / "race.db")
+        # Seed a legacy v1 schema (no wire_record, unstamped).
+        legacy = sqlite3.connect(db, isolation_level=None)
+        legacy.executescript("""
+            CREATE TABLE prekeys (
+                prekey_id INTEGER PRIMARY KEY,
+                private_key BLOB NOT NULL,
+                public_key BLOB NOT NULL,
+                exp INTEGER NOT NULL,
+                created_at INTEGER NOT NULL
+            );
+            """)
+        legacy.close()
+
+        errors: list = []
+        stores: list = []
+        start = threading.Event()
+        lock = threading.Lock()
+
+        def _worker():
+            start.wait()
+            try:
+                s = PrekeyStore(db)
+                with lock:
+                    stores.append(s)
+            except Exception as exc:
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=_worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join(timeout=10)
+
+        try:
+            assert not errors, f"concurrent migrations raised: {errors}"
+            for s in stores:
+                cols = {
+                    row[1]
+                    for row in s._conn.execute("PRAGMA table_info(prekeys)").fetchall()
+                }
+                assert "wire_record" in cols
+                stamped = s._conn.execute("PRAGMA user_version").fetchone()[0]
+                assert stamped == 2
+        finally:
+            for s in stores:
+                s.close()
+
 
 class TestRrsetNaming:
     def test_hashed_label(self):


### PR DESCRIPTION
## Summary

Two of the auxiliary sqlite stores (`intro_queue.py`, `prekeys.py`) ran bare `CREATE TABLE IF NOT EXISTS` with no `PRAGMA user_version` stamp. `prekeys.py` also had an ad-hoc inline column-presence check to migrate v1 → v2 for `wire_record`. The audit flagged this as a real footgun: a future schema bump would silently misalign deployed databases against the running code, and there was no way to detect a database stamped at a higher version than the binary understands.

This PR adds an explicit migration ladder to both stores:

- `_SCHEMA_VERSION` constant (1 for `intro_queue`, 2 for `prekeys`).
- `_migrate()` method that reads `PRAGMA user_version`, applies each step in order, and stamps the result.
- **Hard refusal** to open a database whose stored version is HIGHER than `_SCHEMA_VERSION` — older-binary-against-newer-database is a real downgrade risk that this catches.

The main store (`dmp/storage/sqlite_store.py`) was already versioned via column-presence migration; this PR brings the auxiliary stores up to the same hygiene level.

## Changes

### `dmp/client/intro_queue.py`
- `_SCHEMA` → `_SCHEMA_V1` (named for its place in the ladder).
- `_SCHEMA_VERSION = 1`.
- `_migrate()` runs the v0 → v1 baseline (CREATE TABLE IF NOT EXISTS, idempotent) and stamps `user_version=1`.

### `dmp/core/prekeys.py`
- `_SCHEMA_V1` is the original schema (no `wire_record`).
- `_MIGRATION_V1_TO_V2` carries the existing `ALTER TABLE ADD COLUMN wire_record`.
- `_SCHEMA_VERSION = 2`.
- `_migrate()` handles three pre-existing database shapes cleanly:
  - **v0 fresh / unversioned without wire_record**: run v0→v1 baseline, then v1→v2 ALTER, stamp v2.
  - **v0 unversioned WITH wire_record** (some pre-versioning binaries did the inline migration but never stamped): skip the ALTER (sqlite would raise `duplicate column`), just stamp v2.
  - **v2 stamped**: idempotent open.

### Tests

`tests/test_intro_queue.py::TestSchemaVersioning` (4 tests):
- Fresh db stamped at latest version
- Legacy unversioned (user_version=0) migrates and preserves rows
- Future-version db refuses to open (clear RuntimeError)
- Re-open is idempotent

`tests/test_prekeys.py::TestPrekeyStoreSchemaVersioning` (4 tests):
- Fresh db stamped at v2
- Legacy v1 (no wire_record) migrates to v2 with rows preserved
- Legacy v1.5 (with wire_record but unstamped) stamps to v2 without re-ALTER
- Future-version db refuses to open

## Validation

- **Full suite:** 1470 passed, 3 skipped (docker tests when image absent). Net +8 new tests.
- **Lint:** `black --check dmp tests` clean.
- **Behavior change:** none for healthy databases. Only the future-version-db case introduces a new failure mode (RuntimeError), which is the whole point.

## Out of scope (future P2 work)

The other auxiliary stores (`tokens.py`, `tsig_keystore.py`, `heartbeat_store.py`) still rely on column-presence migrations or implicit ordering. Worth converting to the same ladder pattern for consistency, but they're more entangled with active migration paths and deserve their own PR.

## Audit reconciliation

The original feedback flagged "no schema versioning in SQLite" as PARTIAL — `sqlite_store.py` was migrated, the auxiliary stores weren't. After this PR the two specific stores the audit named (`intro_queue.py` and `prekeys.py`) carry explicit versioning. PARTIAL → RESOLVED for those.