### PR TITLE
require explicit prekey_store_path + intro_queue_path on DMPClient

### DIFF
--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -242,9 +242,9 @@ class DMPClient:
         reader: Optional[DNSRecordReader] = None,
         replay_cache_path: Optional[str] = None,
         kdf_salt: Optional[bytes] = None,
-        prekey_store_path: Optional[str] = None,
+        prekey_store_path: str,
         rotation_chain_enabled: bool = False,
-        intro_queue_path: Optional[str] = None,
+        intro_queue_path: str,
         allow_tofu: bool = False,
     ):
         if store is not None:
@@ -272,10 +272,11 @@ class DMPClient:
 
         # Prekey store: holds one-time X25519 prekey *private* halves so the
         # receive path can look them up by prekey_id and consume after decrypt.
-        # If no path is provided we get an ephemeral in-memory store via
-        # sqlite's :memory: — useful for tests but it drops on process exit,
-        # so a CLI deployment should always pass a path.
-        self.prekey_store = PrekeyStore(prekey_store_path or ":memory:")
+        # The path is required at the call site — silently falling back to
+        # ``:memory:`` had every CLI restart wipe the prekey pool, breaking
+        # forward secrecy negotiation for in-flight messages. Tests that
+        # genuinely want an ephemeral store pass ``":memory:"`` explicitly.
+        self.prekey_store = PrekeyStore(prekey_store_path)
 
         self.contacts: Dict[str, Contact] = {}
 
@@ -315,7 +316,7 @@ class DMPClient:
         # never invoke claim send/recv don't pay the import cost.
         from dmp.client.intro_queue import IntroQueue
 
-        self.intro_queue = IntroQueue(intro_queue_path or ":memory:")
+        self.intro_queue = IntroQueue(intro_queue_path)
 
         # M10 — local DNS endpoint for SAME-ZONE recipient-zone claim
         # publishes. The CLI sets these (from ``cfg.tsig_dns_server``

--- a/tests/test_claim_flow.py
+++ b/tests/test_claim_flow.py
@@ -102,8 +102,22 @@ class TestClaimFlow:
     def test_pinned_sender_claim_delivered_to_inbox(self):
         """Alice (pinned) publishes a claim; Bob receives it as a normal inbox message."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Alice has bob pinned (so she can address him).
         alice.add_contact(
@@ -149,8 +163,22 @@ class TestClaimFlow:
     def test_unpinned_sender_lands_in_intro_queue(self):
         """Alice is NOT pinned; her claim leads to a quarantined intro."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Alice can address bob (knows his pubkey from a directory
         # lookup, say). Bob does NOT pin alice.
@@ -195,8 +223,22 @@ class TestClaimFlow:
     def test_block_then_re_poll_drops_silently(self):
         """A blocked sender's claim is dropped; intro queue stays empty."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -231,8 +273,22 @@ class TestClaimFlow:
 
     def test_replay_skips_repolled_claim(self):
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -278,9 +334,30 @@ class TestClaimFlow:
         points at a manifest signed by someone else.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        eve = DMPClient("eve", "eve-pass", domain="eve.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="eve.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Alice publishes a real message + manifest.
         alice.add_contact(
@@ -350,8 +427,22 @@ class TestClaimFlow:
 class TestIntroQueueCli:
     def _setup_pending_intro(self):
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -410,8 +501,22 @@ class TestIntroQueueCli:
         """Codex P1 fix: send_message with claim_providers populates the
         provider's claim namespace."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -438,8 +543,22 @@ class TestIntroQueueCli:
         """Codex P1 fix: receive_messages with claim_providers also polls
         claims and lands un-pinned senders in the intro queue."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -466,7 +585,14 @@ class TestIntroQueueCli:
         """Codex P1 fix: a contact pinned via `intro trust` (spk only)
         cannot be sent to until X25519 is filled in."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # Manually pin a spk-only contact (mimics what trust_intro
         # leaves behind before identity-fetch fills in pub).
         ok = alice.add_contact(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,8 @@ def shared_store(monkeypatch):
             store=store,
             replay_cache_path=replay_path,
             allow_tofu=config.allow_tofu,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         for name, entry in config.contacts.items():
             # Mirror the real _make_client: use the persisted
@@ -1264,7 +1266,14 @@ class TestSendRecv:
         monkeypatch.setenv("DMP_PASSPHRASE", "alice-pass")
 
         # Discover bob's pubkey by spinning up a client in the same store.
-        bob = DMPClient("bob", "bob-pass", domain="mesh.local", store=shared_store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.local",
+            store=shared_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         cli.main(["contacts", "add", "bob", bob.get_public_key_hex()])
 
         rc = cli.main(["send", "bob", "hello from cli"])
@@ -1316,7 +1325,14 @@ class TestSendRecv:
         capsys.readouterr()
         monkeypatch.setenv("DMP_PASSPHRASE", "alice-pass")
 
-        bob = DMPClient("bob", "bob-pass", domain="mesh.local", store=shared_store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.local",
+            store=shared_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         cli.main(["contacts", "add", "bob", bob.get_public_key_hex()])
         capsys.readouterr()
 
@@ -1628,7 +1644,14 @@ class TestDnsResolvers:
         monkeypatch.setenv("DMP_PASSPHRASE", "alice-pass")
         capsys.readouterr()
 
-        bob = DMPClient("bob", "bob-pass", domain="mesh.local", store=shared_store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.local",
+            store=shared_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         cli.main(["contacts", "add", "bob", bob.get_public_key_hex()])
         cli.main(["send", "bob", "legacy hi"])
         assert "sent" in capsys.readouterr().out

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 """End-to-end client tests over an InMemoryDNSStore."""
 
+import inspect
 import time
 
 import pytest
@@ -9,8 +10,22 @@ from dmp.network.memory import InMemoryDNSStore
 
 
 def _pair(store: InMemoryDNSStore, domain: str = "mesh.test"):
-    alice = DMPClient("alice", "alice-pass", domain=domain, store=store)
-    bob = DMPClient("bob", "bob-pass", domain=domain, store=store)
+    alice = DMPClient(
+        "alice",
+        "alice-pass",
+        domain=domain,
+        store=store,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
+    )
+    bob = DMPClient(
+        "bob",
+        "bob-pass",
+        domain=domain,
+        store=store,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
+    )
     # Pin signing keys mutually — the secure default. Without
     # signing_key_hex the receiver's known_spks is empty and
     # receive_messages drops every manifest unless ``allow_tofu=True``.
@@ -66,7 +81,14 @@ class TestSendReceive:
     def test_other_user_cannot_decrypt(self):
         store = InMemoryDNSStore()
         alice, bob = _pair(store)
-        eve = DMPClient("eve", "eve-pass", domain="mesh.test", store=store)
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         alice.send_message("bob", "secret")
 
@@ -78,12 +100,26 @@ class TestSendReceive:
 
     def test_unknown_recipient_returns_false(self):
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "p", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "p",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         assert alice.send_message("nobody", "hi") is False
 
     def test_invalid_contact_key_rejected(self):
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "p", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "p",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         assert alice.add_contact("badhex", "zz") is False
         assert alice.add_contact("shortkey", "aabb") is False
 
@@ -142,7 +178,14 @@ class TestSendReceive:
         """Back-to-back sends prefer empty slots so neither message is lost."""
         store = InMemoryDNSStore()
         alice, bob = _pair(store)
-        eve = DMPClient("eve", "eve-pass", domain="mesh.test", store=store)
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         eve.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -178,9 +221,30 @@ class TestSendReceive:
         import hashlib
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
-        eve = DMPClient("eve", "eve-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # alice pins bob (both keys). No pin for eve.
         alice.add_contact(
@@ -214,9 +278,22 @@ class TestSendReceive:
         """
         store = InMemoryDNSStore()
         alice = DMPClient(
-            "alice", "alice-pass", domain="mesh.test", store=store, allow_tofu=True
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            allow_tofu=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # alice has no pinned signing keys at all — pure TOFU receive.
         bob.add_contact(
             "alice",
@@ -237,8 +314,22 @@ class TestSendReceive:
         explicitly via ``allow_tofu=True`` or ``enable_tofu()``.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         bob.add_contact(
             "alice",
             alice.get_public_key_hex(),
@@ -264,8 +355,22 @@ class TestSendReceive:
         cannot recover that session's plaintext.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Pin both directions with signing keys so prekey verification works.
         alice.add_contact(
@@ -319,11 +424,24 @@ class TestSendReceive:
         """Without a pinned signing key for bob, alice falls back to his
         long-term X25519 key (no FS) rather than failing to send."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # bob receives via TOFU because no contact pins HIM — explicit
         # opt-in is required after P0-3.
         bob = DMPClient(
-            "bob", "bob-pass", domain="mesh.test", store=store, allow_tofu=True
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            allow_tofu=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         # NOTE: no signing_key_hex — alice can't verify any prekey signature.
         alice.add_contact("bob", bob.get_public_key_hex())
@@ -364,11 +482,24 @@ class TestSendReceive:
         has one fewer entry.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # bob has no pinned contacts in this test — receive falls back to
         # TOFU which is opt-in after P0-3.
         bob = DMPClient(
-            "bob", "bob-pass", domain="mesh.test", store=store, allow_tofu=True
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            allow_tofu=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         alice.add_contact(
             "bob",
@@ -396,8 +527,22 @@ class TestSendReceive:
         he polls, the ciphertext is undeliverable — the FS property working
         in the other direction."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -621,7 +766,14 @@ class TestSendReceive:
 
         store = InMemoryDNSStore()
         alice, bob = _pair(store)
-        eve = DMPClient("eve", "eve-pass", domain="mesh.test", store=store)
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Alice legitimately sends, chunks and manifest land in the store.
         assert alice.send_message("bob", "survive the squat")
@@ -661,7 +813,14 @@ class TestSendReceive:
 
         store = InMemoryDNSStore()
         alice, bob = _pair(store)
-        eve = DMPClient("eve", "eve-pass", domain="mesh.test", store=store)
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Eve overwrites every one of Bob's slots with a manifest that claims
         # to be from Alice. Since Eve can't sign with Alice's Ed25519 key, the
@@ -699,7 +858,14 @@ class TestSpkOnlyContact:
 
     def test_add_contact_accepts_spk_only(self):
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         ok = alice.add_contact(
             "spk-only-friend",
             public_key_hex="",
@@ -714,15 +880,36 @@ class TestSpkOnlyContact:
 
     def test_add_contact_rejects_no_keys_at_all(self):
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # Empty pub AND empty spk — nothing useful to pin.
         assert alice.add_contact("ghost", public_key_hex="", domain="g.mesh") is False
 
     def test_recv_walks_spk_only_contact_zone(self):
         """An spk-only pinned contact still gets their zone polled."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Bob pins alice with full keys.
         bob.add_contact(
@@ -775,8 +962,22 @@ class TestCrossZoneReceive:
         nothing.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Bob pins alice and explicitly records her zone — this is what
         # `dnsmesh identity fetch alice@alice.mesh --add` writes today.
@@ -817,8 +1018,22 @@ class TestCrossZoneReceive:
         alice.mesh and decodes successfully.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         bob.add_contact(
             "alice",
             alice.get_public_key_hex(),
@@ -869,9 +1084,22 @@ class TestCrossZoneReceive:
         explicit ``allow_tofu=True``.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         bob = DMPClient(
-            "bob", "bob-pass", domain="mesh.test", store=store, allow_tofu=True
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            allow_tofu=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         # Legacy add — no domain= passed, no signing key (TOFU mode).
         alice.add_contact("bob", bob.get_public_key_hex())
@@ -890,10 +1118,29 @@ class TestCrossZoneReceive:
         manifest must not be discovered.
         """
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         mallory = DMPClient(
-            "mallory", "mallory-pass", domain="mallory.mesh", store=store
+            "mallory",
+            "mallory-pass",
+            domain="mallory.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
 
         bob.add_contact(
@@ -927,3 +1174,39 @@ class TestCrossZoneReceive:
         # pinned) — but the M8.1 promise is that we don't even look.
         assert len(inbox) == 1
         assert inbox[0].plaintext == b"from alice"
+
+
+class TestPersistencePathsRequired:
+    # Both ``intro_queue_path`` and ``prekey_store_path`` were
+    # ``Optional[str] = None`` and silently fell back to a
+    # ``:memory:`` sqlite when omitted. That made every CLI restart
+    # wipe the prekey pool (breaking forward-secrecy negotiation
+    # for in-flight messages) and dropped every pending first-
+    # contact intro on the floor. They are now required keyword
+    # arguments. Tests pin the contract at the signature level so a
+    # future refactor that re-introduces a default catches here.
+
+    def test_intro_queue_path_has_no_default(self):
+        sig = inspect.signature(DMPClient)
+        param = sig.parameters["intro_queue_path"]
+        assert param.default is inspect.Parameter.empty
+        # Pin keyword-only so a future refactor that re-orders the
+        # signature into positionals cannot satisfy the no-default
+        # check by accident — passing a path positionally is also
+        # forbidden.
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+
+    def test_prekey_store_path_has_no_default(self):
+        sig = inspect.signature(DMPClient)
+        param = sig.parameters["prekey_store_path"]
+        assert param.default is inspect.Parameter.empty
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+
+    def test_construct_without_persistence_paths_raises(self):
+        with pytest.raises(TypeError):
+            DMPClient(  # type: ignore[call-arg]
+                "alice",
+                "alice-pass",
+                domain="mesh.test",
+                store=InMemoryDNSStore(),
+            )

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -196,6 +196,8 @@ def test_container_roundtrip(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     bob = DMPClient(
         "bob",
@@ -203,6 +205,8 @@ def test_container_roundtrip(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     alice.add_contact(
         "bob",
@@ -238,6 +242,8 @@ def test_container_survives_client_restart(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     # Grab bob's pub + spk without retaining the client instance.
     _bob_for_keys = DMPClient(
@@ -246,6 +252,8 @@ def test_container_survives_client_restart(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     bob_pubkey = _bob_for_keys.get_public_key_hex()
     bob_spk = _bob_for_keys.get_signing_public_key_hex()
@@ -263,6 +271,8 @@ def test_container_survives_client_restart(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     bob_fresh.add_contact(
         "alice", alice.get_public_key_hex(), signing_key_hex=alice_spk
@@ -299,6 +309,7 @@ def test_container_forward_secrecy_end_to_end(node_container, tmp_path):
         writer=writer,
         reader=reader,
         prekey_store_path=alice_prekeys,
+        intro_queue_path=":memory:",
     )
     bob = DMPClient(
         "bob-fs",
@@ -307,6 +318,7 @@ def test_container_forward_secrecy_end_to_end(node_container, tmp_path):
         writer=writer,
         reader=reader,
         prekey_store_path=bob_prekeys,
+        intro_queue_path=":memory:",
     )
     # Alice pins both of bob's keys — required to verify prekey signatures.
     alice.add_contact(
@@ -391,6 +403,8 @@ def test_container_zone_anchored_identity(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     record = make_record(alice.crypto, "alice-z")
     wire = record.sign(alice.crypto)
@@ -500,6 +514,8 @@ def _rotate_identity(
         reader=old_client.reader,
         kdf_salt=kdf_salt,
         rotation_chain_enabled=old_client.rotation_chain_enabled,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
 
 
@@ -522,6 +538,8 @@ def test_container_rotation_routine_chain_walk(node_container):
         writer=writer,
         reader=reader,
         kdf_salt=alice_salt,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     bob = DMPClient(
         "bob",
@@ -531,6 +549,8 @@ def test_container_rotation_routine_chain_walk(node_container):
         reader=reader,
         kdf_salt=bob_salt,
         rotation_chain_enabled=True,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     alice.add_contact(
         "bob",
@@ -588,6 +608,8 @@ def test_container_rotation_compromise_revokes_old_key(node_container):
         writer=writer,
         reader=reader,
         kdf_salt=alice_salt,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     bob = DMPClient(
         "bob",
@@ -597,6 +619,8 @@ def test_container_rotation_compromise_revokes_old_key(node_container):
         reader=reader,
         kdf_salt=bob_salt,
         rotation_chain_enabled=True,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
 
     _rotate_identity(
@@ -651,6 +675,8 @@ def test_container_concurrent_receive_delivers_exactly_once(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     bob = DMPClient(
         "bob-conc",
@@ -658,6 +684,8 @@ def test_container_concurrent_receive_delivers_exactly_once(node_container):
         domain="mesh.docker",
         writer=writer,
         reader=reader,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
     )
     alice.add_contact(
         "bob-conc",

--- a/tests/test_m10_notifications.py
+++ b/tests/test_m10_notifications.py
@@ -52,8 +52,22 @@ def _alice_bob_pinned(store: InMemoryDNSStore):
     land on the recipient's zone and bob's phase-1 poll finds them on
     his own zone.
     """
-    alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-    bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+    alice = DMPClient(
+        "alice",
+        "alice-pass",
+        domain="alice.mesh",
+        store=store,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
+    )
+    bob = DMPClient(
+        "bob",
+        "bob-pass",
+        domain="bob.mesh",
+        store=store,
+        intro_queue_path=":memory:",
+        prekey_store_path=":memory:",
+    )
     alice.add_contact(
         "bob",
         bob.get_public_key_hex(),
@@ -145,9 +159,21 @@ class TestM10Client:
         # share AND short-circuiting publish_claim with a writer that
         # rejects the recipient-zone path.
         alice = DMPClient(
-            "alice", "alice-pass", domain="alice.mesh", store=sender_store
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=sender_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
-        bob = DMPClient("bob", "bob-pass", domain="alice.mesh", store=sender_store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="alice.mesh",
+            store=sender_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # Both clients see the same shared store at "alice.mesh"; bob's
         # contact for alice carries a *different* domain (bob.mesh), so
         # alice's M10 publish targets a zone that doesn't exist in the
@@ -221,9 +247,21 @@ class TestM10Client:
         slot-walk recovers."""
         sender_store = InMemoryDNSStore()
         alice = DMPClient(
-            "alice", "alice-pass", domain="alice.mesh", store=sender_store
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=sender_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
-        bob = DMPClient("bob", "bob-pass", domain="alice.mesh", store=sender_store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="alice.mesh",
+            store=sender_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -266,7 +304,14 @@ class TestM10Client:
         recipient_store = InMemoryDNSStore()
         # bob's own zone has the claim but no manifest is reachable at
         # alice's claimed sender_mailbox_domain.
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=recipient_store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=recipient_store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice_signer = DMPCrypto.from_passphrase("alice", salt=b"S" * 32)
         bob.add_contact(
             "alice",
@@ -304,9 +349,30 @@ class TestM10Client:
         OWN hash12."""
         store = InMemoryDNSStore()
         m10_un_tsig_d_to_store(store)
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
-        carol = DMPClient("carol", "carol-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        carol = DMPClient(
+            "carol",
+            "carol-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         alice.add_contact(
             "bob",
@@ -361,9 +427,30 @@ class TestM10Client:
         TOFU rule."""
         store = InMemoryDNSStore()
         m10_un_tsig_d_to_store(store)
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
-        eve = DMPClient("eve", "eve-pass", domain="eve.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="eve.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         alice.add_contact(
             "bob",
@@ -477,9 +564,30 @@ class TestCodexRound1Regressions:
         the diagnostic flag turns off — the M8.3 first-contact
         provider channel is orthogonal."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
-        eve = DMPClient("eve", "eve-pass", domain="eve.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="eve.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         # Bob pins alice (so phase 1's TOFU skip rule doesn't fire),
         # but NOT eve. Eve is the unpinned stranger whose claim has
@@ -526,9 +634,30 @@ class TestCodexRound1Regressions:
         """Same regression flagged in the same finding: ``skip_primary``
         MUST also leave the claim_providers channel intact."""
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
-        eve = DMPClient("eve", "eve-pass", domain="eve.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        eve = DMPClient(
+            "eve",
+            "eve-pass",
+            domain="eve.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         bob.add_contact(
             "alice",
@@ -571,8 +700,22 @@ class TestCodexRound1Regressions:
         store = InMemoryDNSStore()
         m10_un_tsig_d_to_store(store)
         # No pinned contacts → pure TOFU.
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -717,7 +860,14 @@ class TestCodexRound5DomainExplicitPersistence:
         from dmp.client.client import Contact
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # Add a contact with an explicit domain — what
         # ``identity fetch user@host --add`` does.
         alice.add_contact(
@@ -765,8 +915,22 @@ class TestCodexRound1ServerSameZone:
         from dmp.client import client as _client
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="dmp.example.com", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="dmp.example.com", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="dmp.example.com",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="dmp.example.com",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # Legacy add: no domain passed → backfill to self.domain,
         # domain_explicit=False.
         alice.add_contact(
@@ -806,8 +970,22 @@ class TestCodexRound1ServerSameZone:
         from dmp.client import client as _client
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="dmp.example.com", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="dmp.example.com", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="dmp.example.com",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="dmp.example.com",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # Explicit same-zone: caller passed the zone name even though
         # it matches alice's own.
         alice.add_contact(
@@ -851,8 +1029,22 @@ class TestCodexRound1ServerSameZone:
         from dmp.client import client as _client
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -903,8 +1095,22 @@ class TestCodexRound1ServerSameZone:
         from dmp.client import client as _client
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="dmp.example.com", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="dmp.example.com", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="dmp.example.com",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="dmp.example.com",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),
@@ -960,8 +1166,22 @@ class TestCodexRound1ServerSameZone:
         from dmp.client import client as _client
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="alice.mesh", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="bob.mesh", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -78,8 +78,22 @@ class TestDMPNode:
         # Drive the client directly against the node's sqlite store. Exercises
         # the full send -> chunk -> publish -> poll -> decrypt path through a
         # real persistent store behind the same API the DNS + HTTP layers use.
-        alice = DMPClient("alice", "apass", domain="mesh.test", store=node.store)
-        bob = DMPClient("bob", "bpass", domain="mesh.test", store=node.store)
+        alice = DMPClient(
+            "alice",
+            "apass",
+            domain="mesh.test",
+            store=node.store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bpass",
+            domain="mesh.test",
+            store=node.store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob.get_public_key_hex(),

--- a/tests/test_resolver_failover.py
+++ b/tests/test_resolver_failover.py
@@ -203,6 +203,8 @@ class TestResolverFailoverAcceptance:
             domain="mesh.test",
             writer=shared_store,
             reader=pool,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         bob = DMPClient(
             "bob",
@@ -210,6 +212,8 @@ class TestResolverFailoverAcceptance:
             domain="mesh.test",
             writer=shared_store,
             reader=pool,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         alice.add_contact(
             "bob",

--- a/tests/test_rotation_chain.py
+++ b/tests/test_rotation_chain.py
@@ -556,7 +556,7 @@ def test_chain_walk_unions_zone_anchored_and_hash_form():
 
 
 class TestDMPClientRotationChainIntegration:
-    """Verify DMPClient(rotation_chain_enabled=...) plumbing.
+    """Verify DMPClient(rotation_chain_enabled=..., intro_queue_path=":memory:", prekey_store_path=":memory:") plumbing.
 
     Default (False) MUST preserve byte-identical legacy behavior: a
     manifest from a non-pinned signer is dropped, period.
@@ -572,8 +572,22 @@ class TestDMPClientRotationChainIntegration:
         from dmp.network.memory import InMemoryDNSStore
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        bob = DMPClient("bob", "bob-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         # Bob pins alice, then alice rotates to a new passphrase/key.
         # The rotated-alice sends from the new key; without the flag,
         # bob's receive drops it (pinned key doesn't match).
@@ -582,7 +596,14 @@ class TestDMPClientRotationChainIntegration:
             alice.get_public_key_hex(),
             signing_key_hex=alice.get_signing_public_key_hex(),
         )
-        alice2 = DMPClient("alice", "alice-new-pass", domain="mesh.test", store=store)
+        alice2 = DMPClient(
+            "alice",
+            "alice-new-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice2.add_contact("bob", bob.get_public_key_hex())
         alice2.send_message("bob", "hello from rotated alice")
         assert bob.receive_messages() == []
@@ -597,8 +618,22 @@ class TestDMPClientRotationChainIntegration:
         from dmp.network.memory import InMemoryDNSStore
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        alice2 = DMPClient("alice", "alice-new-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        alice2 = DMPClient(
+            "alice",
+            "alice-new-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
 
         bob = DMPClient(
             "bob",
@@ -606,6 +641,8 @@ class TestDMPClientRotationChainIntegration:
             domain="mesh.test",
             store=store,
             rotation_chain_enabled=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         bob.add_contact(
             "alice",
@@ -648,13 +685,22 @@ class TestDMPClientRotationChainIntegration:
         from dmp.network.memory import InMemoryDNSStore
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         bob = DMPClient(
             "bob",
             "bob-pass",
             domain="mesh.test",
             store=store,
             rotation_chain_enabled=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         # Pin alice with her CURRENT signing key (no rotation yet).
         bob.add_contact(
@@ -688,14 +734,30 @@ class TestDMPClientRotationChainIntegration:
         from dmp.network.memory import InMemoryDNSStore
 
         store = InMemoryDNSStore()
-        alice = DMPClient("alice", "alice-pass", domain="mesh.test", store=store)
-        alice2 = DMPClient("alice", "alice-new-pass", domain="mesh.test", store=store)
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        alice2 = DMPClient(
+            "alice",
+            "alice-new-pass",
+            domain="mesh.test",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         bob = DMPClient(
             "bob",
             "bob-pass",
             domain="mesh.test",
             store=store,
             rotation_chain_enabled=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         bob.add_contact(
             "alice",
@@ -747,10 +809,20 @@ class TestDMPClientRotationChainIntegration:
         # locally on "mesh.local". This is the cross-zone case:
         # alice was pinned via `dmp identity fetch alice@other-zone.example --add`.
         alice = DMPClient(
-            "alice", "alice-pass", domain="other-zone.example", store=store
+            "alice",
+            "alice-pass",
+            domain="other-zone.example",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         alice2 = DMPClient(
-            "alice", "alice-new-pass", domain="other-zone.example", store=store
+            "alice",
+            "alice-new-pass",
+            domain="other-zone.example",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
 
         bob = DMPClient(
@@ -759,6 +831,8 @@ class TestDMPClientRotationChainIntegration:
             domain="mesh.local",
             store=store,
             rotation_chain_enabled=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         # Bob pins alice WITH the remote domain — exactly what the CLI
         # does after the M5.4-followup fix (persist contact.domain from
@@ -798,7 +872,12 @@ class TestDMPClientRotationChainIntegration:
         # RRsets. Because bob's mailbox addressing is tied to bob's
         # domain, alice2 must publish there.
         alice2_in_bob_zone = DMPClient(
-            "alice", "alice-new-pass", domain="mesh.local", store=store
+            "alice",
+            "alice-new-pass",
+            domain="mesh.local",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
         )
         alice2_in_bob_zone.add_contact("bob", bob.get_public_key_hex())
         alice2_in_bob_zone.send_message("bob", "cross-zone rotated hello")

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -141,8 +141,22 @@ class TestClientOverSqlite:
 
         store = SqliteMailboxStore(str(tmp_path / "mesh.db"))
         try:
-            alice = DMPClient("alice", "apass", domain="mesh.test", store=store)
-            bob = DMPClient("bob", "bpass", domain="mesh.test", store=store)
+            alice = DMPClient(
+                "alice",
+                "apass",
+                domain="mesh.test",
+                store=store,
+                intro_queue_path=":memory:",
+                prekey_store_path=":memory:",
+            )
+            bob = DMPClient(
+                "bob",
+                "bpass",
+                domain="mesh.test",
+                store=store,
+                intro_queue_path=":memory:",
+                prekey_store_path=":memory:",
+            )
             alice.add_contact(
                 "bob",
                 bob.get_public_key_hex(),
@@ -168,8 +182,22 @@ class TestClientOverSqlite:
 
         # Phase 1: alice sends while bob is "offline". Close the store.
         store1 = SqliteMailboxStore(db)
-        alice = DMPClient("alice", "apass", domain="mesh.test", store=store1)
-        bob_for_keys = DMPClient("bob", "bpass", domain="mesh.test", store=store1)
+        alice = DMPClient(
+            "alice",
+            "apass",
+            domain="mesh.test",
+            store=store1,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob_for_keys = DMPClient(
+            "bob",
+            "bpass",
+            domain="mesh.test",
+            store=store1,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
         alice.add_contact(
             "bob",
             bob_for_keys.get_public_key_hex(),
@@ -183,7 +211,14 @@ class TestClientOverSqlite:
         # manifest unless ``allow_tofu=True`` (P0-3 default-deny).
         store2 = SqliteMailboxStore(db)
         try:
-            bob = DMPClient("bob", "bpass", domain="mesh.test", store=store2)
+            bob = DMPClient(
+                "bob",
+                "bpass",
+                domain="mesh.test",
+                store=store2,
+                intro_queue_path=":memory:",
+                prekey_store_path=":memory:",
+            )
             bob.add_contact(
                 "alice",
                 alice.get_public_key_hex(),


### PR DESCRIPTION
## Summary

Follow-up to #47. `DMPClient` had `prekey_store_path: Optional[str] = None` and `intro_queue_path: Optional[str] = None`, and silently fell back to `":memory:"` when either was omitted. That had every CLI restart wipe the prekey pool (breaking forward-secrecy for in-flight messages) and dropped every pending first-contact intro on the floor — no error, no log.

Both kwargs are now required. The CLI already passes real on-disk paths via `_config_path()`; tests that want ephemeral stores pass `":memory:"` explicitly (130 sites updated).

## Changes

- `dmp/client/client.py`: required kwargs, drop `or ":memory:"` fallbacks, update docstring.
- `tests/test_client.py`: `TestPersistencePathsRequired` pins the contract at `inspect.signature` so a future refactor cannot re-introduce the silent default.
- 130 test call sites across 9 files updated to pass `intro_queue_path=":memory:", prekey_store_path=":memory:"`.

## Test plan

- [x] `tests/test_client.py::TestPersistencePathsRequired`
- [x] full unit suite (1538 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: re-introducing the silent fallback fails the new tests