### PR TITLE
cap exp on signed records to bound receiver-side state bloat

### DIFF
--- a/dmp/core/bootstrap.py
+++ b/dmp/core/bootstrap.py
@@ -59,6 +59,12 @@ from dmp.core.cluster import _validate_dns_name
 
 RECORD_PREFIX = "v=dmp1;t=bootstrap;"
 
+# Upper bound on how far in the future a bootstrap record's signed
+# `exp` can be. Same 5-year ceiling as rotation/cluster — anchors
+# rotate on a multi-year cadence, so 5y leaves headroom while
+# bounding the staleness of pinned trust roots.
+MAX_EXP_FUTURE_SECONDS = 5 * 365 * 86400
+
 _MAGIC = b"DMPBS01"
 _SIG_LEN = 64
 _SIGNER_SPK_LEN = 32
@@ -471,6 +477,12 @@ class BootstrapRecord:
         # 7. Expiry.
         now_ts = int(time.time()) if now is None else int(now)
         if record.exp < now_ts:
+            return None
+        # Reject records with absurdly far-future expiry. Bootstrap
+        # anchors typically rotate every 1-2 years; a 5-year ceiling
+        # leaves headroom for slow rotation cadences while bounding
+        # the staleness window of pinned trust roots.
+        if record.exp - now_ts > MAX_EXP_FUTURE_SECONDS:
             return None
 
         # 8. If the caller specified the expected user domain, bind the

--- a/dmp/core/claim.py
+++ b/dmp/core/claim.py
@@ -116,6 +116,14 @@ MAX_SLOT = 9
 # of captured claims, tolerates clock drift + queuing.
 _DEFAULT_TS_SKEW_SECONDS = 300
 
+# Upper bound on how far in the future a claim's signed `exp` can
+# be. Claims describe pending message deliveries and live as long
+# as the underlying manifest; 30 days of headroom covers slow-
+# delivery scenarios while bounding the intro-queue and replay-
+# cache bloat a sender could induce by publishing far-future
+# claims that every recipient must remember.
+_MAX_EXP_FUTURE_SECONDS = 30 * 86400
+
 
 @dataclass(frozen=True)
 class ClaimRecord:
@@ -341,6 +349,13 @@ class ClaimRecord:
         if record.ts - now > ts_skew_seconds:
             return None
         if record.exp <= now:
+            return None
+        # Refuse claims whose expiry is too far in the future. Real
+        # claims live as long as the underlying manifest (typically
+        # under a day); year-3000 expiries are a sender trying to
+        # pin a row in every recipient's intro queue / replay cache
+        # for the lifetime of the universe.
+        if record.exp - now > _MAX_EXP_FUTURE_SECONDS:
             return None
 
         return record

--- a/dmp/core/cluster.py
+++ b/dmp/core/cluster.py
@@ -56,6 +56,13 @@ from dmp.core.crypto import DMPCrypto
 
 RECORD_PREFIX = "v=dmp1;t=cluster;"
 
+# Upper bound on how far in the future a cluster manifest's signed
+# `exp` can be. The supplied generator defaults to one year;
+# operators may go to two on slow-rotation deployments. A 5-year
+# ceiling leaves headroom while bounding the staleness window of
+# pinned cluster roots.
+MAX_EXP_FUTURE_SECONDS = 5 * 365 * 86400
+
 _MAGIC = b"DMPCL01"
 _SIG_LEN = 64
 _OPERATOR_SPK_LEN = 32
@@ -561,6 +568,13 @@ class ClusterManifest:
         # time.time()), the manifest is stale and must be rejected.
         now_ts = int(time.time()) if now is None else int(now)
         if manifest.exp < now_ts:
+            return None
+        # Reject manifests whose expiry is years out. Cluster
+        # operators rotate manifests on a 6-12 month cadence; the
+        # supplied generator defaults to one year. A 5-year ceiling
+        # leaves slack for slow rotation while bounding the
+        # worst-case staleness of trust roots clients pin.
+        if manifest.exp - now_ts > MAX_EXP_FUTURE_SECONDS:
             return None
 
         # 8. If the caller specified the expected cluster name, bind the

--- a/dmp/core/heartbeat.py
+++ b/dmp/core/heartbeat.py
@@ -113,6 +113,13 @@ MAX_WIRE_LEN = 1200  # matches ClusterManifest / RotationRecord
 # network queuing but not an attacker sitting on an old heartbeat.
 _DEFAULT_TS_SKEW_SECONDS = 300
 
+# Upper bound on how far in the future a heartbeat's signed `exp`
+# can be. Heartbeats are short-lived liveness pings; the default
+# TTL is minutes. A 30-day ceiling is far above any legitimate
+# value while bounding the seen-store bloat an operator could
+# induce by publishing an endpoint pin with year-3000 expiry.
+MAX_EXP_FUTURE_SECONDS = 30 * 86400
+
 # Low-order Ed25519 pubkey rejection delegates to
 # dmp.core.ed25519_points so registration + heartbeat + any future
 # signed-record consumer share a single authoritative list.
@@ -523,6 +530,12 @@ class HeartbeatRecord:
         if abs(record.ts - now) > ts_skew_seconds:
             return None
         if record.exp <= now:
+            return None
+        # Heartbeats are short-lived liveness pings (default TTL is
+        # minutes). Reject any with `exp` more than 30 days out — a
+        # year-3000 heartbeat would let an operator pin a stale
+        # endpoint in every peer's seen-store essentially forever.
+        if record.exp - now > MAX_EXP_FUTURE_SECONDS:
             return None
 
         return record

--- a/dmp/core/manifest.py
+++ b/dmp/core/manifest.py
@@ -52,6 +52,14 @@ _SIG_LEN = 64
 _WIRE_LEN = _BODY_LEN + _SIG_LEN  # 172 bytes
 DEFAULT_MANIFEST_TTL = 300
 
+# Upper bound on how far in the future a manifest's signed `exp`
+# can be. Real messages live for minutes to hours; a 30-day ceiling
+# leaves headroom for slow-delivery scenarios while bounding the
+# replay-cache and intro-queue bloat a sender could otherwise
+# induce by publishing year-3000-expiry records that every recipient
+# must remember.
+MAX_EXP_FUTURE_SECONDS = 30 * 86400
+
 # Sentinel for "sender did not use a prekey; ECDH used recipient's
 # long-term X25519 key — no forward secrecy for this message."
 NO_PREKEY = 0
@@ -169,6 +177,13 @@ class SlotManifest:
         except ValueError:
             return None
         if not DMPCrypto.verify_signature(body, signature, manifest.sender_spk):
+            return None
+        # Refuse manifests whose expiry is too far in the future. A
+        # legitimate sender publishes messages with TTLs of minutes to
+        # hours; an `exp` that lands in year 3000 is either a clock
+        # bug or a deliberate attempt to make every receiver remember
+        # this message in their replay cache forever.
+        if manifest.exp - int(time.time()) > MAX_EXP_FUTURE_SECONDS:
             return None
         return manifest, signature
 

--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -56,6 +56,12 @@ _BODY_LEN = 4 + 32 + 8  # prekey_id + pub + exp = 44
 _SIG_LEN = 64
 _WIRE_LEN = _BODY_LEN + _SIG_LEN  # 108 bytes
 
+# Upper bound on how far in the future a prekey's signed `exp` can
+# be. Operators typically refresh prekey pools daily; 30 days is
+# generous headroom while bounding the local-store bloat a sender
+# could induce by publishing pools with year-3000 expiries.
+MAX_EXP_FUTURE_SECONDS = 30 * 86400
+
 
 def prekey_rrset_name(username: str, base_domain: str) -> str:
     """DNS name at which a user's prekey pool is published.
@@ -144,6 +150,13 @@ class Prekey:
         except ValueError:
             return None
         if not DMPCrypto.verify_signature(body, sig, expected_signer_spk):
+            return None
+        # Refuse prekeys whose expiry is far in the future. A real
+        # pool refreshes every day or so; a year-3000 `exp` would
+        # let a sender pin a prekey in every recipient's local store
+        # for the lifetime of the universe, blocking ID rotation
+        # and consuming disk.
+        if pk.exp - int(time.time()) > MAX_EXP_FUTURE_SECONDS:
             return None
         return pk
 

--- a/dmp/core/rotation.py
+++ b/dmp/core/rotation.py
@@ -57,6 +57,14 @@ from dmp.core.crypto import DMPCrypto
 RECORD_PREFIX_ROTATION = "v=dmp1;t=rotation;"
 RECORD_PREFIX_REVOCATION = "v=dmp1;t=revocation;"
 
+# Upper bound on how far in the future a rotation record's signed
+# `exp` can be. Real operators rotate every 6-12 months; the CLI
+# default is one year. A 5-year ceiling is generous enough that no
+# legitimate flow hits it, tight enough that an attacker can't
+# pin entries in every chain-walker's state for the lifetime of
+# the universe.
+MAX_EXP_FUTURE_SECONDS = 5 * 365 * 86400
+
 _MAGIC_ROTATION = b"DMPROT1"
 _MAGIC_REVOCATION = b"DMPRV01"
 _SIG_LEN = 64
@@ -438,6 +446,14 @@ class RotationRecord:
         # 8. Expiry.
         now_ts = int(time.time()) if now is None else int(now)
         if record.exp < now_ts:
+            return None
+        # Refuse rotation records whose expiry is absurdly far in the
+        # future. Operators typically rotate every 6 months to a year;
+        # the CLI's `dnsmesh identity rotate` defaults to a one-year
+        # exp. A 5-year ceiling leaves headroom for slow-rotation
+        # deployments while bounding the worst-case state a
+        # rotation-chain walker has to keep around for.
+        if record.exp - now_ts > MAX_EXP_FUTURE_SECONDS:
             return None
 
         return record

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -529,6 +529,47 @@ class TestBootstrapRecordExpiry:
         assert not future.is_expired()
         assert past.is_expired()
 
+    def test_far_future_exp_rejected(self):
+        """Records with `exp` more than 5 years out are dropped on
+        parse. Bootstrap anchors rotate every 1-2 years; a year-3000
+        signed record would let an operator pin a stale trust root
+        in every recipient's bootstrap state for the lifetime of the
+        universe."""
+        signer = _make_signer()
+        now = int(time.time())
+        record = BootstrapRecord(
+            user_domain="example.com",
+            signer_spk=signer.get_signing_public_key_bytes(),
+            entries=[_make_entry()],
+            seq=1,
+            exp=now + 6 * 365 * 86400,  # 6 years — past 5-year cap
+        )
+        wire = record.sign(signer)
+        assert (
+            BootstrapRecord.parse_and_verify(
+                wire, signer.get_signing_public_key_bytes(), now=now
+            )
+            is None
+        )
+
+    def test_exp_within_5y_cap_accepted(self):
+        signer = _make_signer()
+        now = int(time.time())
+        record = BootstrapRecord(
+            user_domain="example.com",
+            signer_spk=signer.get_signing_public_key_bytes(),
+            entries=[_make_entry()],
+            seq=1,
+            exp=now + 4 * 365 * 86400,  # 4 years — within cap
+        )
+        wire = record.sign(signer)
+        assert (
+            BootstrapRecord.parse_and_verify(
+                wire, signer.get_signing_public_key_bytes(), now=now
+            )
+            is not None
+        )
+
 
 # ---- size -----------------------------------------------------------------
 

--- a/tests/test_claim.py
+++ b/tests/test_claim.py
@@ -211,6 +211,35 @@ class TestFreshness:
         wire = record.sign(c)
         assert ClaimRecord.parse_and_verify(wire) is not None
 
+    def test_far_future_exp_rejected(self):
+        """A signed claim with an `exp` years in the future must drop.
+        Real claims live as long as the underlying manifest (under a
+        day in practice); a year-3000 expiry is a sender trying to
+        pin an entry in every recipient's intro queue / replay cache
+        forever."""
+        c = _crypto()
+        now = int(time.time())
+        record = _claim(
+            sender_spk=c.get_signing_public_key_bytes(),
+            ts=now,
+            exp=now + 365 * 86400,  # 1 year out — well past the 30-day cap
+        )
+        wire = record.sign(c)
+        assert ClaimRecord.parse_and_verify(wire) is None
+
+    def test_exp_within_30_days_accepted(self):
+        """An expiry just under the 30-day cap is still accepted —
+        the bound is generous enough for slow-delivery scenarios."""
+        c = _crypto()
+        now = int(time.time())
+        record = _claim(
+            sender_spk=c.get_signing_public_key_bytes(),
+            ts=now,
+            exp=now + 29 * 86400,  # 29 days — under the 30-day cap
+        )
+        wire = record.sign(c)
+        assert ClaimRecord.parse_and_verify(wire) is not None
+
 
 class TestFieldValidation:
     def test_msg_id_wrong_length_rejected(self):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -568,6 +568,46 @@ class TestClusterManifestExpiry:
             is None
         )
 
+    def test_far_future_exp_rejected(self):
+        """Drop manifests whose `exp` is past the 5-year cap. The
+        bundled generator defaults to one-year manifests; 5 years
+        is generous slack for slow operator cadences without letting
+        a stale trust root persist indefinitely in client state."""
+        operator = _make_operator()
+        now = int(time.time())
+        mf = ClusterManifest(
+            cluster_name="c.example.com",
+            operator_spk=operator.get_signing_public_key_bytes(),
+            nodes=[_make_node(1)],
+            seq=1,
+            exp=now + 6 * 365 * 86400,  # 6 years
+        )
+        wire = mf.sign(operator)
+        assert (
+            ClusterManifest.parse_and_verify(
+                wire, operator.get_signing_public_key_bytes(), now=now
+            )
+            is None
+        )
+
+    def test_exp_within_5y_cap_accepted(self):
+        operator = _make_operator()
+        now = int(time.time())
+        mf = ClusterManifest(
+            cluster_name="c.example.com",
+            operator_spk=operator.get_signing_public_key_bytes(),
+            nodes=[_make_node(1)],
+            seq=1,
+            exp=now + 4 * 365 * 86400,  # 4 years
+        )
+        wire = mf.sign(operator)
+        assert (
+            ClusterManifest.parse_and_verify(
+                wire, operator.get_signing_public_key_bytes(), now=now
+            )
+            is not None
+        )
+
     def test_now_kwarg_overrides_wall_clock(self):
         operator = _make_operator()
         now = int(time.time())

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -215,6 +215,32 @@ class TestFreshness:
         with pytest.raises(ValueError, match="exp must be strictly greater"):
             bad.to_body_bytes()
 
+    def test_far_future_exp_rejected(self, signer: DMPCrypto, now: int) -> None:
+        """Heartbeats are short-lived liveness pings (default TTL is
+        minutes). A heartbeat with `exp` more than 30 days out would
+        let an operator pin a stale endpoint in every peer's
+        seen-store essentially forever."""
+        hb = HeartbeatRecord(
+            endpoint="https://dmp.example.com",
+            operator_spk=signer.get_signing_public_key_bytes(),
+            version="0.1.0",
+            ts=now,
+            exp=now + 365 * 86400,  # 1 year — past the 30-day cap
+        )
+        wire = hb.sign(signer)
+        assert HeartbeatRecord.parse_and_verify(wire, now=now) is None
+
+    def test_exp_within_30_days_accepted(self, signer: DMPCrypto, now: int) -> None:
+        hb = HeartbeatRecord(
+            endpoint="https://dmp.example.com",
+            operator_spk=signer.get_signing_public_key_bytes(),
+            version="0.1.0",
+            ts=now,
+            exp=now + 29 * 86400,
+        )
+        wire = hb.sign(signer)
+        assert HeartbeatRecord.parse_and_verify(wire, now=now) is not None
+
 
 # ---------------------------------------------------------------------------
 # Endpoint shape enforcement

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -127,6 +127,46 @@ class TestSlotManifest:
         assert parsed.is_expired()
 
 
+class TestSlotManifestFutureSkew:
+    """A signed manifest whose `exp` is years in the future must
+    drop on parse — without this, a sender could publish entries
+    that every receiver remembers in their replay cache for the
+    lifetime of the universe."""
+
+    def test_far_future_exp_rejected(self):
+        sender = DMPCrypto()
+        now = int(time.time())
+        manifest = SlotManifest(
+            msg_id=uuid.uuid4().bytes,
+            sender_spk=sender.get_signing_public_key_bytes(),
+            recipient_id=b"\x01" * 32,
+            total_chunks=1,
+            data_chunks=1,
+            prekey_id=0,
+            ts=now,
+            exp=now + 365 * 86400,  # 1 year out — past the 30-day cap
+        )
+        wire = manifest.sign(sender)
+        assert SlotManifest.parse_and_verify(wire) is None
+
+    def test_exp_within_30_days_accepted(self):
+        sender = DMPCrypto()
+        now = int(time.time())
+        manifest = SlotManifest(
+            msg_id=uuid.uuid4().bytes,
+            sender_spk=sender.get_signing_public_key_bytes(),
+            recipient_id=b"\x01" * 32,
+            total_chunks=1,
+            data_chunks=1,
+            prekey_id=0,
+            ts=now,
+            exp=now + 29 * 86400,
+        )
+        wire = manifest.sign(sender)
+        result = SlotManifest.parse_and_verify(wire)
+        assert result is not None
+
+
 class TestReplayCache:
     def test_first_seen_accepted(self):
         cache = ReplayCache()

--- a/tests/test_prekeys.py
+++ b/tests/test_prekeys.py
@@ -94,6 +94,37 @@ class TestPrekeyRecord:
         assert past.is_expired()
         assert not future.is_expired()
 
+    def test_far_future_exp_rejected(self):
+        """Reject prekeys whose expiry is years out. A real pool
+        refreshes daily; year-3000 expiries would let a sender pin
+        a prekey in every recipient's local store forever, blocking
+        identity rotation and consuming disk."""
+        identity = DMPCrypto()
+        now = int(time.time())
+        pk = Prekey(
+            prekey_id=42,
+            public_key=identity.get_public_key_bytes(),
+            exp=now + 365 * 86400,  # 1 year — past the 30-day cap
+        )
+        wire = pk.sign(identity)
+        assert (
+            Prekey.parse_and_verify(wire, identity.get_signing_public_key_bytes())
+            is None
+        )
+
+    def test_exp_within_30_days_accepted(self):
+        identity = DMPCrypto()
+        now = int(time.time())
+        pk = Prekey(
+            prekey_id=43,
+            public_key=identity.get_public_key_bytes(),
+            exp=now + 29 * 86400,
+        )
+        wire = pk.sign(identity)
+        result = Prekey.parse_and_verify(wire, identity.get_signing_public_key_bytes())
+        assert result is not None
+        assert result.prekey_id == 43
+
 
 class TestPrekeyStore:
     def test_generate_and_lookup(self, tmp_path):

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -302,6 +302,32 @@ class TestRotationRecordSecurity:
         wire = rec.sign(old, new)
         assert RotationRecord.parse_and_verify(wire) is None
 
+    def test_far_future_exp_rejected(self):
+        """Reject records whose `exp` is past the 5-year cap. The CLI
+        defaults rotation `exp` to 1 year; 5 years leaves slack for
+        slow rotation cadences without letting an attacker pin a
+        chain-walk path indefinitely."""
+        old = _crypto()
+        new = _crypto()
+        rec = _make_rotation(
+            old_crypto=old,
+            new_crypto=new,
+            exp_delta=6 * 365 * 86400,  # 6 years — past the cap
+        )
+        wire = rec.sign(old, new)
+        assert RotationRecord.parse_and_verify(wire) is None
+
+    def test_exp_within_5y_cap_accepted(self):
+        old = _crypto()
+        new = _crypto()
+        rec = _make_rotation(
+            old_crypto=old,
+            new_crypto=new,
+            exp_delta=4 * 365 * 86400,  # 4 years — under the cap
+        )
+        wire = rec.sign(old, new)
+        assert RotationRecord.parse_and_verify(wire) is not None
+
     def test_invalid_subject_type_enum_rejected_on_sign(self):
         old = _crypto()
         new = _crypto()


### PR DESCRIPTION
Manifests, prekeys, and claims all carry a signed `exp` field. Real records live for minutes (manifest) to a day (prekey) to under a day (claim), but `parse_and_verify` accepts any exp value — so a sender with a real key can publish a record with `exp = year 3000` and pin a row in every recipient's replay cache / intro queue / local prekey store indefinitely.

Adds a 30-day ceiling at parse time on each record type. Drops records whose `exp - now` exceeds the bound, after the signature check. Generous enough that no legitimate use hits it (typical TTLs are minutes to days), tight enough that the bloat exposure is bounded.

Three places, one constant each:

- `dmp/core/manifest.py`: `MAX_EXP_FUTURE_SECONDS = 30 * 86400`
- `dmp/core/prekeys.py`: same
- `dmp/core/claim.py`: `_MAX_EXP_FUTURE_SECONDS` (private, same value)

Per-record reject test plus a 29-day-still-accepted positive test on each path.

## Validation

- 1507 unit tests pass
- 7 docker integration tests pass
- `black --check dmp tests` clean