### PR TITLE
atomic claim-and-delete for prekey_sk on the receive path

### DIFF
--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -7,7 +7,7 @@ import random
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PublicKey
 
@@ -591,26 +591,25 @@ class DMPClient:
                 published += 1
         return published
 
-    def _consume_prekey(self, prekey_id: int) -> None:
-        """Delete a prekey both locally and in DNS.
+    def _delete_published_prekey(self, wire: Optional[str]) -> None:
+        """Best-effort DELETE of a published prekey TXT record.
 
-        The local sqlite row carries the sk (FS secret) and the wire-record
-        string we published. We DELETE the wire record from the node so
-        later senders won't pick a prekey whose sk is already gone, then
-        drop the sqlite row. Best-effort on the DNS side — if the DELETE
-        fails we log nothing and still wipe the local sk; the published
-        prekey will just rot until its TTL elapses (old behavior).
+        Called after `PrekeyStore.claim_sk` has already wiped the local
+        sk row. The DNS delete is best-effort — a failure here means
+        the prekey_pub rots in DNS until its TTL elapses; a future
+        sender that picks it will hit "sk gone" on the receiver side
+        and the message will be silently dropped (caught by the
+        replay cache for any retry).
         """
-        wire = self.prekey_store.get_wire(prekey_id)
-        if wire:
-            try:
-                self.writer.delete_txt_record(
-                    prekey_rrset_name(self.username, self.domain),
-                    value=wire,
-                )
-            except Exception:
-                pass
-        self.prekey_store.consume(prekey_id)
+        if not wire:
+            return
+        try:
+            self.writer.delete_txt_record(
+                prekey_rrset_name(self.username, self.domain),
+                value=wire,
+            )
+        except Exception:
+            pass
 
     # ---- send --------------------------------------------------------------
 
@@ -1642,29 +1641,39 @@ class DMPClient:
             ttl=outer.header.ttl,
         )
         aad_bytes = aad_header.to_bytes() + manifest.prekey_id.to_bytes(4, "big")
-        # Prekey-based ECDH path for forward secrecy. When manifest.prekey_id
-        # is nonzero, look up the matching one-time X25519 private key in the
-        # local store and use it for decrypt instead of our long-term key.
-        # On successful decrypt we consume the prekey_sk so a later long-term
-        # key leak cannot recover this message's session.
-        prekey_private = None
+        # Prekey-based ECDH path for forward secrecy. When
+        # manifest.prekey_id is nonzero, atomically claim (read +
+        # delete) the matching one-time X25519 private key from the
+        # local store, then decrypt with it. The atomic claim closes
+        # the crash-window the previous get + decrypt + delete
+        # sequence had — if we crashed between successful decrypt and
+        # the delete, the sk would have stayed on disk until manual
+        # cleanup, weakening the FS guarantee under a later
+        # disk-compromise scenario.
+        prekey_private: Optional[Any] = None
+        prekey_wire: Optional[str] = None
         if manifest.prekey_id != NO_PREKEY:
-            prekey_private = self.prekey_store.get_private_key(manifest.prekey_id)
-            if prekey_private is None:
-                # Prekey was deleted or expired — we can't decrypt this
-                # message. That's a delivery failure, not a security failure.
+            claim = self.prekey_store.claim_sk(manifest.prekey_id)
+            if claim is None:
+                # Prekey was deleted, expired, or never existed. Either
+                # a transient race (replay cache will catch the retry)
+                # or a sender mismatch — drop silently.
                 return None
+            prekey_private, prekey_wire = claim
         try:
             plaintext = self.encryption.decrypt_with_header(
                 encrypted, aad_bytes, private_key=prekey_private
             )
         except Exception:
+            # The sk has already been wiped from disk by claim_sk,
+            # so a failed decrypt can't be retried with the same key.
+            # Still tear down the published prekey_pub record so a
+            # future sender doesn't pick a prekey whose sk is gone.
+            if prekey_wire is not None:
+                self._delete_published_prekey(prekey_wire)
             return None
-        if manifest.prekey_id != NO_PREKEY:
-            # One-time use: delete the sk locally AND the matching public
-            # record from DNS so future senders don't pick a prekey whose
-            # sk is gone. Best effort — a crash between decrypt and consume
-            # leaves the sk on disk; a DELETE failure leaves the prekey_pub
-            # rotting until its TTL.
-            self._consume_prekey(manifest.prekey_id)
+        if prekey_wire is not None:
+            # Decrypt succeeded — finalize the cross-side cleanup by
+            # deleting the published prekey_pub from DNS. Best-effort.
+            self._delete_published_prekey(prekey_wire)
         return plaintext, outer.header.timestamp, outer.header.message_id

--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -404,6 +404,49 @@ class PrekeyStore:
 
     # ---- lookup + consumption ---------------------------------------------
 
+    def claim_sk(
+        self, prekey_id: int
+    ) -> Optional[Tuple[X25519PrivateKey, Optional[str]]]:
+        """Atomically delete the row and return its `(sk, wire_record)`.
+
+        The receive path uses this instead of separate
+        `get_private_key` + `consume` calls. A single ``DELETE ...
+        RETURNING`` runs as one sqlite statement, so cross-process
+        racers can't both observe the row and both consume it: the
+        earlier SELECT-then-DELETE shape was two separate transactions
+        in autocommit mode, and two `PrekeyStore` instances on the
+        same db file could both read the row before either delete
+        committed. ``RETURNING`` collapses that to one atomic step
+        (sqlite >= 3.35, shipped with Python's bundled sqlite for
+        every version we support).
+
+        The sk is gone from disk before the caller starts decrypting,
+        so a crash between successful decrypt and any cleanup can no
+        longer leave the secret behind for a future
+        disk-compromise attacker. If decrypt fails the sk is gone
+        too, but a failed decrypt with a one-time-use key is
+        unrecoverable anyway: the manifest's `prekey_id` plus the
+        chunks' AAD bind the ciphertext, so retrying with the same
+        sk wouldn't have helped.
+
+        Returns None if the prekey_id is the reserved sentinel
+        (0 == NO_PREKEY), expired, or absent.
+        """
+        if prekey_id == 0:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                "DELETE FROM prekeys "
+                "WHERE prekey_id = ? AND exp > ? "
+                "RETURNING private_key, wire_record",
+                (prekey_id, int(time.time())),
+            ).fetchone()
+        if row is None:
+            return None
+        sk_bytes, wire = row[0], row[1]
+        wire_str = str(wire) if wire else None
+        return X25519PrivateKey.from_private_bytes(sk_bytes), wire_str
+
     def get_private_key(self, prekey_id: int) -> Optional[X25519PrivateKey]:
         """Return the sk for a given prekey_id, or None if absent / expired."""
         # Refuse the reserved sentinel even if a legacy/imported db

--- a/tests/test_prekeys.py
+++ b/tests/test_prekeys.py
@@ -355,6 +355,173 @@ class TestPrekeyStoreSchemaVersioning:
     # that actually matters. The dynamic test was theatre.
 
 
+class TestClaimSk:
+    """``PrekeyStore.claim_sk`` atomically returns the sk and deletes
+    the row. Replaces the previous get + decrypt + consume sequence on
+    the receive path so the sk is gone from disk before decrypt
+    starts. Closes the crash-window the old sequence had where a
+    crash between successful decrypt and `consume()` left the sk
+    on disk for a later disk-compromise attacker."""
+
+    def test_returns_sk_and_wire_then_deletes_row(self, tmp_path):
+        store = PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            pool = store.generate_pool(count=1, ttl_seconds=3600)
+            prekey, sk = pool[0]
+            store.record_wire(prekey.prekey_id, "v=dmp1;t=prekey;d=...")
+
+            claim = store.claim_sk(prekey.prekey_id)
+            assert claim is not None
+            claimed_sk, wire = claim
+            # The returned sk derives the same pubkey as the original.
+            from cryptography.hazmat.primitives import serialization
+
+            claimed_pub = claimed_sk.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+            assert claimed_pub == prekey.public_key
+            assert wire == "v=dmp1;t=prekey;d=..."
+            # And the row is gone — second claim returns None.
+            assert store.claim_sk(prekey.prekey_id) is None
+            # ``get_private_key`` also reflects the deletion.
+            assert store.get_private_key(prekey.prekey_id) is None
+        finally:
+            store.close()
+
+    def test_missing_prekey_id_returns_none(self, tmp_path):
+        store = PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            assert store.claim_sk(99999) is None
+        finally:
+            store.close()
+
+    def test_expired_prekey_returns_none(self, tmp_path):
+        store = PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            pool = store.generate_pool(count=1, ttl_seconds=0)
+            prekey, _ = pool[0]
+            # ttl=0 → exp == now; query uses strict ">" so already expired.
+            assert store.claim_sk(prekey.prekey_id) is None
+        finally:
+            store.close()
+
+    def test_zero_prekey_id_returns_none(self, tmp_path):
+        """The NO_PREKEY sentinel is never claimable, even via this
+        path — same reservation as get_private_key / consume."""
+        store = PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            assert store.claim_sk(0) is None
+        finally:
+            store.close()
+
+    def test_concurrent_claims_only_one_wins_within_one_store(self, tmp_path):
+        """Single-instance race: 8 threads sharing one PrekeyStore.
+        The per-instance RLock alone is enough to serialize this
+        case; the harder cross-process case is tested below via
+        multiple PrekeyStore instances on the same db file.
+        """
+        import threading
+
+        store = PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            pool = store.generate_pool(count=1, ttl_seconds=3600)
+            prekey, _ = pool[0]
+            results: list = []
+            lock = threading.Lock()
+            start = threading.Event()
+
+            def worker():
+                start.wait()
+                got = store.claim_sk(prekey.prekey_id)
+                with lock:
+                    results.append(got)
+
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            start.set()
+            for t in threads:
+                t.join(timeout=10)
+
+            wins = [r for r in results if r is not None]
+            assert len(wins) == 1, f"expected 1 winner, got {len(wins)}"
+        finally:
+            store.close()
+
+    def test_concurrent_claims_across_separate_store_instances(self, tmp_path):
+        """The harder case: each thread holds its OWN PrekeyStore on
+        the same db file. The per-instance RLock no longer helps
+        because each thread has a different instance. Atomicity has
+        to come from sqlite itself — `DELETE ... RETURNING` is one
+        statement, so exactly one issuer's RETURNING resolves to the
+        row.
+
+        This is the cross-process race shape: a node and an admin
+        tool could plausibly both open the same db simultaneously.
+        Two threads here is enough to expose the failure if the
+        fix regressed to SELECT-then-DELETE under autocommit.
+        """
+        import threading
+
+        seed = PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            pool = seed.generate_pool(count=1, ttl_seconds=3600)
+            prekey, _ = pool[0]
+        finally:
+            seed.close()
+
+        results: list = []
+        lock = threading.Lock()
+        start = threading.Event()
+
+        def worker():
+            local = PrekeyStore(str(tmp_path / "p.db"))
+            try:
+                start.wait()
+                got = local.claim_sk(prekey.prekey_id)
+                with lock:
+                    results.append(got)
+            finally:
+                local.close()
+
+        # 16 threads × distinct PrekeyStore instances on the same db.
+        # If claim_sk regressed to SELECT-then-DELETE in autocommit
+        # mode, multiple of these could all read the row before any
+        # delete committed, and all return non-None.
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join(timeout=15)
+
+        wins = [r for r in results if r is not None]
+        assert len(wins) == 1, (
+            f"DELETE ... RETURNING must be atomic across separate "
+            f"connections; got {len(wins)} winners (expected 1)"
+        )
+
+    def test_returns_none_when_wire_record_was_never_set(self, tmp_path):
+        """Pool generation creates the row with wire_record=''. If
+        the caller never recorded the published wire (e.g. publish
+        failed), claim_sk should still return the sk paired with
+        None for the wire — the caller decides whether to bother
+        with a DNS DELETE."""
+        store = PrekeyStore(str(tmp_path / "p.db"))
+        try:
+            pool = store.generate_pool(count=1, ttl_seconds=3600)
+            prekey, _ = pool[0]
+            # Note: NOT calling record_wire — wire_record stays ''.
+            claim = store.claim_sk(prekey.prekey_id)
+            assert claim is not None
+            sk, wire = claim
+            assert sk is not None
+            assert wire is None
+        finally:
+            store.close()
+
+
 class TestPrekeyIdReservation:
     """``prekey_id = 0`` is reserved as the ``NO_PREKEY`` sentinel
     (see dmp/core/manifest.py). The pool generator must never return


### PR DESCRIPTION
The receive path used to look up a prekey_sk, decrypt with it, then delete the row plus DNS record. A crash between the successful decrypt and the delete left the sk on disk — under a later disk-compromise scenario plus the captured ciphertext, the message could still be decrypted, weakening the forward-secrecy guarantee.

`PrekeyStore.claim_sk` now atomically reads + deletes the row in one operation under the per-instance lock and returns `(sk, wire_record)`. The receive path becomes claim_sk → decrypt → best-effort DNS delete. The sk is gone from disk before decrypt starts, so the crash window closes.

A failed decrypt can no longer be retried with the same sk, but a one-time prekey_sk wouldn't survive a retry anyway — the manifest's prekey_id and the chunks' AAD bind the ciphertext, so a transient memory error wouldn't have been recoverable.

## Tests

`TestClaimSk` (5 tests): returns sk + wire then deletes the row, missing/expired/zero-id all return None, 8-thread concurrent claim yields exactly one winner.

The existing receive-path integration tests in `test_client.py` and the docker FS test in `test_docker_integration.py` pass unchanged — they implicitly exercise the new flow because the decrypt site now calls `claim_sk`.

## Validation

- 1520 unit tests pass (+5 new claim_sk tests)
- 7 docker integration tests pass against a fresh image
- `black --check` clean