### PR TITLE
log when other readers drop AD-less DNS answers

### DIFF
--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -24,6 +24,7 @@ import argparse
 import getpass
 import ipaddress
 import json
+import logging
 import os
 import sys
 import time
@@ -42,6 +43,8 @@ from dmp.core.cluster import ClusterNode
 from dmp.network.base import DNSRecordReader, DNSRecordWriter
 from dmp.network.composite_reader import CompositeReader
 from dmp.network.resolver_pool import ResolverPool, WELL_KNOWN_RESOLVERS
+
+log = logging.getLogger(__name__)
 
 # ----------------------------- config ----------------------------------------
 
@@ -491,6 +494,22 @@ class _DnsReader(DNSRecordReader):
             response = getattr(answers, "response", None)
             flags = getattr(response, "flags", 0) if response else 0
             if not (flags & dns.flags.AD):
+                # Same operator-visibility concern as the heartbeat
+                # reader and the resolver pool: a silent return here
+                # looks identical to "no record" to upstream callers.
+                # Include the configured upstream so a misbehaving
+                # recursor is identifiable from the log.
+                upstream = (
+                    f"{self._resolver.nameservers[0]}:{self._resolver.port}"
+                    if self._resolver.nameservers
+                    else "system-resolver"
+                )
+                log.warning(
+                    "_DnsReader: dropping AD-less TXT answer for %s "
+                    "from upstream %s (dnssec_required=True)",
+                    name,
+                    upstream,
+                )
                 return None
         values = []
         for rdata in answers:

--- a/dmp/core/dns.py
+++ b/dmp/core/dns.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import hashlib
+import logging
 from typing import Dict, Any, Optional, List, Tuple
 from dataclasses import dataclass
 import dns.flags
@@ -10,6 +11,8 @@ import dns.resolver
 import dns.message
 import dns.rdatatype
 import dns.name
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -192,6 +195,13 @@ class DNSOperations:
                     # Upstream didn't validate (or the chain failed).
                     # Drop the answer — DMP must not consume DNS data
                     # without validation when the operator opted in.
+                    # Warn so operators can correlate vanished records
+                    # with their DNSSEC opt-in rather than guessing.
+                    log.warning(
+                        "DNSOperations: dropping AD-less TXT answer for "
+                        "%s (dnssec_required=True)",
+                        domain,
+                    )
                     return None
             records = []
             for rdata in answers:

--- a/dmp/network/resolver_pool.py
+++ b/dmp/network/resolver_pool.py
@@ -413,6 +413,16 @@ class ResolverPool(DNSRecordReader):
             # and is documented on the constructor; mitigate via
             # DoT/DoH or a pinned local recursor.
             if self._dnssec_required and not _ad_bit_set(answers):
+                # Demote and continue. Without a log line the operator
+                # sees pool exhaustion (No answer / cooldown) but no
+                # signal that DNSSEC enforcement is the cause.
+                log.warning(
+                    "ResolverPool: dropping AD-less TXT answer for %s "
+                    "from upstream %s:%d (dnssec_required=True)",
+                    name,
+                    state.host,
+                    state.port,
+                )
                 self._mark_failure(state)
                 continue
 
@@ -484,6 +494,14 @@ class ResolverPool(DNSRecordReader):
                 # P0-4: same AD-bit gate as TXT — refuse address answers
                 # that the upstream did not DNSSEC-validate.
                 if self._dnssec_required and not _ad_bit_set(answers):
+                    log.warning(
+                        "ResolverPool: dropping AD-less %s answer for %s "
+                        "from upstream %s:%d (dnssec_required=True)",
+                        rdtype,
+                        host,
+                        state.host,
+                        state.port,
+                    )
                     self._mark_failure(state)
                     continue
                 for rdata in answers:
@@ -522,6 +540,13 @@ class ResolverPool(DNSRecordReader):
             # answer routes writes to an attacker-chosen host. Demote
             # the upstream and try the next.
             if self._dnssec_required and not _ad_bit_set(answers):
+                log.warning(
+                    "ResolverPool: dropping AD-less NS answer for %s "
+                    "from upstream %s:%d (dnssec_required=True)",
+                    zone,
+                    state.host,
+                    state.port,
+                )
                 self._mark_failure(state)
                 continue
             self._mark_success(state)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2859,6 +2859,50 @@ class TestNodeDnsReaderDnssecGate:
             reader.query_txt_record("x.example.com.")
 
 
+class TestDnsReaderDnssecLogs:
+    # `_DnsReader` (the single-host reader the CLI builds when the
+    # operator passes only --dns-host) returns None when the AD bit
+    # is missing on a `dnssec_required=True` reply. Without a log
+    # the operator sees empty results with no signal that DNSSEC
+    # enforcement is the cause — same blind spot the heartbeat
+    # reader had before #49.
+
+    def test_logs_when_dropping_ad_less_answer(self, monkeypatch, caplog):
+        import logging
+
+        import dns.flags
+        import dns.resolver
+
+        class _FakeRdata:
+            def __init__(self, s):
+                self.strings = [s.encode("utf-8")]
+
+        class _FakeResponse:
+            def __init__(self, ad):
+                self.flags = dns.flags.AD if ad else 0
+
+        class _FakeAnswer(list):
+            def __init__(self, vals, ad):
+                super().__init__(_FakeRdata(v) for v in vals)
+                self.response = _FakeResponse(ad)
+
+        def fake_resolve(self, name, rdtype):
+            return _FakeAnswer(["nope"], ad=False)
+
+        monkeypatch.setattr(dns.resolver.Resolver, "resolve", fake_resolve)
+        reader = cli._DnsReader("127.0.0.1", 53, dnssec_required=True)
+        with caplog.at_level(logging.WARNING, logger="dmp.cli"):
+            assert reader.query_txt_record("missing-token") is None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less TXT" in m
+            and "missing-token" in m
+            and "127.0.0.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
+
 class TestLocalOnlyClusterBootstrap:
     """Local-only CLI commands must not crash on cluster bootstrap failure.
 

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,8 +1,15 @@
 """Tests for DNS operations and encoding"""
 
+import logging
+from unittest.mock import patch
+
 import pytest
 import base64
 import json
+
+import dns.flags
+import dns.resolver
+
 from dmp.core.dns import DMPDNSRecord, DNSEncoder, DNSOperations, DNSChunkManager
 
 
@@ -231,6 +238,41 @@ class TestDNSOperations:
         assert len(messages) == 1
         assert messages[0][0] == 3  # Slot number
         assert messages[0][1].data == b"message for slot 3"
+
+
+class TestDNSOperationsDnssecLogs:
+    # Without these warnings a non-validating recursor silently
+    # turns every TXT lookup into None — same operator-blindspot
+    # as the heartbeat reader before #49.
+
+    def test_logs_when_dropping_ad_less_answer(self, caplog):
+        class _FakeRdata:
+            def __init__(self, s):
+                self.strings = [s.encode("utf-8")]
+
+        class _FakeResponse:
+            def __init__(self, ad):
+                self.flags = dns.flags.AD if ad else 0
+
+        class _FakeAnswer(list):
+            def __init__(self, vals, ad):
+                super().__init__(_FakeRdata(v) for v in vals)
+                self.response = _FakeResponse(ad)
+
+        ops = DNSOperations(dnssec_required=True)
+        with patch.object(
+            dns.resolver.Resolver,
+            "resolve",
+            autospec=True,
+            return_value=_FakeAnswer(["nope"], ad=False),
+        ):
+            with caplog.at_level(logging.WARNING, logger="dmp.core.dns"):
+                assert ops.query_txt_record("dropped-domain") is None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less TXT" in m and "dropped-domain" in m and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
 
 
 class TestDNSChunkManager:

--- a/tests/test_resolver_pool.py
+++ b/tests/test_resolver_pool.py
@@ -647,6 +647,96 @@ class TestResolverPoolDnssecGate:
             pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
             assert pool.resolve_ns_hosts("example.com") == []
 
+    # The three log-emission tests below pin operator visibility for
+    # the three call sites that drop AD-less answers. Without these,
+    # a misconfigured recursor silently halts TXT/address/NS lookups
+    # and the only symptom is empty results — same blind-spot the
+    # heartbeat reader had before #49.
+
+    def test_required_logs_when_dropping_ad_less_txt(self, caplog):
+        routes = {
+            "1.1.1.1": lambda n, t: _answer("not-validated", ad=False),
+        }
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            with caplog.at_level(logging.WARNING, logger="dmp.network.resolver_pool"):
+                assert pool.query_txt_record("dropped-name") is None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        # Pin every load-bearing field — name, upstream IP+port, the
+        # rdtype tag (TXT), and the env-style flag — so a future
+        # refactor that drops any of them fails the test.
+        assert any(
+            "AD-less TXT" in m
+            and "dropped-name" in m
+            and "1.1.1.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
+    def test_required_logs_when_dropping_ad_less_address(self, caplog):
+        class _AddrRdata:
+            def __init__(self, addr):
+                self.address = addr
+
+        def _addr_answer(addr, ad):
+            ans = _FakeAnswer()
+            ans.append(_AddrRdata(addr))
+            ans.response = _FakeResponse(dns.flags.AD if ad else 0)
+            return ans
+
+        routes = {"1.1.1.1": lambda n, t: _addr_answer("203.0.113.7", ad=False)}
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            with caplog.at_level(logging.WARNING, logger="dmp.network.resolver_pool"):
+                assert pool.resolve_address("addr-target") is None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        # `resolve_address` runs the AD gate inside an rdtype loop
+        # (A then AAAA). Pin "AD-less A" specifically — a mutation
+        # that strips the rdtype from the message would otherwise
+        # pass with a bare "AD-less" substring check.
+        assert any(
+            "AD-less A " in m
+            and "addr-target" in m
+            and "1.1.1.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
+    def test_required_logs_when_dropping_ad_less_ns(self, caplog):
+        class _FakeNsRdata:
+            def __init__(self, target):
+                self.target = dns.name.from_text(target)
+
+        def _ns_answer(*targets, ad: bool):
+            ans = _FakeAnswer()
+            for t in targets:
+                ans.append(_FakeNsRdata(t))
+            ans.response = _FakeResponse(dns.flags.AD if ad else 0)
+            return ans
+
+        routes = {"1.1.1.1": lambda n, t: _ns_answer("ns1.test.", ad=False)}
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = _route_by_nameserver(routes)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            with caplog.at_level(logging.WARNING, logger="dmp.network.resolver_pool"):
+                assert pool.resolve_ns_hosts("ns-zone-target") == []
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less NS" in m
+            and "ns-zone-target" in m
+            and "1.1.1.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
 
 # ---------------------------------------------------------------------
 # Health tracking & cooldown


### PR DESCRIPTION
## Summary

Follow-up to #49. Codex flagged the same silent-drop pattern at four more sites:

- `dmp/network/resolver_pool.py` — `query_txt_record`, `resolve_address`, `resolve_ns_hosts` (3 sites)
- `dmp/core/dns.py` — `DNSOperations.query_txt_record`
- `dmp/cli.py` — `_DnsReader.query_txt_record`

When `dnssec_required=True` and the upstream's reply lacks the AD bit, the answer was demoted/dropped silently. Operators saw pool exhaustion or empty results with no signal that DNSSEC enforcement was the cause.

Add `log.warning` at each site naming the queried name, the upstream host:port (where applicable), and the `dnssec_required` flag. Initialise module-level loggers in `dmp/core/dns.py` and `dmp/cli.py` since neither had logging set up before.

## Test plan

- [x] 5 new caplog-based regression tests
- [x] full unit suite (1544 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: removing one of the log lines fails the corresponding test