### PR TITLE
fix(prekeys): reserve prekey_id=0 in PrekeyStore.generate_pool

### DIFF
--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -304,9 +304,21 @@ class PrekeyStore:
         out: List[Tuple[Prekey, X25519PrivateKey]] = []
         with self._lock:
             for _ in range(count):
-                # Random prekey_id, retry on collision.
+                # Random prekey_id, retry on collision OR on the
+                # reserved value 0. ``NO_PREKEY = 0`` is the manifest
+                # sentinel for "no prekey, fall back to long-term key"
+                # (see dmp/core/manifest.py); a generator that returns 0
+                # would silently strip forward secrecy from senders that
+                # picked it, with the receiver indistinguishable from
+                # the legitimate long-term-key path. The collision
+                # probability against ``randbits(32)`` is 2^-32 per
+                # draw, but rare events fire under enough load — the
+                # one-line ``pid == 0`` check costs nothing and removes
+                # the failure mode entirely.
                 for _retry in range(10):
                     pid = secrets.randbits(32)
+                    if pid == 0:
+                        continue
                     exists = self._conn.execute(
                         "SELECT 1 FROM prekeys WHERE prekey_id = ?", (pid,)
                     ).fetchone()

--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -76,8 +76,16 @@ class Prekey:
     exp: int  # unix seconds after which recipient may drop
 
     def to_body_bytes(self) -> bytes:
-        if not (0 <= self.prekey_id < (1 << 32)):
-            raise ValueError("prekey_id out of range")
+        # ``prekey_id == 0`` is reserved as the manifest sentinel
+        # ``NO_PREKEY`` (see dmp.core.manifest); a signed record
+        # carrying it would be ambiguous with the "no prekey
+        # selected, fall back to long-term X25519" path on the
+        # receiver. Refuse to construct such a record at all.
+        if not (1 <= self.prekey_id < (1 << 32)):
+            raise ValueError(
+                "prekey_id out of range (must be 1..2^32-1; "
+                "0 is reserved as NO_PREKEY)"
+            )
         if len(self.public_key) != 32:
             raise ValueError("public_key must be 32 bytes")
         return (
@@ -90,8 +98,18 @@ class Prekey:
     def from_body_bytes(cls, body: bytes) -> "Prekey":
         if len(body) != _BODY_LEN:
             raise ValueError(f"prekey body must be {_BODY_LEN} bytes, got {len(body)}")
+        prekey_id = int.from_bytes(body[0:4], "big")
+        # Reject the reserved NO_PREKEY value at parse time so a
+        # malicious or buggy peer can't publish a signed prekey
+        # record that the sender then picks, silently bypassing
+        # forward secrecy on the manifest wire.
+        if prekey_id == 0:
+            raise ValueError(
+                "prekey_id 0 is reserved as NO_PREKEY and not valid "
+                "in a signed prekey record"
+            )
         return cls(
-            prekey_id=int.from_bytes(body[0:4], "big"),
+            prekey_id=prekey_id,
             public_key=body[4:36],
             exp=int.from_bytes(body[36:44], "big"),
         )
@@ -375,6 +393,14 @@ class PrekeyStore:
 
     def get_private_key(self, prekey_id: int) -> Optional[X25519PrivateKey]:
         """Return the sk for a given prekey_id, or None if absent / expired."""
+        # Refuse the reserved sentinel even if a legacy/imported db
+        # has a row at prekey_id=0. The manifest wire encodes "no
+        # prekey, fall back to long-term key" as 0; a successful
+        # lookup here would silently strip forward secrecy from a
+        # session that the receiver was meant to recognize as the
+        # legacy fallback path.
+        if prekey_id == 0:
+            return None
         with self._lock:
             row = self._conn.execute(
                 "SELECT private_key FROM prekeys WHERE prekey_id = ? AND exp > ?",
@@ -391,6 +417,13 @@ class PrekeyStore:
         row is gone, a later leak of the long-term X25519 key cannot
         recover the same session key.
         """
+        # Same refusal as ``get_private_key``: the reserved sentinel
+        # is not a consumable prekey. Don't delete a legacy id=0
+        # row here either — leave it alone so an operator can audit
+        # how it got there. (A separate one-off cleanup migration
+        # could remove zero rows; out of scope for this fix.)
+        if prekey_id == 0:
+            return False
         with self._lock:
             cur = self._conn.execute(
                 "DELETE FROM prekeys WHERE prekey_id = ?", (prekey_id,)

--- a/tests/test_prekeys.py
+++ b/tests/test_prekeys.py
@@ -324,6 +324,84 @@ class TestPrekeyStoreSchemaVersioning:
     # that actually matters. The dynamic test was theatre.
 
 
+class TestPrekeyIdReservation:
+    """``prekey_id = 0`` is reserved as the ``NO_PREKEY`` sentinel
+    (see dmp/core/manifest.py). The pool generator must never return
+    it — otherwise a sender that picked the prekey would silently
+    fall back to the recipient's long-term X25519 key (no forward
+    secrecy) without the manifest's ``prekey_id`` carrying any
+    distinguishing signal.
+    """
+
+    def test_zero_prekey_id_is_skipped(self, tmp_path, monkeypatch):
+        """Force ``secrets.randbits`` to return 0 on the first draw,
+        then a usable value on the second. The generator must skip 0
+        and produce a non-zero prekey_id on the second attempt.
+        """
+        from dmp.core import prekeys as mod
+
+        store = mod.PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            # Stateful patch: first call returns 0, every subsequent
+            # call returns 12345.
+            calls = {"n": 0}
+
+            def fake_randbits(n_bits):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    return 0
+                return 12345
+
+            monkeypatch.setattr(mod.secrets, "randbits", fake_randbits)
+            pool = store.generate_pool(count=1, ttl_seconds=3600)
+            assert len(pool) == 1
+            prekey, _ = pool[0]
+            # Reserved 0 was rejected; the second draw landed.
+            assert prekey.prekey_id == 12345
+            # And we made at least 2 draws.
+            assert calls["n"] >= 2
+        finally:
+            store.close()
+
+    def test_no_zero_id_in_a_large_pool(self, tmp_path):
+        """Statistical sanity: generate many prekeys and verify none
+        end up with ``prekey_id == 0``. Without the reservation, the
+        2^-32 chance per draw means this rarely catches the bug —
+        but combined with the targeted test above it confirms the
+        guard fires in production usage too.
+        """
+        from dmp.core.manifest import NO_PREKEY
+        from dmp.core.prekeys import PrekeyStore
+
+        store = PrekeyStore(str(tmp_path / "pool.db"))
+        try:
+            pool = store.generate_pool(count=200, ttl_seconds=3600)
+            ids = [pk.prekey_id for pk, _ in pool]
+            assert NO_PREKEY == 0  # if the sentinel ever changes
+            assert NO_PREKEY not in ids
+        finally:
+            store.close()
+
+    def test_collision_retry_budget_still_works_with_zero_skip(
+        self, tmp_path, monkeypatch
+    ):
+        """If every draw returns 0 (an extreme stuck-RNG scenario),
+        the retry budget runs out and the generator raises rather
+        than looping forever. Belt-and-suspenders: the generator's
+        outer 10-retry bound covers both the collision case AND a
+        pathological all-zero RNG.
+        """
+        from dmp.core import prekeys as mod
+
+        store = mod.PrekeyStore(str(tmp_path / "stuck.db"))
+        try:
+            monkeypatch.setattr(mod.secrets, "randbits", lambda n: 0)
+            with pytest.raises(RuntimeError, match="could not allocate"):
+                store.generate_pool(count=1, ttl_seconds=3600)
+        finally:
+            store.close()
+
+
 class TestRrsetNaming:
     def test_hashed_label(self):
         name = prekey_rrset_name("alice", "mesh.example.com")

--- a/tests/test_prekeys.py
+++ b/tests/test_prekeys.py
@@ -401,6 +401,137 @@ class TestPrekeyIdReservation:
         finally:
             store.close()
 
+    def test_to_body_bytes_rejects_zero(self):
+        """Codex P1: defense-in-depth at the wire layer. Even if a
+        legacy / buggy / malicious caller constructs a Prekey with
+        ``prekey_id=0``, ``to_body_bytes`` (and therefore ``sign``)
+        must refuse — preventing publication of an ambiguous record.
+        """
+        pk = Prekey(prekey_id=0, public_key=b"\x01" * 32, exp=9_999_999_999)
+        with pytest.raises(ValueError, match="reserved as NO_PREKEY"):
+            pk.to_body_bytes()
+
+    def test_from_body_bytes_rejects_zero(self):
+        """Same wire-layer defense on the parse side: a signed prekey
+        record carrying ``prekey_id=0`` must be rejected at parse
+        time so a sender cannot pick it from DNS."""
+        body = (
+            (0).to_bytes(4, "big")  # prekey_id = 0
+            + b"\x01" * 32  # public_key
+            + (9_999_999_999).to_bytes(8, "big")  # exp
+        )
+        with pytest.raises(ValueError, match="reserved as NO_PREKEY"):
+            Prekey.from_body_bytes(body)
+
+    def test_parse_and_verify_returns_none_for_zero_id_record(self):
+        """End-to-end: even a correctly-signed prekey record with
+        ``prekey_id=0`` must NOT round-trip through
+        ``parse_and_verify``. ``from_body_bytes`` raises ValueError
+        on the zero id, which parse_and_verify converts to None.
+        """
+        from dmp.core.crypto import DMPCrypto
+
+        identity = DMPCrypto()
+        # Construct a body manually (since to_body_bytes refuses zero)
+        # and sign it. This simulates a non-conforming peer publishing
+        # the ambiguous record.
+        body = (
+            (0).to_bytes(4, "big")
+            + b"\x01" * 32
+            + (int(time.time()) + 86400).to_bytes(8, "big")
+        )
+        sig = identity.sign_data(body)
+        wire = RECORD_PREFIX + base64.b64encode(body + sig).decode("ascii")
+        # Even though the signature is valid, parse_and_verify must
+        # reject the zero prekey_id — the wire-layer guard fires
+        # before signature check matters for delivery.
+        result = Prekey.parse_and_verify(wire, identity.get_signing_public_key_bytes())
+        assert result is None
+
+    def test_get_private_key_refuses_zero_even_if_row_exists(self, tmp_path):
+        """Codex P2: a legacy/imported db could already have a row at
+        ``prekey_id=0``. ``get_private_key`` must refuse the lookup
+        regardless of what the table contains, so the receiver's
+        decrypt path can't accidentally use it."""
+        import sqlite3
+
+        from dmp.core.prekeys import PrekeyStore
+
+        path = str(tmp_path / "legacy_zero.db")
+        # Create a v2 schema directly and inject a row at prekey_id=0,
+        # mimicking a legacy/imported db that managed to slip 0 in.
+        legacy = sqlite3.connect(path, isolation_level=None)
+        legacy.executescript("""
+            CREATE TABLE prekeys (
+                prekey_id INTEGER PRIMARY KEY,
+                private_key BLOB NOT NULL,
+                public_key BLOB NOT NULL,
+                exp INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                wire_record TEXT DEFAULT ''
+            );
+            """)
+        legacy.execute(
+            "INSERT INTO prekeys(prekey_id, private_key, public_key, "
+            "exp, created_at) VALUES(?, ?, ?, ?, ?)",
+            (0, b"\x05" * 32, b"\x06" * 32, 9_999_999_999, 100),
+        )
+        legacy.execute("PRAGMA user_version = 2")
+        legacy.close()
+
+        store = PrekeyStore(path)
+        try:
+            # The row exists — but the lookup must refuse the
+            # reserved id.
+            assert store.get_private_key(0) is None
+            # Direct sql confirms the row IS still there (we don't
+            # auto-delete legacy rows).
+            row = store._conn.execute(
+                "SELECT prekey_id FROM prekeys WHERE prekey_id = 0"
+            ).fetchone()
+            assert row is not None and row[0] == 0
+        finally:
+            store.close()
+
+    def test_consume_refuses_zero(self, tmp_path):
+        """``consume(0)`` must return False even if a legacy id=0
+        row is present in the table. Same NO_PREKEY guarantee as
+        ``get_private_key``."""
+        import sqlite3
+
+        from dmp.core.prekeys import PrekeyStore
+
+        path = str(tmp_path / "legacy_zero_consume.db")
+        legacy = sqlite3.connect(path, isolation_level=None)
+        legacy.executescript("""
+            CREATE TABLE prekeys (
+                prekey_id INTEGER PRIMARY KEY,
+                private_key BLOB NOT NULL,
+                public_key BLOB NOT NULL,
+                exp INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                wire_record TEXT DEFAULT ''
+            );
+            """)
+        legacy.execute(
+            "INSERT INTO prekeys(prekey_id, private_key, public_key, "
+            "exp, created_at) VALUES(?, ?, ?, ?, ?)",
+            (0, b"\x05" * 32, b"\x06" * 32, 9_999_999_999, 100),
+        )
+        legacy.execute("PRAGMA user_version = 2")
+        legacy.close()
+
+        store = PrekeyStore(path)
+        try:
+            # Refusal returns False without touching the row.
+            assert store.consume(0) is False
+            row = store._conn.execute(
+                "SELECT prekey_id FROM prekeys WHERE prekey_id = 0"
+            ).fetchone()
+            assert row is not None
+        finally:
+            store.close()
+
 
 class TestRrsetNaming:
     def test_hashed_label(self):


### PR DESCRIPTION
## Summary

P1-6 from the audit. `NO_PREKEY = 0` is the manifest sentinel for "no prekey, fall back to long-term X25519 key" (`dmp/core/manifest.py:NO_PREKEY`). The pool generator draws prekey_ids via `secrets.randbits(32)` and accepts whatever it returns — including 0. A 1-in-2^32 collision per draw is rare but not zero, and the failure mode is silent: a sender that picks the prekey would encrypt to the long-term key without forward secrecy, and the receiver can't distinguish that path from a legitimate "no prekey published" deployment.

The audit flagged this directly:

> **NO_PREKEY = 0 is impossible to distinguish from "no prekey" if generated.** `generate_pool()` uses `secrets.randbits(32)` and does not reject zero.

## Change

One-line guard in the existing retry loop in `dmp/core/prekeys.py:generate_pool`:

```python
for _retry in range(10):
    pid = secrets.randbits(32)
    if pid == 0:               # ← new
        continue                #
    exists = self._conn.execute(...)
    if not exists:
        break
else:
    raise RuntimeError("could not allocate unique prekey_id")
```

The outer 10-retry bound already covers the case where the RNG is stuck returning 0 — the generator raises `RuntimeError` rather than infinite-looping.

## Tests

`TestPrekeyIdReservation` in `tests/test_prekeys.py` (3 tests):
- `test_zero_prekey_id_is_skipped` — monkeypatches `secrets.randbits` to return `0` on the first draw, `12345` on subsequent. Generator must produce the `12345` prekey. **Mutation-confirmed**: removing the `pid == 0` skip makes this test fail.
- `test_no_zero_id_in_a_large_pool` — generates 200 prekeys, asserts none == `NO_PREKEY`. Statistical sanity.
- `test_collision_retry_budget_still_works_with_zero_skip` — forces `randbits` to always return 0, asserts generator raises `RuntimeError` rather than infinite-looping.

## Validation

- 1499 unit tests pass (was 1493 on main; +3 new tests + 3 from the v0.7-prep work that's already on main but not yet counted in the previous run)
- 7 docker integration e2e against fresh `dnsmesh-node:latest`
- `black --check dmp tests` clean

## Audit P-list status

After this PR:
- P0-1, P0-2, P0-3, P0-4 ✅ closed
- P1 (intro queue + prekey schema) ✅ closed (#40)
- P1-6 (this PR) ✅ closed
- Side fixes (CI #37, http_api logging #41, more sqlite stores #42) ✅ closed

Still open:
- P1-5 atomic prekey state machine (closes prekey-claim race)
- P1-7 KDF transcript binding (defense-in-depth)
- P1-8 single canonical AAD/manifest transcript (wire format)
- P2-11 future-skew bound on `exp`/`ttl`
- Intro queue persistence-default hardening (~120 test sites)
- DNSSEC negative-response gap (PR #39 codex follow-up)
- Other DNS readers bypassing AD gate (PR #39 codex follow-up)

## Test plan

- [ ] CI matrix all green
- [ ] `pytest tests/test_prekeys.py::TestPrekeyIdReservation -v`