### PR TITLE
log when heartbeat reader drops an AD-less TXT answer

### DIFF
--- a/dmp/server/node.py
+++ b/dmp/server/node.py
@@ -209,6 +209,19 @@ def _build_heartbeat_dns_reader():
                     response = getattr(answers, "response", None)
                     flags = getattr(response, "flags", 0) if response else 0
                     if not (flags & dns.flags.AD):
+                        # Drop the answer, but say so loudly. Returning
+                        # None here makes the heartbeat worker quietly
+                        # skip the peer; without this log line the
+                        # operator has no signal that DNSSEC enforcement
+                        # is what stopped harvesting. Warning level
+                        # (not error) because a single AD-less reply
+                        # may be transient — if the recursor is
+                        # broken it'll fire on every poll.
+                        log.warning(
+                            "heartbeat: dropping AD-less TXT answer for %s "
+                            "(DMP_HEARTBEAT_DNSSEC_REQUIRED=1)",
+                            name,
+                        )
                         return None
                 values = []
                 for rdata in answers:

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -179,6 +179,57 @@ class TestHeartbeatDnsReaderDnssecGate:
         reader = _build_heartbeat_dns_reader()
         assert reader.query_txt_record("x.example.com") is None
 
+    def test_system_resolver_path_logs_when_dropping_ad_less(self, monkeypatch, caplog):
+        # The drop must be visible to operators. Without a log line,
+        # an AD-less recursor silently halts peer harvest and the
+        # only symptom is a stale seen-store with no obvious cause.
+        import logging
+
+        import dns.flags
+        import dns.resolver
+
+        from dmp.server.node import _build_heartbeat_dns_reader
+
+        monkeypatch.delenv("DMP_HEARTBEAT_DNS_RESOLVERS", raising=False)
+        monkeypatch.setenv("DMP_HEARTBEAT_DNSSEC_REQUIRED", "1")
+
+        class _FakeRdata:
+            def __init__(self, s):
+                self.strings = [s.encode("utf-8")]
+
+        class _FakeResponse:
+            def __init__(self, ad: bool):
+                self.flags = dns.flags.AD if ad else 0
+
+        class _FakeAnswer(list):
+            def __init__(self, vals, ad: bool):
+                super().__init__(_FakeRdata(v) for v in vals)
+                self.response = _FakeResponse(ad)
+
+        def fake_resolve(self, name, rdtype):
+            return _FakeAnswer(["unvalidated"], ad=False)
+
+        monkeypatch.setattr(dns.resolver.Resolver, "resolve", fake_resolve)
+        reader = _build_heartbeat_dns_reader()
+
+        # Use a non-dotted token as the queried name so the substring
+        # assertion below doesn't trip CodeQL's URL-substring rule
+        # (the test substring would otherwise look URL-shaped).
+        queried = "harvested-peer-token"
+        with caplog.at_level(logging.WARNING, logger="dmp.server.node"):
+            assert reader.query_txt_record(queried) is None
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less" in r.getMessage()
+            and queried in r.getMessage()
+            and "DMP_HEARTBEAT_DNSSEC_REQUIRED" in r.getMessage()
+            for r in warnings
+        ), (
+            "expected AD-less warning naming the queried name AND the env "
+            f"var, got: {[r.getMessage() for r in warnings]}"
+        )
+
     def test_system_resolver_path_passes_ad_set(self, monkeypatch):
         import dns.flags
         import dns.resolver


### PR DESCRIPTION
## Summary

Codex flagged on PR #46 that the heartbeat `_SystemResolver` path returned `None` silently when `DMP_HEARTBEAT_DNSSEC_REQUIRED=1` and the recursor's reply had no AD bit. The worker tolerates `None` as "nothing to harvest", so an AD-less recursor halted peer harvest with no operator-visible signal.

Add a `log.warning` naming the queried name and the env var so the cause is visible. WARNING (not ERROR) because a single AD-less reply can be transient; if the recursor is broken it'll fire on every poll, which is what an operator needs to see.

## Test plan

- [x] `tests/test_node.py::TestHeartbeatDnsReaderDnssecGate` (5 tests, including new `test_system_resolver_path_logs_when_dropping_ad_less`)
- [x] full unit suite (1539 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: removing the log line fails the new test