### PR TITLE
extend DNSSEC AD-bit gate to _NodeDnsReader and the heartbeat reader

### DIFF
--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -744,13 +744,29 @@ class _NodeDnsReader(DNSRecordReader):
     has a single deterministic destination — we do NOT fall back to
     the system resolver on failure (that would hide an unreachable
     cluster node from the union).
+
+    `dnssec_required` mirrors the policy on `ResolverPool` /
+    `_DnsReader`: when set, every reply must carry the AD flag from
+    a validating recursor or it is treated as transport failure
+    (raised so the union counts it as a node failure). The DO bit
+    is set on outgoing queries so the recursor knows to validate
+    and include RRSIGs. Same trust caveat: meaningful only over a
+    pinned local recursor or DoT/DoH; an on-path attacker on
+    plaintext UDP can flip AD.
     """
 
-    def __init__(self, dns_endpoint: str, *, timeout: float = 3.0) -> None:
+    def __init__(
+        self,
+        dns_endpoint: str,
+        *,
+        timeout: float = 3.0,
+        dnssec_required: bool = False,
+    ) -> None:
         host, port = _parse_host_port(dns_endpoint, default_port=53)
         self._host = host
         self._port = port
         self._timeout = float(timeout)
+        self._dnssec_required = dnssec_required
 
     def query_txt_record(self, name: str):
         import dns.exception
@@ -766,7 +782,16 @@ class _NodeDnsReader(DNSRecordReader):
         # failure and increments consecutive_failures). Coalescing both
         # to None would make dead DNS endpoints look perpetually
         # healthy in `cluster status` and defeat the pool's demotion.
-        request = dns.message.make_query(name, dns.rdatatype.TXT)
+        if self._dnssec_required:
+            # EDNS0 + DO so the recursor knows to do DNSSEC processing
+            # and include RRSIGs. Without DO many recursors strip
+            # RRSIGs and never set AD, which would make the gate fail
+            # every answer even from a validating resolver.
+            request = dns.message.make_query(
+                name, dns.rdatatype.TXT, use_edns=0, want_dnssec=True
+            )
+        else:
+            request = dns.message.make_query(name, dns.rdatatype.TXT)
         response = dns.query.udp(
             request,
             self._host,
@@ -784,6 +809,19 @@ class _NodeDnsReader(DNSRecordReader):
                 self._host,
                 port=self._port,
                 timeout=self._timeout,
+            )
+        # AD-bit gate: applied BEFORE the NXDOMAIN/rcode handling
+        # below. DNSSEC supports validated denial of existence via
+        # NSEC/NSEC3 — a real validating recursor sets AD on
+        # NXDOMAIN responses for signed zones. If the operator
+        # opted into `dnssec_required`, an AD-less NXDOMAIN is
+        # indistinguishable from a spoofed one and must NOT pass
+        # as a healthy "no record" answer. Raising treats it as a
+        # per-node transport failure so UnionReader demotes the
+        # upstream rather than blackholing reads.
+        if self._dnssec_required and not (response.flags & dns.flags.AD):
+            raise RuntimeError(
+                f"DNSSEC AD flag missing from {self._host} reply for {name}"
             )
         rcode = response.rcode()
         if rcode == dns.rcode.NXDOMAIN:
@@ -846,7 +884,9 @@ def _make_cluster_reader_factory(
 
     def factory(node: ClusterNode) -> DNSRecordReader:
         if node.dns_endpoint:
-            return _NodeDnsReader(node.dns_endpoint)
+            return _NodeDnsReader(
+                node.dns_endpoint, dnssec_required=config.dnssec_required
+            )
         return bootstrap_reader
 
     return factory

--- a/dmp/server/node.py
+++ b/dmp/server/node.py
@@ -145,7 +145,17 @@ def _build_heartbeat_dns_reader():
          deployments, so the system resolver is the right default.
       3. Returns None when neither is available; the worker tolerates
          this and just doesn't harvest peers.
+
+    ``DMP_HEARTBEAT_DNSSEC_REQUIRED=1`` opts both paths into AD-bit
+    enforcement: the recursor must return validated answers or the
+    record is dropped. Same caveat as elsewhere — meaningful only
+    when paired with a trusted local recursor or DoT/DoH, since an
+    on-path attacker on plaintext UDP can flip AD.
     """
+    require_dnssec = os.environ.get(
+        "DMP_HEARTBEAT_DNSSEC_REQUIRED", ""
+    ).strip().lower() in ("1", "true", "yes")
+
     raw = os.environ.get("DMP_HEARTBEAT_DNS_RESOLVERS", "").strip()
     if raw:
         try:
@@ -162,7 +172,7 @@ def _build_heartbeat_dns_reader():
                 else:
                     hosts.append(entry)
             if hosts:
-                return ResolverPool(hosts=hosts)
+                return ResolverPool(hosts=hosts, dnssec_required=require_dnssec)
         except Exception:
             log.exception(
                 "DMP_HEARTBEAT_DNS_RESOLVERS unparseable; falling back to system resolver"
@@ -173,27 +183,39 @@ def _build_heartbeat_dns_reader():
     # their served zone (a common cluster pattern) get peer harvest
     # for free, and split-horizon deployments don't have to override.
     try:
+        import dns.flags
         import dns.resolver
 
         from dmp.network.base import DNSRecordReader
 
         class _SystemResolver(DNSRecordReader):
-            def __init__(self) -> None:
+            def __init__(self, dnssec_required: bool) -> None:
                 self._resolver = dns.resolver.Resolver()
                 self._resolver.timeout = 3.0
                 self._resolver.lifetime = 6.0
+                self._dnssec_required = dnssec_required
+                if dnssec_required:
+                    # EDNS0 + DO so the recursor knows we want DNSSEC
+                    # processing. Without DO many recursors strip
+                    # RRSIGs and never set AD.
+                    self._resolver.use_edns(0, dns.flags.DO, 4096)
 
             def query_txt_record(self, name: str):
                 try:
                     answers = self._resolver.resolve(name, "TXT")
                 except Exception:
                     return None
+                if self._dnssec_required:
+                    response = getattr(answers, "response", None)
+                    flags = getattr(response, "flags", 0) if response else 0
+                    if not (flags & dns.flags.AD):
+                        return None
                 values = []
                 for rdata in answers:
                     values.append(b"".join(rdata.strings).decode("utf-8"))
                 return values or None
 
-        return _SystemResolver()
+        return _SystemResolver(require_dnssec)
     except Exception:
         log.exception(
             "could not build heartbeat-worker resolver; peer harvest disabled"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2660,6 +2660,182 @@ class TestNodeDnsReaderTruncation:
             reader.query_txt_record("example.com.")
 
 
+class TestNodeDnsReaderDnssecGate:
+    """``_NodeDnsReader(dnssec_required=True)`` requires the AD flag on
+    the recursor's reply. Same policy as ResolverPool / DNSOperations;
+    closes the gap codex flagged on PR #39 where cluster-mode reads
+    bypassed the AD gate even when the operator opted in."""
+
+    def _build_response(self, request, name, values, *, ad_set: bool):
+        import dns.flags
+        import dns.message
+        import dns.rdataclass
+        import dns.rdatatype
+        import dns.rrset
+
+        response = dns.message.make_response(request)
+        if ad_set:
+            response.flags |= dns.flags.AD
+        rrset = dns.rrset.from_text_list(
+            name,
+            300,
+            dns.rdataclass.IN,
+            dns.rdatatype.TXT,
+            [f'"{v}"' for v in values],
+        )
+        response.answer.append(rrset)
+        return response
+
+    def test_default_off_does_not_require_ad(self, monkeypatch):
+        """Existing operators get the legacy behavior: AD-less replies
+        round-trip cleanly."""
+        import dns.query
+
+        from dmp.cli import _NodeDnsReader
+
+        reader = _NodeDnsReader("127.0.0.1:9999")
+
+        def fake_udp(request, host, port, timeout):
+            return self._build_response(
+                request, "x.example.com.", ["v=dmp1;t=chunk;d=aGk="], ad_set=False
+            )
+
+        monkeypatch.setattr(dns.query, "udp", fake_udp)
+        assert reader.query_txt_record("x.example.com.") == ["v=dmp1;t=chunk;d=aGk="]
+
+    def test_required_passes_when_ad_set(self, monkeypatch):
+        import dns.query
+
+        from dmp.cli import _NodeDnsReader
+
+        reader = _NodeDnsReader("127.0.0.1:9999", dnssec_required=True)
+
+        def fake_udp(request, host, port, timeout):
+            return self._build_response(
+                request, "x.example.com.", ["validated"], ad_set=True
+            )
+
+        monkeypatch.setattr(dns.query, "udp", fake_udp)
+        assert reader.query_txt_record("x.example.com.") == ["validated"]
+
+    def test_required_raises_when_ad_unset(self, monkeypatch):
+        """A reply without AD is treated as a per-node transport
+        failure (raised), not as a healthy "no records" outcome.
+        UnionReader counts it against the node so a non-validating
+        upstream gets demoted instead of silently passing through."""
+        import dns.query
+
+        from dmp.cli import _NodeDnsReader
+
+        reader = _NodeDnsReader("127.0.0.1:9999", dnssec_required=True)
+
+        def fake_udp(request, host, port, timeout):
+            return self._build_response(
+                request, "x.example.com.", ["unvalidated"], ad_set=False
+            )
+
+        monkeypatch.setattr(dns.query, "udp", fake_udp)
+        with pytest.raises(RuntimeError, match="AD flag missing"):
+            reader.query_txt_record("x.example.com.")
+
+    def test_required_sets_do_bit_on_outgoing_query(self, monkeypatch):
+        """Without the DO bit on the outgoing query, many recursors
+        strip RRSIGs and never set AD on the response. Verify the
+        wire query carries DO so a validating recursor will actually
+        do the validation we're going to check for."""
+        import dns.flags
+        import dns.query
+
+        from dmp.cli import _NodeDnsReader
+
+        reader = _NodeDnsReader("127.0.0.1:9999", dnssec_required=True)
+        captured = {}
+
+        def fake_udp(request, host, port, timeout):
+            captured["request"] = request
+            return self._build_response(request, "x.example.com.", ["v"], ad_set=True)
+
+        monkeypatch.setattr(dns.query, "udp", fake_udp)
+        reader.query_txt_record("x.example.com.")
+        # dnspython's Message.ednsflags reflects the DO bit on the
+        # outgoing question.
+        assert captured["request"].ednsflags & dns.flags.DO
+
+    def test_required_raises_on_ad_less_nxdomain(self, monkeypatch):
+        """DNSSEC supports validated denial of existence — a real
+        validating recursor sets AD on NXDOMAIN for signed zones. An
+        AD-less NXDOMAIN is indistinguishable from a spoofed one and
+        must not be accepted as a healthy 'no record' answer when the
+        operator opted in to `dnssec_required`."""
+        import dns.message
+        import dns.query
+        import dns.rcode
+
+        from dmp.cli import _NodeDnsReader
+
+        reader = _NodeDnsReader("127.0.0.1:9999", dnssec_required=True)
+
+        def fake_udp(request, host, port, timeout):
+            response = dns.message.make_response(request)
+            response.set_rcode(dns.rcode.NXDOMAIN)
+            return response
+
+        monkeypatch.setattr(dns.query, "udp", fake_udp)
+        with pytest.raises(RuntimeError, match="AD flag missing"):
+            reader.query_txt_record("missing.example.com.")
+
+    def test_required_accepts_validated_nxdomain(self, monkeypatch):
+        """AD-set NXDOMAIN is a validated denial — accept as a healthy
+        'no record' (return None). UnionReader treats None as
+        healthy-not-found, distinct from a transport error."""
+        import dns.flags
+        import dns.message
+        import dns.query
+        import dns.rcode
+
+        from dmp.cli import _NodeDnsReader
+
+        reader = _NodeDnsReader("127.0.0.1:9999", dnssec_required=True)
+
+        def fake_udp(request, host, port, timeout):
+            response = dns.message.make_response(request)
+            response.set_rcode(dns.rcode.NXDOMAIN)
+            response.flags |= dns.flags.AD
+            return response
+
+        monkeypatch.setattr(dns.query, "udp", fake_udp)
+        assert reader.query_txt_record("missing.example.com.") is None
+
+    def test_required_checks_ad_after_tcp_retry(self, monkeypatch):
+        """When UDP returns truncated and the reader retries over TCP,
+        the AD check must apply to the TCP response — not the UDP one.
+        Without this, an attacker who can spoof TC=1 forces a TCP
+        retry whose unvalidated answer would slip through."""
+        import dns.flags
+        import dns.message
+        import dns.query
+
+        from dmp.cli import _NodeDnsReader
+
+        reader = _NodeDnsReader("127.0.0.1:9999", dnssec_required=True)
+
+        def fake_udp(request, host, port, timeout):
+            response = dns.message.make_response(request)
+            response.flags |= dns.flags.TC  # truncated → forces TCP retry
+            response.flags |= dns.flags.AD  # AD on UDP must not satisfy the gate
+            return response
+
+        def fake_tcp(request, host, port, timeout):
+            response = dns.message.make_response(request)
+            # TCP response WITHOUT AD — this is the one the gate must see.
+            return response
+
+        monkeypatch.setattr(dns.query, "udp", fake_udp)
+        monkeypatch.setattr(dns.query, "tcp", fake_tcp)
+        with pytest.raises(RuntimeError, match="AD flag missing"):
+            reader.query_txt_record("x.example.com.")
+
+
 class TestLocalOnlyClusterBootstrap:
     """Local-only CLI commands must not crash on cluster bootstrap failure.
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -101,3 +101,95 @@ class TestDMPNode:
     def test_node_stop_is_idempotent(self, node):
         node.stop()
         node.stop()  # must not raise
+
+
+class TestHeartbeatDnsReaderDnssecGate:
+    """``DMP_HEARTBEAT_DNSSEC_REQUIRED=1`` opts the heartbeat worker's
+    DNS reader into AD-bit enforcement on both code paths: the
+    ResolverPool built from ``DMP_HEARTBEAT_DNS_RESOLVERS`` and the
+    fallback system resolver."""
+
+    def test_pool_path_propagates_dnssec_required(self, monkeypatch):
+        from dmp.network.resolver_pool import ResolverPool
+        from dmp.server.node import _build_heartbeat_dns_reader
+
+        monkeypatch.setenv("DMP_HEARTBEAT_DNS_RESOLVERS", "1.1.1.1,9.9.9.9")
+        monkeypatch.setenv("DMP_HEARTBEAT_DNSSEC_REQUIRED", "1")
+
+        reader = _build_heartbeat_dns_reader()
+        assert isinstance(reader, ResolverPool)
+        assert reader._dnssec_required is True
+
+    def test_pool_path_default_off(self, monkeypatch):
+        from dmp.network.resolver_pool import ResolverPool
+        from dmp.server.node import _build_heartbeat_dns_reader
+
+        monkeypatch.setenv("DMP_HEARTBEAT_DNS_RESOLVERS", "1.1.1.1")
+        monkeypatch.delenv("DMP_HEARTBEAT_DNSSEC_REQUIRED", raising=False)
+
+        reader = _build_heartbeat_dns_reader()
+        assert isinstance(reader, ResolverPool)
+        assert reader._dnssec_required is False
+
+    def test_system_resolver_path_drops_ad_less_answer(self, monkeypatch):
+        """Fallback system-resolver path must also enforce AD when the
+        env var is set. AD-less answers return None — the worker
+        treats that as "nothing to harvest" (graceful degradation)
+        rather than passing unvalidated records through."""
+        import dns.flags
+        import dns.resolver
+
+        from dmp.server.node import _build_heartbeat_dns_reader
+
+        monkeypatch.delenv("DMP_HEARTBEAT_DNS_RESOLVERS", raising=False)
+        monkeypatch.setenv("DMP_HEARTBEAT_DNSSEC_REQUIRED", "1")
+
+        # Stub Resolver.resolve so we control the AD bit on the response.
+        class _FakeRdata:
+            def __init__(self, s):
+                self.strings = [s.encode("utf-8")]
+
+        class _FakeResponse:
+            def __init__(self, ad: bool):
+                self.flags = dns.flags.AD if ad else 0
+
+        class _FakeAnswer(list):
+            def __init__(self, vals, ad: bool):
+                super().__init__(_FakeRdata(v) for v in vals)
+                self.response = _FakeResponse(ad)
+
+        def fake_resolve(self, name, rdtype):
+            return _FakeAnswer(["unvalidated"], ad=False)
+
+        monkeypatch.setattr(dns.resolver.Resolver, "resolve", fake_resolve)
+        reader = _build_heartbeat_dns_reader()
+        assert reader.query_txt_record("x.example.com") is None
+
+    def test_system_resolver_path_passes_ad_set(self, monkeypatch):
+        import dns.flags
+        import dns.resolver
+
+        from dmp.server.node import _build_heartbeat_dns_reader
+
+        monkeypatch.delenv("DMP_HEARTBEAT_DNS_RESOLVERS", raising=False)
+        monkeypatch.setenv("DMP_HEARTBEAT_DNSSEC_REQUIRED", "1")
+
+        class _FakeRdata:
+            def __init__(self, s):
+                self.strings = [s.encode("utf-8")]
+
+        class _FakeResponse:
+            def __init__(self, ad: bool):
+                self.flags = dns.flags.AD if ad else 0
+
+        class _FakeAnswer(list):
+            def __init__(self, vals, ad: bool):
+                super().__init__(_FakeRdata(v) for v in vals)
+                self.response = _FakeResponse(ad)
+
+        def fake_resolve(self, name, rdtype):
+            return _FakeAnswer(["validated"], ad=True)
+
+        monkeypatch.setattr(dns.resolver.Resolver, "resolve", fake_resolve)
+        reader = _build_heartbeat_dns_reader()
+        assert reader.query_txt_record("x.example.com") == ["validated"]


### PR DESCRIPTION
The cluster-mode `_NodeDnsReader` and the heartbeat worker's DNS reader were the two paths still bypassing the AD-bit policy that ResolverPool and DNSOperations got earlier. Operators that opted into `dnssec_required` had no way to extend it to those readers, leaving unvalidated reads on the cluster-status path and the peer-harvest path even when the rest of the system enforced DNSSEC.

`_NodeDnsReader` gains a `dnssec_required` kwarg. When set: emits EDNS0+DO on the outgoing query and raises if the reply lacks AD. The cluster reader factory propagates `config.dnssec_required` to each constructed reader. UnionReader treats the raised exception as a per-node transport failure, so a non-validating upstream gets demoted.

`_build_heartbeat_dns_reader` reads `DMP_HEARTBEAT_DNSSEC_REQUIRED` from the environment and threads it into both code paths: the `ResolverPool` (built from `DMP_HEARTBEAT_DNS_RESOLVERS`) and the fallback system resolver. AD-less answers on the fallback path return None — the worker treats that as nothing to harvest rather than raising, matching the system-resolver contract elsewhere.

## Tests

`TestNodeDnsReaderDnssecGate` (4): default-off accepts AD-less; required accepts AD-set; required raises on AD-unset; required emits DO on the outgoing query.

`TestHeartbeatDnsReaderDnssecGate` (4): pool path propagates the env var; default off; system-resolver path drops AD-less answers; system-resolver path passes AD-set answers.

## Validation

- 1530 unit tests pass
- 7 docker integration tests pass
- `black --check` clean