### PR TITLE
feat(storage): version remaining sqlite stores via PRAGMA user_version

### DIFF
--- a/dmp/server/admin.py
+++ b/dmp/server/admin.py
@@ -432,7 +432,15 @@ def main(argv: Optional[list] = None) -> int:
         )
         return 2
 
-    store = TokenStore(db_path)
+    try:
+        store = TokenStore(db_path)
+    except RuntimeError as exc:
+        # Schema-version refusal from TokenStore._migrate. Surface as
+        # a friendly CLI error rather than a Python traceback so the
+        # operator sees what to act on (downgrade the binary or
+        # migrate the data file).
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     try:
         return int(args.func(args, store))
     finally:

--- a/dmp/server/heartbeat_store.py
+++ b/dmp/server/heartbeat_store.py
@@ -55,7 +55,7 @@ DEFAULT_RETENTION_SECONDS = 72 * 3600  # 3 days
 DEFAULT_MAX_ROWS = 10_000
 
 
-_SCHEMA = """
+_SCHEMA_V1 = """
 CREATE TABLE IF NOT EXISTS heartbeats_seen (
     operator_spk_hex  TEXT NOT NULL,
     endpoint          TEXT NOT NULL,
@@ -72,6 +72,10 @@ CREATE INDEX IF NOT EXISTS idx_hb_ts          ON heartbeats_seen(ts DESC);
 CREATE INDEX IF NOT EXISTS idx_hb_exp         ON heartbeats_seen(exp);
 CREATE INDEX IF NOT EXISTS idx_hb_received_at ON heartbeats_seen(received_at);
 """
+
+# Latest schema version this code understands. Bump on every
+# schema-affecting change and add a v(N-1) → v(N) step in ``_migrate``.
+_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -109,8 +113,31 @@ class SeenStore:
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
-        self._conn.executescript(_SCHEMA)
+        self._migrate()
         self._conn.commit()
+
+    def _migrate(self) -> None:
+        """Apply schema migrations idempotently and stamp ``user_version``.
+
+        v0 → v1: create the v1 schema (or no-op if tables already exist
+        from a pre-versioning binary).
+
+        Per-node singleton: no cross-process concurrent open expected,
+        so ``BEGIN IMMEDIATE`` isn't needed here (unlike PrekeyStore /
+        IntroQueue where multi-process opens are a real concern).
+        """
+        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if cur_version > _SCHEMA_VERSION:
+            raise RuntimeError(
+                f"heartbeat seen-store at {self._path!r} has schema version "
+                f"{cur_version}, but this binary only understands up to "
+                f"{_SCHEMA_VERSION}. Refusing to open — using an older "
+                f"binary against a newer database would risk silently "
+                f"dropping fields."
+            )
+        if cur_version < 1:
+            self._conn.executescript(_SCHEMA_V1)
+            self._conn.execute("PRAGMA user_version = 1")
 
     # ------------------------------------------------------------------
     # writes

--- a/dmp/server/node.py
+++ b/dmp/server/node.py
@@ -1633,7 +1633,19 @@ class DMPNode:
 
 
 def main() -> None:
-    node = DMPNode.from_env()
+    try:
+        node = DMPNode.from_env()
+    except RuntimeError as exc:
+        # Schema-version refusal from one of the per-node sqlite stores
+        # (SeenStore, TokenStore, TSIGKeyStore). Surface as a friendly
+        # exit-1 so the operator sees what to act on instead of a Python
+        # traceback. PR #40 added the same pattern to ``dnsmesh``'s
+        # ``_make_client``; PR #42 codex review caught it was missing on
+        # ``dnsmesh-node`` startup.
+        import sys
+
+        print(f"dnsmesh-node: {exc}", file=sys.stderr)
+        sys.exit(1)
     node.start()
     node.wait()
 

--- a/dmp/server/tokens.py
+++ b/dmp/server/tokens.py
@@ -554,7 +554,7 @@ class TokenStore:
         self._rate_limiter = _PerTokenBucket()
 
     def _migrate(self) -> None:
-        """Apply schema migrations idempotently and stamp ``user_version``.
+        """Apply schema migrations atomically and stamp ``user_version``.
 
         Versions:
           0 → 2: a fresh database — ``executescript(_SCHEMA)`` creates
@@ -567,29 +567,52 @@ class TokenStore:
                  "v2 already, just stamp it".
           2 → 2: fully migrated, idempotent stamp.
 
-        Per-node singleton: no cross-process concurrent open expected,
-        so ``BEGIN IMMEDIATE`` isn't needed (PrekeyStore / IntroQueue
-        are different — multi-process opens are a real concern there).
+        Concurrency: NOT a per-node singleton — ``dnsmesh-node-admin``
+        opens the same token DB as the running node (see
+        ``dmp/server/admin.py``). Without ``BEGIN IMMEDIATE`` two
+        connections could both read ``user_version=0``, both attempt
+        the ALTER, and the second hits ``duplicate column``. The
+        current swallow handles that case, but a future migration
+        with non-idempotent operations (a UPDATE backfill, etc) would
+        race silently. Take the reserved write lock now.
         """
-        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
-        if cur_version > _SCHEMA_VERSION:
-            raise RuntimeError(
-                f"token store at {self._path!r} has schema version "
-                f"{cur_version}, but this binary only understands up to "
-                f"{_SCHEMA_VERSION}. Refusing to open — using an older "
-                f"binary against a newer database would risk silently "
-                f"dropping fields."
-            )
-        if cur_version < 2:
-            # CREATE TABLE IF NOT EXISTS — no-op if tables already exist
-            # (legacy v1 + pre-versioning v2 cases).
-            self._conn.executescript(_SCHEMA)
-            try:
-                self._conn.execute(_MIGRATION_V1_TO_V2)
-            except sqlite3.OperationalError as exc:
-                if "duplicate column" not in str(exc).lower():
-                    raise
-            self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+        # Phase 1: ensure the schema tables/indexes exist. Idempotent
+        # at the SQL level via ``CREATE TABLE IF NOT EXISTS`` — sqlite
+        # serializes concurrent issuers via the file lock, so two
+        # connections both running this won't conflict. Run OUTSIDE
+        # ``BEGIN IMMEDIATE`` because ``executescript`` does an
+        # implicit COMMIT that would end our explicit transaction.
+        self._conn.commit()
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+        # Phase 2: atomic version-check + ALTER + stamp under
+        # ``BEGIN IMMEDIATE`` so two connections (e.g. node + admin)
+        # can't both read ``user_version=0`` and both attempt the
+        # ALTER. The second waits for the first to commit and then
+        # sees v2 already stamped.
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+            if cur_version > _SCHEMA_VERSION:
+                raise RuntimeError(
+                    f"token store at {self._path!r} has schema version "
+                    f"{cur_version}, but this binary only understands up to "
+                    f"{_SCHEMA_VERSION}. Refusing to open — using an older "
+                    f"binary against a newer database would risk silently "
+                    f"dropping fields."
+                )
+            if cur_version < 2:
+                try:
+                    self._conn.execute(_MIGRATION_V1_TO_V2)
+                except sqlite3.OperationalError as exc:
+                    if "duplicate column" not in str(exc).lower():
+                        raise
+                self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+            self._conn.execute("COMMIT")
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
 
     # ---- issuance ----------------------------------------------------------
 

--- a/dmp/server/tokens.py
+++ b/dmp/server/tokens.py
@@ -517,12 +517,18 @@ CREATE TABLE IF NOT EXISTS token_audit (
 CREATE INDEX IF NOT EXISTS idx_audit_ts ON token_audit(ts);
 """
 
-# One-off migration for deployments that predate phase 3. Adding a
-# column at runtime is cheaper than bumping the schema_version and the
-# `tokens` table is single-owner (no migrations of in-flight data).
-_MIGRATION_ADD_REGISTERED_SPK = """
+# v1 → v2: add registered_spk so the anti-takeover gate has the
+# original signing key to compare future re-registrations against.
+# Pre-versioning binaries ran this inline and never stamped
+# ``user_version``; the migration ladder catches that case via the
+# ``duplicate column`` errno.
+_MIGRATION_V1_TO_V2 = """
 ALTER TABLE tokens ADD COLUMN registered_spk TEXT
 """
+
+# Latest schema version this code understands. Bump on every
+# schema-affecting change and add a v(N-1) → v(N) step in ``_migrate``.
+_SCHEMA_VERSION = 2
 
 
 class TokenStore:
@@ -539,21 +545,51 @@ class TokenStore:
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
-        self._conn.executescript(_SCHEMA)
-        # Best-effort additive migration for the phase-3 column.
-        # sqlite rejects "ADD COLUMN if already exists"; catch the
-        # duplicate-column error and move on.
-        try:
-            self._conn.execute(_MIGRATION_ADD_REGISTERED_SPK)
-        except sqlite3.OperationalError as exc:
-            if "duplicate column" not in str(exc).lower():
-                raise
+        self._migrate()
         self._conn.commit()
         # Per-token rate limiter. In-memory, ephemeral by design —
         # rate state doesn't survive a node restart, matching how the
         # per-IP limiter behaves. Reissuing a throttled token via a
         # restart is a documented failure mode in the operator guide.
         self._rate_limiter = _PerTokenBucket()
+
+    def _migrate(self) -> None:
+        """Apply schema migrations idempotently and stamp ``user_version``.
+
+        Versions:
+          0 → 2: a fresh database — ``executescript(_SCHEMA)`` creates
+                 the v2 shape directly (registered_spk is in the CREATE
+                 TABLE). Stamp v2 and we're done.
+          1 → 2: a legacy database from before the inline registered_spk
+                 migration. Run the ALTER. Pre-versioning binaries that
+                 already ran the inline ALTER but never stamped will
+                 raise ``duplicate column`` here — caught and treated as
+                 "v2 already, just stamp it".
+          2 → 2: fully migrated, idempotent stamp.
+
+        Per-node singleton: no cross-process concurrent open expected,
+        so ``BEGIN IMMEDIATE`` isn't needed (PrekeyStore / IntroQueue
+        are different — multi-process opens are a real concern there).
+        """
+        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if cur_version > _SCHEMA_VERSION:
+            raise RuntimeError(
+                f"token store at {self._path!r} has schema version "
+                f"{cur_version}, but this binary only understands up to "
+                f"{_SCHEMA_VERSION}. Refusing to open — using an older "
+                f"binary against a newer database would risk silently "
+                f"dropping fields."
+            )
+        if cur_version < 2:
+            # CREATE TABLE IF NOT EXISTS — no-op if tables already exist
+            # (legacy v1 + pre-versioning v2 cases).
+            self._conn.executescript(_SCHEMA)
+            try:
+                self._conn.execute(_MIGRATION_V1_TO_V2)
+            except sqlite3.OperationalError as exc:
+                if "duplicate column" not in str(exc).lower():
+                    raise
+            self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
     # ---- issuance ----------------------------------------------------------
 

--- a/dmp/server/tsig_keystore.py
+++ b/dmp/server/tsig_keystore.py
@@ -87,11 +87,17 @@ CREATE INDEX IF NOT EXISTS idx_tsig_active ON tsig_keys(revoked, expires_at);
 CREATE INDEX IF NOT EXISTS idx_tsig_subject ON tsig_keys(subject);
 """
 
-# Schema migration for keystores created before later columns landed.
+# Schema migrations. Each ADD COLUMN was added in successive code
+# revisions (subject → v2, registered_spk → v3, registered_x25519_pub
+# → v4); the current ``_SCHEMA`` declares all of them inline so a fresh
+# database lands directly at v4 via ``executescript``. For keystores
+# created by older binaries, the ALTERs run idempotently — sqlite
+# raises ``duplicate column`` on already-present columns, which we
+# swallow.
+#
 # ALTER TABLE IF NOT EXISTS is sqlite 3.35+, which we don't depend on,
-# so we add the columns idempotently via try/except. Each ADD COLUMN
-# raises OperationalError if the column already exists; swallow that
-# and continue.
+# so we add the columns via try/except. Future schema bumps add a
+# v(N) → v(N+1) ALTER and bump ``_SCHEMA_VERSION``.
 _MIGRATIONS = (
     "ALTER TABLE tsig_keys ADD COLUMN subject TEXT NOT NULL DEFAULT ''",
     "ALTER TABLE tsig_keys ADD COLUMN registered_spk TEXT NOT NULL DEFAULT ''",
@@ -105,6 +111,10 @@ _MIGRATIONS = (
     # zone (no ``mb-{hash}.{zone}`` entry to extract).
     "ALTER TABLE tsig_keys ADD COLUMN registered_x25519_pub TEXT NOT NULL DEFAULT ''",
 )
+
+# Latest schema version this code understands. Bump on every
+# schema-affecting change and append the ALTER to ``_MIGRATIONS``.
+_SCHEMA_VERSION = 4
 
 
 def _normalize_name(name: str) -> str:
@@ -265,16 +275,48 @@ class TSIGKeyStore:
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
-        self._conn.executescript(_SCHEMA)
-        # Best-effort column adds for keystores created before the
-        # subject + registered_spk columns landed. SQLite raises on
-        # duplicate ADD COLUMN, which we swallow.
-        for stmt in _MIGRATIONS:
-            try:
-                self._conn.execute(stmt)
-            except sqlite3.OperationalError:
-                pass
+        self._migrate()
         self._conn.commit()
+
+    def _migrate(self) -> None:
+        """Apply schema migrations idempotently and stamp ``user_version``.
+
+        v0 → v4: a fresh database lands at v4 directly via
+        ``executescript(_SCHEMA)`` (the current schema has all four
+        columns inline). Legacy databases with subsets of the columns
+        get filled in by the idempotent ALTER pass — sqlite raises
+        ``duplicate column`` when a column is already present, which we
+        swallow.
+
+        Per-node singleton: no cross-process concurrent open expected,
+        so ``BEGIN IMMEDIATE`` isn't needed (PrekeyStore / IntroQueue
+        are different — multi-process opens are a real concern there).
+        """
+        cur_version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if cur_version > _SCHEMA_VERSION:
+            raise RuntimeError(
+                f"tsig keystore at {self._path!r} has schema version "
+                f"{cur_version}, but this binary only understands up to "
+                f"{_SCHEMA_VERSION}. Refusing to open — using an older "
+                f"binary against a newer database would risk silently "
+                f"dropping fields."
+            )
+        if cur_version < _SCHEMA_VERSION:
+            # Order matters: ALTERs first to backfill columns on a
+            # legacy v1 keystore before executescript runs the CREATE
+            # INDEX on ``subject`` (which would otherwise raise
+            # ``no such column: subject`` on a v1 db). On a fresh db
+            # the ALTERs hit ``no such table`` (ignored), executescript
+            # creates everything from the v4 inline schema, and the
+            # second ALTER pass below hits ``duplicate column``
+            # (ignored). Idempotent in both directions.
+            for stmt in _MIGRATIONS:
+                try:
+                    self._conn.execute(stmt)
+                except sqlite3.OperationalError:
+                    pass
+            self._conn.executescript(_SCHEMA)
+            self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 
     # ------------------------------------------------------------------
     # writes

--- a/dmp/server/tsig_keystore.py
+++ b/dmp/server/tsig_keystore.py
@@ -310,11 +310,20 @@ class TSIGKeyStore:
             # creates everything from the v4 inline schema, and the
             # second ALTER pass below hits ``duplicate column``
             # (ignored). Idempotent in both directions.
+            #
+            # Filter the swallowed errors to ONLY the two we expect
+            # (PR #42 codex review caught the original blanket swallow:
+            # an unrelated OperationalError would silently leave the
+            # schema half-migrated and we would still stamp v4, which
+            # permanently masks the problem).
             for stmt in _MIGRATIONS:
                 try:
                     self._conn.execute(stmt)
-                except sqlite3.OperationalError:
-                    pass
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc).lower()
+                    if "duplicate column" in msg or "no such table" in msg:
+                        continue
+                    raise
             self._conn.executescript(_SCHEMA)
             self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
 

--- a/tests/test_heartbeat_store.py
+++ b/tests/test_heartbeat_store.py
@@ -360,3 +360,80 @@ class TestForget:
         spk_hex = signer.get_signing_public_key_bytes().hex()
         store.forget(spk_hex, "https://dmp.example.com")
         assert store.forget(spk_hex, "https://dmp.example.com") is False
+
+
+class TestSchemaVersioning:
+    """``PRAGMA user_version`` migration ladder for SeenStore.
+
+    Per-node singleton with a single schema version so far; the ladder
+    is in place for future bumps and to refuse newer-on-older opens.
+    """
+
+    def test_fresh_db_is_stamped_at_current_version(self, tmp_path):
+        from dmp.server.heartbeat_store import _SCHEMA_VERSION, SeenStore
+
+        store = SeenStore(str(tmp_path / "fresh.db"))
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == _SCHEMA_VERSION
+        finally:
+            store.close()
+
+    def test_legacy_unversioned_db_is_migrated(self, tmp_path):
+        """A pre-versioning database (current schema, user_version=0)
+        opens cleanly, gets the current version stamped, and existing
+        rows survive — the migration is no-op data-wise."""
+        import sqlite3
+
+        from dmp.server.heartbeat_store import SeenStore, _SCHEMA_V1
+
+        path = str(tmp_path / "legacy.db")
+        legacy = sqlite3.connect(path)
+        legacy.executescript(_SCHEMA_V1)
+        legacy.execute(
+            "INSERT INTO heartbeats_seen("
+            "operator_spk_hex, endpoint, wire, ts, exp, version,"
+            "received_at, remote_addr"
+            ") VALUES(?,?,?,?,?,?,?,?)",
+            (
+                "aa" * 32,
+                "https://x.test",
+                "v=dmp1;t=hb;d=AAAA",
+                1000,
+                9_999_999_999,
+                "0.0.1",
+                1500,
+                "127.0.0.1",
+            ),
+        )
+        legacy.commit()
+        legacy.close()
+
+        store = SeenStore(path)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 1
+            row = store._conn.execute(
+                "SELECT operator_spk_hex FROM heartbeats_seen"
+            ).fetchone()
+            assert row[0] == "aa" * 32
+        finally:
+            store.close()
+
+    def test_future_version_db_refuses_to_open(self, tmp_path):
+        """A db stamped HIGHER than this binary understands raises —
+        running an older binary against newer data risks dropping
+        fields silently."""
+        import sqlite3
+
+        from dmp.server.heartbeat_store import SeenStore, _SCHEMA_V1, _SCHEMA_VERSION
+
+        path = str(tmp_path / "future.db")
+        future = sqlite3.connect(path)
+        future.executescript(_SCHEMA_V1)
+        future.execute(f"PRAGMA user_version = {_SCHEMA_VERSION + 5}")
+        future.commit()
+        future.close()
+
+        with pytest.raises(RuntimeError, match="schema version"):
+            SeenStore(path)

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -592,3 +592,152 @@ class TestAuditSplit:
         assert len(rejects) == 1
         _, _, _, _, addr, _ = rejects[0]
         assert addr == "10.0.0.7"
+
+
+class TestSchemaVersioning:
+    """Migration ladder for TokenStore.
+
+    Versions:
+      v1 = original schema (no registered_spk column)
+      v2 = current schema (registered_spk inline)
+
+    Pre-versioning binaries either already ran the inline ALTER (no
+    user_version stamp) or never did (legacy v1 schema). The ladder
+    handles both.
+    """
+
+    def test_fresh_db_is_stamped_at_current_version(self, tmp_path):
+        from dmp.server.tokens import _SCHEMA_VERSION, TokenStore
+
+        store = TokenStore(str(tmp_path / "fresh.db"))
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == _SCHEMA_VERSION
+            cols = {
+                row[1]
+                for row in store._conn.execute("PRAGMA table_info(tokens)").fetchall()
+            }
+            assert "registered_spk" in cols
+        finally:
+            store.close()
+
+    def test_legacy_v1_db_migrates_to_v2(self, tmp_path):
+        """A db created by the original tokens schema (no
+        registered_spk, user_version=0) gets the column added on
+        open and the version stamped. Existing rows are preserved.
+        """
+        import sqlite3
+
+        from dmp.server.tokens import TokenStore
+
+        path = str(tmp_path / "legacy.db")
+        legacy = sqlite3.connect(path)
+        legacy.executescript("""
+            CREATE TABLE tokens (
+                token_hash     TEXT PRIMARY KEY,
+                subject        TEXT NOT NULL,
+                subject_type   INTEGER NOT NULL,
+                subject_hash12 TEXT,
+                rate_per_sec   REAL NOT NULL DEFAULT 10.0,
+                rate_burst     INTEGER NOT NULL DEFAULT 50,
+                issued_at      INTEGER NOT NULL,
+                expires_at     INTEGER,
+                revoked_at     INTEGER,
+                issuer         TEXT NOT NULL DEFAULT '',
+                note           TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE token_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER NOT NULL,
+                event TEXT NOT NULL,
+                token_hash TEXT,
+                subject TEXT,
+                remote_addr TEXT,
+                detail TEXT
+            );
+            """)
+        legacy.execute(
+            "INSERT INTO tokens(token_hash, subject, subject_type, "
+            "issued_at, issuer, note) VALUES(?, ?, ?, ?, ?, ?)",
+            ("h0", "alice@example", 1, 100, "test", ""),
+        )
+        legacy.commit()
+        legacy.close()
+
+        store = TokenStore(path)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 2
+            cols = {
+                row[1]
+                for row in store._conn.execute("PRAGMA table_info(tokens)").fetchall()
+            }
+            assert "registered_spk" in cols
+            row = store._conn.execute("SELECT token_hash FROM tokens").fetchone()
+            assert row[0] == "h0"
+        finally:
+            store.close()
+
+    def test_legacy_v1_5_with_registered_spk_but_unstamped(self, tmp_path):
+        """A pre-versioning binary that already ran the inline
+        registered_spk ALTER but never stamped ``user_version`` opens
+        cleanly: the ALTER hits ``duplicate column`` (caught), and the
+        version is stamped to v2.
+        """
+        import sqlite3
+
+        from dmp.server.tokens import TokenStore
+
+        path = str(tmp_path / "legacy_with_spk.db")
+        legacy = sqlite3.connect(path)
+        # Same as v1 schema but with registered_spk pre-added (matches
+        # what the pre-versioning binary's inline ALTER produced).
+        legacy.executescript("""
+            CREATE TABLE tokens (
+                token_hash TEXT PRIMARY KEY,
+                subject TEXT NOT NULL,
+                subject_type INTEGER NOT NULL,
+                subject_hash12 TEXT,
+                rate_per_sec REAL NOT NULL DEFAULT 10.0,
+                rate_burst INTEGER NOT NULL DEFAULT 50,
+                issued_at INTEGER NOT NULL,
+                expires_at INTEGER,
+                revoked_at INTEGER,
+                issuer TEXT NOT NULL DEFAULT '',
+                note TEXT NOT NULL DEFAULT '',
+                registered_spk TEXT
+            );
+            CREATE TABLE token_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER NOT NULL,
+                event TEXT NOT NULL,
+                token_hash TEXT,
+                subject TEXT,
+                remote_addr TEXT,
+                detail TEXT
+            );
+            """)
+        legacy.commit()
+        legacy.close()
+
+        store = TokenStore(path)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 2
+        finally:
+            store.close()
+
+    def test_future_version_db_refuses_to_open(self, tmp_path):
+        import sqlite3
+
+        from dmp.server.tokens import TokenStore, _SCHEMA, _SCHEMA_VERSION
+
+        path = str(tmp_path / "future.db")
+        future = sqlite3.connect(path)
+        future.executescript(_SCHEMA)
+        future.execute(f"PRAGMA user_version = {_SCHEMA_VERSION + 5}")
+        future.commit()
+        future.close()
+
+        with pytest.raises(RuntimeError, match="schema version"):
+            TokenStore(path)

--- a/tests/test_tsig_keystore.py
+++ b/tests/test_tsig_keystore.py
@@ -509,3 +509,90 @@ class TestSchemaVersioning:
 
         with pytest.raises(RuntimeError, match="schema version"):
             TSIGKeyStore(path)
+
+    def test_legacy_v2_with_subject_already_present_but_unstamped(self, tmp_path):
+        """A pre-versioning binary that already ran the inline ``subject``
+        ALTER (and possibly more) but never stamped ``user_version`` opens
+        cleanly: the ALTER for ``subject`` hits ``duplicate column``
+        (caught), the ALTERs for the columns that don't exist yet succeed,
+        and the version is stamped to 4.
+        """
+        import sqlite3
+
+        from dmp.server.tsig_keystore import TSIGKeyStore
+
+        path = str(tmp_path / "legacy_v2.db")
+        legacy = sqlite3.connect(path)
+        # v2 shape: original v1 columns + subject (codex flagged the
+        # missing test for this half-migrated case).
+        legacy.executescript("""
+            CREATE TABLE tsig_keys (
+                name TEXT PRIMARY KEY,
+                algorithm TEXT NOT NULL DEFAULT 'hmac-sha256',
+                secret BLOB NOT NULL,
+                allowed_suffixes TEXT NOT NULL DEFAULT '',
+                created_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL DEFAULT 0,
+                revoked INTEGER NOT NULL DEFAULT 0,
+                subject TEXT NOT NULL DEFAULT ''
+            );
+            """)
+        legacy.execute(
+            "INSERT INTO tsig_keys(name, secret, created_at, subject) "
+            "VALUES(?, ?, ?, ?)",
+            ("k0.", b"\xaa" * 32, 100, "alice@example.com"),
+        )
+        legacy.commit()
+        legacy.close()
+
+        store = TSIGKeyStore(path)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 4
+            cols = {
+                row[1]
+                for row in store._conn.execute(
+                    "PRAGMA table_info(tsig_keys)"
+                ).fetchall()
+            }
+            # All v4 columns present, including the v3/v4 ones added
+            # by the ladder on top of the v2 starting point.
+            assert {"subject", "registered_spk", "registered_x25519_pub"} <= cols
+            row = store._conn.execute("SELECT name, subject FROM tsig_keys").fetchone()
+            assert row == ("k0.", "alice@example.com")
+        finally:
+            store.close()
+
+    def test_unrelated_operational_error_propagates(self, tmp_path, monkeypatch):
+        """Codex P1 catch: the ALTER swallow must filter to only
+        ``duplicate column`` / ``no such table``. Any OTHER
+        OperationalError — a real SQL mistake in a future migration —
+        must propagate rather than silently leaving the schema
+        half-migrated AND stamping the new version."""
+        import sqlite3
+
+        from dmp.server import tsig_keystore as mod
+
+        # Pre-create the table so the bogus ALTER hits a real error
+        # rather than ``no such table`` (which is intentionally
+        # swallowed for the v0→v* fresh-db case).
+        path = str(tmp_path / "unrelated_err.db")
+        seed = sqlite3.connect(path)
+        seed.executescript(
+            "CREATE TABLE tsig_keys ("
+            "name TEXT PRIMARY KEY, secret BLOB NOT NULL, "
+            "created_at INTEGER NOT NULL"
+            ");"
+        )
+        seed.commit()
+        seed.close()
+        # Inject a bogus ALTER. ``ADD COLUMN ... PRIMARY KEY`` is
+        # rejected by sqlite ("Cannot add a PRIMARY KEY column") with
+        # an OperationalError whose message contains neither swallowed
+        # phrase — so the migration must propagate, not silently stamp
+        # v4 over a half-migrated schema.
+        bogus = "ALTER TABLE tsig_keys ADD COLUMN bogus INTEGER PRIMARY KEY"
+        monkeypatch.setattr(mod, "_MIGRATIONS", (bogus,))
+
+        with pytest.raises(sqlite3.OperationalError):
+            mod.TSIGKeyStore(path)

--- a/tests/test_tsig_keystore.py
+++ b/tests/test_tsig_keystore.py
@@ -417,3 +417,95 @@ class TestEndToEndWithDnsServer:
 
         assert response.rcode() == dns.rcode.REFUSED
         assert record_store.query_txt_record("bob.example.com") is None
+
+
+class TestSchemaVersioning:
+    """Migration ladder for TSIGKeyStore (schema v4).
+
+    Versions:
+      v1 = original (name, algorithm, secret, allowed_suffixes, created_at,
+           expires_at, revoked)
+      v2 = + subject
+      v3 = + registered_spk
+      v4 = + registered_x25519_pub (current)
+
+    Pre-versioning binaries blindly ran every ALTER swallowing
+    ``duplicate column``; the new ladder preserves that idempotency
+    while stamping ``user_version`` on the way out.
+    """
+
+    def test_fresh_db_is_stamped_at_current_version(self, tmp_path):
+        from dmp.server.tsig_keystore import _SCHEMA_VERSION, TSIGKeyStore
+
+        store = TSIGKeyStore(str(tmp_path / "fresh.db"))
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == _SCHEMA_VERSION
+            cols = {
+                row[1]
+                for row in store._conn.execute(
+                    "PRAGMA table_info(tsig_keys)"
+                ).fetchall()
+            }
+            assert {"subject", "registered_spk", "registered_x25519_pub"} <= cols
+        finally:
+            store.close()
+
+    def test_legacy_v1_db_gets_all_three_columns_added(self, tmp_path):
+        """A pre-versioning v1 keystore (only the original 7 columns)
+        opens cleanly: all three v2/v3/v4 columns get ALTERed in,
+        ``user_version`` is stamped to 4."""
+        import sqlite3
+
+        from dmp.server.tsig_keystore import TSIGKeyStore
+
+        path = str(tmp_path / "legacy.db")
+        legacy = sqlite3.connect(path)
+        legacy.executescript("""
+            CREATE TABLE tsig_keys (
+                name TEXT PRIMARY KEY,
+                algorithm TEXT NOT NULL DEFAULT 'hmac-sha256',
+                secret BLOB NOT NULL,
+                allowed_suffixes TEXT NOT NULL DEFAULT '',
+                created_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL DEFAULT 0,
+                revoked INTEGER NOT NULL DEFAULT 0
+            );
+            """)
+        legacy.execute(
+            "INSERT INTO tsig_keys(name, secret, created_at) VALUES(?, ?, ?)",
+            ("k0.", b"\xaa" * 32, 100),
+        )
+        legacy.commit()
+        legacy.close()
+
+        store = TSIGKeyStore(path)
+        try:
+            stored = store._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert stored == 4
+            cols = {
+                row[1]
+                for row in store._conn.execute(
+                    "PRAGMA table_info(tsig_keys)"
+                ).fetchall()
+            }
+            assert {"subject", "registered_spk", "registered_x25519_pub"} <= cols
+            row = store._conn.execute("SELECT name FROM tsig_keys").fetchone()
+            assert row[0] == "k0."
+        finally:
+            store.close()
+
+    def test_future_version_db_refuses_to_open(self, tmp_path):
+        import sqlite3
+
+        from dmp.server.tsig_keystore import TSIGKeyStore, _SCHEMA, _SCHEMA_VERSION
+
+        path = str(tmp_path / "future.db")
+        future = sqlite3.connect(path)
+        future.executescript(_SCHEMA)
+        future.execute(f"PRAGMA user_version = {_SCHEMA_VERSION + 5}")
+        future.commit()
+        future.close()
+
+        with pytest.raises(RuntimeError, match="schema version"):
+            TSIGKeyStore(path)


### PR DESCRIPTION
## Summary

Closes the rest of the schema-versioning gap codex flagged during PR #40's review. Three sqlite stores still ran ad-hoc or no migration; this PR brings each up to the same explicit ladder + future-version refusal pattern that PR #40 applied to `IntroQueue` and `PrekeyStore`.

| Store | Was | Now |
|---|---|---|
| `dmp/server/heartbeat_store.py:SeenStore` | bare `CREATE TABLE` only | v1 schema, refuses `>v1` |
| `dmp/server/tokens.py:TokenStore` | inline `ALTER` w/o stamping | v1 → v2 (`+registered_spk`), refuses `>v2` |
| `dmp/server/tsig_keystore.py:TSIGKeyStore` | 3 inline `ALTER`s w/o stamping | v1 → v2 → v3 → v4, refuses `>v4` |

Per-node singletons (no cross-process concurrent open in normal operation) — no `BEGIN IMMEDIATE` lock here, unlike `PrekeyStore` / `IntroQueue` where multi-process opens are a real concern.

## Bug found while writing the tsig_keystore tests

The original `TSIGKeyStore.__init__` did `executescript(_SCHEMA)` first, then the `ALTER`s. That works on already-migrated v2+ data (the executescript no-ops on existing tables) but **fails on a strict legacy v1 db** with no `subject` column: `executescript` includes `CREATE INDEX ... ON tsig_keys(subject)`, which raises `no such column: subject` before the ALTER gets a chance to add it.

Reordered: ALTERs first (idempotent — backfills columns on legacy, no-ops on fresh), then `executescript` (creates indexes against the now-complete column set). Migration test for the v1 case exposes this; the reorder fixes it.

## Tests added

10 new schema-versioning tests across the three test files, each covering:
- Fresh db is stamped at the current version
- Legacy unversioned db is migrated cleanly with rows preserved
- Future-version db refuses to open with a clear `RuntimeError`

`test_token_store.py` has an extra case: a pre-versioning v1.5 db where the inline ALTER ran but `user_version` was never stamped — must catch `duplicate column` and stamp v2.

## Validation

- 1494 unit tests pass (was 1484 on main; +10 new schema tests)
- 7 docker integration e2e tests pass against fresh `dnsmesh-node:latest`
- `black --check dmp tests` clean

## Audit P-list status after this PR

- ✅ P0-1 — Ed25519 low-order rejection (#35)
- ✅ P0-2 — Atomic ReplayCache claim (#36)
- ✅ Sqlite race + CI concurrency (#37)
- ✅ P0-3 — TOFU opt-in (#38)
- ✅ P0-4 — DNSSEC AD-bit (#39)
- ✅ P1 — IntroQueue + PrekeyStore versioning (#40)
- ✅ P2 — http_api 500 logging + flake cleanup (#41)
- ✅ **P2 — heartbeat / token / tsig versioning** (this PR)

## Remaining open items from the audit & codex follow-ups

- `_NodeDnsReader` and other DNS readers bypass the AD gate (PR #39 codex)
- DNSSEC AD policy doesn't cover NXDOMAIN/NoAnswer (PR #39 codex; needs lower-level dnspython rewrite)
- Intro queue persistence-default hardening (~120-test blast radius; deferred from PR #40)
- Original P1 cryptographic items: prekey state machine (P1-5), reserve `prekey_id=0` (P1-6), KDF transcript binding (P1-7), single canonical AAD/manifest transcript (P1-8), future-skew bound on exp/ttl (P2-11)