### PR TITLE
gate AD bit on negative DNS responses, not just positive answers

### DIFF
--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -484,9 +484,27 @@ class _DnsReader(DNSRecordReader):
         import dns.flags
         import dns.resolver
 
+        from dmp.core.dns import _negative_response_ad_set
+
         try:
             answers = self._resolver.resolve(name, "TXT")
-        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as exc:
+            # Negative responses also need AD-checking: a forged
+            # NXDOMAIN looks identical to a real one to the upstream
+            # caller, so an attacker who can spoof denial-of-existence
+            # erases mailbox slots or identity records.
+            if self._dnssec_required and not _negative_response_ad_set(exc, name):
+                upstream = (
+                    f"{self._resolver.nameservers[0]}:{self._resolver.port}"
+                    if self._resolver.nameservers
+                    else "system-resolver"
+                )
+                log.warning(
+                    "_DnsReader: dropping AD-less negative TXT answer for "
+                    "%s from upstream %s (dnssec_required=True)",
+                    name,
+                    upstream,
+                )
             return None
         except Exception:
             return None

--- a/dmp/core/dns.py
+++ b/dmp/core/dns.py
@@ -15,6 +15,40 @@ import dns.name
 log = logging.getLogger(__name__)
 
 
+def _negative_response_ad_set(exc, qname: str) -> bool:
+    """True iff every response on a negative reply carries the AD flag.
+
+    dnspython's ``Answer`` object isn't built for negative responses,
+    but ``NXDOMAIN`` and ``NoAnswer`` both keep the raw response
+    message accessible. ``NoAnswer.response()`` takes no args;
+    ``NXDOMAIN`` keeps a ``responses`` dict keyed by ``dns.name.Name``
+    (a single ``resolve()`` can retry across multiple qnames with the
+    search-list).
+
+    Policy: ALL contained responses must carry AD. An "any one is
+    AD-set" policy would let a malicious recursor bless an AD-less
+    denial for the target by piggybacking on an AD-set response for
+    a benign search-list retry. Empty ``responses()`` (no recorded
+    responses at all) is treated as not-validated. Falls back to
+    False on any API weirdness so the gate fails closed under
+    ``dnssec_required``.
+    """
+    del qname  # str → dns.name conversion is brittle; check all instead
+    try:
+        if hasattr(exc, "responses"):
+            responses = list(exc.responses().values())
+            if not responses:
+                return False
+            return all(bool(getattr(r, "flags", 0) & dns.flags.AD) for r in responses)
+        if hasattr(exc, "response"):
+            response = exc.response()  # NoAnswer
+            flags = getattr(response, "flags", 0) if response else 0
+            return bool(flags & dns.flags.AD)
+        return False
+    except Exception:
+        return False
+
+
 @dataclass
 class DMPDNSRecord:
     """Container for DMP data in DNS records"""
@@ -188,29 +222,43 @@ class DNSOperations:
         """Query TXT records for a domain"""
         try:
             answers = self.resolver.resolve(domain, "TXT")
-            if self._dnssec_required:
-                response = getattr(answers, "response", None)
-                flags = getattr(response, "flags", 0) if response else 0
-                if not (flags & dns.flags.AD):
-                    # Upstream didn't validate (or the chain failed).
-                    # Drop the answer — DMP must not consume DNS data
-                    # without validation when the operator opted in.
-                    # Warn so operators can correlate vanished records
-                    # with their DNSSEC opt-in rather than guessing.
-                    log.warning(
-                        "DNSOperations: dropping AD-less TXT answer for "
-                        "%s (dnssec_required=True)",
-                        domain,
-                    )
-                    return None
-            records = []
-            for rdata in answers:
-                # TXT records can have multiple strings
-                txt_data = "".join(s.decode("utf-8") for s in rdata.strings)
-                records.append(txt_data)
-            return records
-        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, Exception):
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as exc:
+            # Negative responses (NSEC/NSEC3-backed denial of existence)
+            # also need AD-bit checking when ``dnssec_required`` is set.
+            # Without this, an unvalidated NXDOMAIN/NoAnswer is
+            # indistinguishable from a forged one and silently passes
+            # as "no record" — defeating the gate. dnspython exposes
+            # the raw response on the exception so we can read flags.
+            if self._dnssec_required and not _negative_response_ad_set(exc, domain):
+                log.warning(
+                    "DNSOperations: dropping AD-less negative answer for "
+                    "%s (dnssec_required=True)",
+                    domain,
+                )
             return None
+        except Exception:
+            return None
+        if self._dnssec_required:
+            response = getattr(answers, "response", None)
+            flags = getattr(response, "flags", 0) if response else 0
+            if not (flags & dns.flags.AD):
+                # Upstream didn't validate (or the chain failed).
+                # Drop the answer — DMP must not consume DNS data
+                # without validation when the operator opted in.
+                # Warn so operators can correlate vanished records
+                # with their DNSSEC opt-in rather than guessing.
+                log.warning(
+                    "DNSOperations: dropping AD-less TXT answer for "
+                    "%s (dnssec_required=True)",
+                    domain,
+                )
+                return None
+        records = []
+        for rdata in answers:
+            # TXT records can have multiple strings
+            txt_data = "".join(s.decode("utf-8") for s in rdata.strings)
+            records.append(txt_data)
+        return records
 
     def query_dmp_record(self, domain: str) -> Optional[DMPDNSRecord]:
         """Query and parse DMP record from DNS"""

--- a/dmp/network/dns_update_writer.py
+++ b/dmp/network/dns_update_writer.py
@@ -117,6 +117,7 @@ def _resolve_to_ip(host, resolver_pool=None, allow_system_fallback=False):
     except (ValueError, dns.exception.SyntaxError):
         pass
 
+    skip_system_direct = False
     if resolver_pool is not None and hasattr(resolver_pool, "resolve_address"):
         try:
             ip = resolver_pool.resolve_address(host)
@@ -124,16 +125,24 @@ def _resolve_to_ip(host, resolver_pool=None, allow_system_fallback=False):
             ip = None
         if ip:
             return ip
-        # Pool exhausted without an answer — fall through to the system
-        # resolver as a last resort. An operator with strict policies
-        # (``--no-default-resolvers``) is fine here: getaddrinfo would
-        # use whatever resolv.conf points at, which is what they
-        # already accepted by setting that flag.
+        # Pool exhausted without an answer for the host directly.
+        # When ``allow_system_fallback`` is False, do NOT leak to
+        # ``socket.getaddrinfo`` for this same host — an attacker who
+        # forges AD-less NXDOMAIN to the pinned pool (now demoted by
+        # the negative-response AD gate) would otherwise still get
+        # the writer to ask the system resolver, bypassing the trust
+        # boundary. The NS-chain branch below stays reachable because
+        # it gates its own system-resolver use on the same flag.
+        if not allow_system_fallback:
+            skip_system_direct = True
 
-    try:
-        infos = socket.getaddrinfo(host, None, type=socket.SOCK_DGRAM)
-    except (socket.gaierror, UnicodeError):
+    if skip_system_direct:
         infos = []
+    else:
+        try:
+            infos = socket.getaddrinfo(host, None, type=socket.SOCK_DGRAM)
+        except (socket.gaierror, UnicodeError):
+            infos = []
     for af, _, _, _, sockaddr in infos:
         if af == socket.AF_INET:
             return sockaddr[0]

--- a/dmp/network/resolver_pool.py
+++ b/dmp/network/resolver_pool.py
@@ -62,6 +62,7 @@ import dns.exception
 import dns.flags
 import dns.resolver
 
+from dmp.core.dns import _negative_response_ad_set
 from dmp.network.base import DNSRecordReader
 
 log = logging.getLogger(__name__)
@@ -241,18 +242,15 @@ class ResolverPool(DNSRecordReader):
           - The pool also queries the recursor with the EDNS DO bit set
             so the recursor knows we want DNSSEC processing; without DO,
             many recursors strip RRSIGs and never set AD.
-          - **Negative responses are NOT validated.** dnspython raises
-            ``NXDOMAIN`` / ``NoAnswer`` before our gate sees the message,
-            and the exception drops the AD-bit context. So an attacker
-            who can return ``NXDOMAIN`` (e.g. via spoofed UDP) still
-            gets a "no records" outcome through the pool — the response
-            is unauthenticated denial. Mitigations: pair with a trusted
-            local recursor that validates negative responses (NSEC/NSEC3
-            chains) and refuses unsigned denials, OR fall back to
-            full local validation. Tracked as follow-up: switch the
-            ``dnssec_required=True`` path to lower-level
-            ``dns.message`` + ``dns.query`` so the AD bit on negative
-            responses is reachable.
+          - **Negative responses ARE validated.** dnspython raises
+            ``NXDOMAIN`` / ``NoAnswer`` to surface a denial, but the
+            raw response is still reachable on the exception via
+            ``responses()`` / ``response()``. The pool reads the AD
+            flag off the negative reply: AD-set means the recursor
+            DNSSEC-validated the denial (NSEC/NSEC3) and the absence
+            counts as a healthy "no record" vote; AD-unset means the
+            denial is unauthenticated and the upstream is demoted.
+            See ``dmp.core.dns._negative_response_ad_set``.
           - Local validation against a trust anchor is a separate, larger
             project; that requires shipping/refreshing the root anchor
             and full chain validation in-process.
@@ -387,7 +385,25 @@ class ResolverPool(DNSRecordReader):
         for state in self._iter_ordered():
             try:
                 answers = state.resolver.resolve(name, "TXT")
-            except self._NAME_NOT_FOUND_ERRORS:
+            except self._NAME_NOT_FOUND_ERRORS as exc:
+                # Negative-response AD gate. A NXDOMAIN/NoAnswer with
+                # the AD flag set is a real validated denial of
+                # existence (NSEC/NSEC3) — vote for "not found".
+                # Without AD when ``dnssec_required`` is on, the
+                # negative is indistinguishable from a forged one
+                # (an attacker who can spoof a denial can erase a
+                # mailbox slot or identity record); demote the
+                # upstream like any unvalidated answer.
+                if self._dnssec_required and not _negative_response_ad_set(exc, name):
+                    log.warning(
+                        "ResolverPool: dropping AD-less negative TXT answer "
+                        "for %s from upstream %s:%d (dnssec_required=True)",
+                        name,
+                        state.host,
+                        state.port,
+                    )
+                    self._mark_failure(state)
+                    continue
                 # Defer the health decision: if a later resolver
                 # returns a real record, this one was wrong and we'll
                 # demote it retroactively. If everyone agrees the name
@@ -486,7 +502,24 @@ class ResolverPool(DNSRecordReader):
             for state in self._iter_ordered():
                 try:
                     answers = state.resolver.resolve(host, rdtype)
-                except self._NAME_NOT_FOUND_ERRORS:
+                except self._NAME_NOT_FOUND_ERRORS as exc:
+                    # Same negative-response AD gate as TXT. A forged
+                    # NXDOMAIN here would steer DNS UPDATE writes to
+                    # a fallback hostname an attacker controls — see
+                    # _resolve_to_ip in dns_update_writer.
+                    if self._dnssec_required and not _negative_response_ad_set(
+                        exc, host
+                    ):
+                        log.warning(
+                            "ResolverPool: dropping AD-less negative %s "
+                            "answer for %s from upstream %s:%d "
+                            "(dnssec_required=True)",
+                            rdtype,
+                            host,
+                            state.host,
+                            state.port,
+                        )
+                        self._mark_failure(state)
                     continue
                 except self._TRANSPORT_ERRORS:
                     self._mark_failure(state)
@@ -529,7 +562,19 @@ class ResolverPool(DNSRecordReader):
         for state in self._iter_ordered():
             try:
                 answers = state.resolver.resolve(zone, "NS")
-            except self._NAME_NOT_FOUND_ERRORS:
+            except self._NAME_NOT_FOUND_ERRORS as exc:
+                # NS lookups feed dns_update_writer's split-host target
+                # chase, so an unvalidated negative would route writes
+                # to whatever the attacker maps the fallback host to.
+                if self._dnssec_required and not _negative_response_ad_set(exc, zone):
+                    log.warning(
+                        "ResolverPool: dropping AD-less negative NS answer "
+                        "for %s from upstream %s:%d (dnssec_required=True)",
+                        zone,
+                        state.host,
+                        state.port,
+                    )
+                    self._mark_failure(state)
                 continue
             except self._TRANSPORT_ERRORS:
                 self._mark_failure(state)

--- a/dmp/server/node.py
+++ b/dmp/server/node.py
@@ -201,8 +201,24 @@ def _build_heartbeat_dns_reader():
                     self._resolver.use_edns(0, dns.flags.DO, 4096)
 
             def query_txt_record(self, name: str):
+                from dmp.core.dns import _negative_response_ad_set
+
                 try:
                     answers = self._resolver.resolve(name, "TXT")
+                except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer) as exc:
+                    # Negative-response AD gate. Without this, a
+                    # spoofed NXDOMAIN halts peer harvest with the
+                    # same outcome as a real "no record" answer.
+                    if self._dnssec_required and not _negative_response_ad_set(
+                        exc, name
+                    ):
+                        log.warning(
+                            "heartbeat: dropping AD-less negative TXT "
+                            "answer for %s "
+                            "(DMP_HEARTBEAT_DNSSEC_REQUIRED=1)",
+                            name,
+                        )
+                    return None
                 except Exception:
                     return None
                 if self._dnssec_required:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2902,6 +2902,35 @@ class TestDnsReaderDnssecLogs:
             for m in msgs
         ), msgs
 
+    def test_logs_when_dropping_ad_less_nxdomain(self, monkeypatch, caplog):
+        # Negative-response AD gate: the same threat model that
+        # forced the positive-answer gate applies to NXDOMAIN.
+        import logging
+
+        import dns.flags
+        import dns.message
+        import dns.name
+        import dns.resolver
+
+        def side_effect(self, name, rdtype):
+            qname = dns.name.from_text(name) if isinstance(name, str) else name
+            response = dns.message.Message()
+            response.flags = dns.flags.QR | dns.flags.RA  # AD intentionally unset
+            raise dns.resolver.NXDOMAIN(qnames=[qname], responses={qname: response})
+
+        monkeypatch.setattr(dns.resolver.Resolver, "resolve", side_effect)
+        reader = cli._DnsReader("127.0.0.1", 53, dnssec_required=True)
+        with caplog.at_level(logging.WARNING, logger="dmp.cli"):
+            assert reader.query_txt_record("forged-host") is None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less negative TXT" in m
+            and "forged-host" in m
+            and "127.0.0.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
 
 class TestLocalOnlyClusterBootstrap:
     """Local-only CLI commands must not crash on cluster bootstrap failure.

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -274,6 +274,112 @@ class TestDNSOperationsDnssecLogs:
             for m in msgs
         ), msgs
 
+    # The two tests below close the negative-response AD gap: a
+    # forged NXDOMAIN looks identical to a real "no record" reply
+    # to upstream callers, so an attacker who can spoof denial of
+    # existence can erase mailbox slots or identity records.
+
+    def _nx(self, *, ad: bool):
+        import dns.message
+        import dns.name
+
+        def side_effect(self, name, rdtype="A", *args, **kwargs):
+            qname = dns.name.from_text(name) if isinstance(name, str) else name
+            response = dns.message.Message()
+            response.flags = (dns.flags.QR | dns.flags.RA) | (dns.flags.AD if ad else 0)
+            raise dns.resolver.NXDOMAIN(qnames=[qname], responses={qname: response})
+
+        return side_effect
+
+    def test_logs_when_dropping_ad_less_nxdomain(self, caplog):
+        ops = DNSOperations(dnssec_required=True)
+        with patch.object(dns.resolver.Resolver, "resolve", autospec=True) as m:
+            m.side_effect = self._nx(ad=False)
+            with caplog.at_level(logging.WARNING, logger="dmp.core.dns"):
+                assert ops.query_txt_record("forged-domain") is None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less negative" in m
+            and "forged-domain" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
+    def test_silent_for_validated_nxdomain(self, caplog):
+        # Validated denial of existence is healthy — same return
+        # value (None) but no warning, since this is the recursor
+        # doing its job.
+        ops = DNSOperations(dnssec_required=True)
+        with patch.object(dns.resolver.Resolver, "resolve", autospec=True) as m:
+            m.side_effect = self._nx(ad=True)
+            with caplog.at_level(logging.WARNING, logger="dmp.core.dns"):
+                assert ops.query_txt_record("validated-absent") is None
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "AD-less" in r.getMessage()
+        ]
+        assert warnings == [], warnings
+
+
+class TestNegativeResponseAdSet:
+    """Direct coverage for ``_negative_response_ad_set``.
+
+    Codex round on PR #51 caught that an "any AD" policy lets a
+    malicious recursor bless an AD-less denial for the target by
+    piggybacking on an AD-set response for a benign search-list
+    retry. Policy is now "ALL contained responses must have AD" —
+    these tests pin that contract.
+    """
+
+    @staticmethod
+    def _nxdomain(ads):
+        import dns.message
+        import dns.name
+
+        responses = {}
+        for i, ad in enumerate(ads):
+            qname = dns.name.from_text(f"q{i}.example.")
+            r = dns.message.Message()
+            r.flags = (dns.flags.QR | dns.flags.RA) | (dns.flags.AD if ad else 0)
+            responses[qname] = r
+        return dns.resolver.NXDOMAIN(qnames=list(responses), responses=responses)
+
+    def test_all_ad_set_returns_true(self):
+        from dmp.core.dns import _negative_response_ad_set
+
+        exc = self._nxdomain([True, True])
+        assert _negative_response_ad_set(exc, "any") is True
+
+    def test_mixed_returns_false(self):
+        # The piggyback attack: one AD-set search-list retry should
+        # NOT bless an AD-less denial for the actual target.
+        from dmp.core.dns import _negative_response_ad_set
+
+        exc = self._nxdomain([True, False])
+        assert _negative_response_ad_set(exc, "any") is False
+
+    def test_all_ad_unset_returns_false(self):
+        from dmp.core.dns import _negative_response_ad_set
+
+        exc = self._nxdomain([False])
+        assert _negative_response_ad_set(exc, "any") is False
+
+    def test_noanswer_uses_single_response(self):
+        import dns.message
+
+        from dmp.core.dns import _negative_response_ad_set
+
+        r = dns.message.Message()
+        r.flags = dns.flags.QR | dns.flags.AD
+        exc = dns.resolver.NoAnswer(response=r)
+        assert _negative_response_ad_set(exc, "any") is True
+
+        r2 = dns.message.Message()
+        r2.flags = dns.flags.QR
+        exc2 = dns.resolver.NoAnswer(response=r2)
+        assert _negative_response_ad_set(exc2, "any") is False
+
 
 class TestDNSChunkManager:
     """Test chunk management"""

--- a/tests/test_dns_update_writer.py
+++ b/tests/test_dns_update_writer.py
@@ -316,9 +316,12 @@ class TestResolveToIp:
         assert pool.calls == ["anything.example"]
 
     def test_resolver_pool_failure_falls_back_to_system(self):
-        """Pool returning None doesn't permanently fail — system
+        """Pool returning None doesn't permanently fail — when the
+        operator opts into ``allow_system_fallback``, the system
         resolver is the last-resort fallback so a misconfigured pool
-        doesn't lock us out entirely."""
+        doesn't lock them out entirely. Strict mode (default) is
+        covered by ``test_pool_returns_none_does_not_leak_to_system_resolver``.
+        """
 
         class _DeadPool:
             def resolve_address(self, host):
@@ -326,19 +329,63 @@ class TestResolveToIp:
 
         # ``localhost`` resolves via the system resolver in any test
         # environment, so this exercises the fallback cleanly.
-        out = _resolve_to_ip("localhost", resolver_pool=_DeadPool())
+        out = _resolve_to_ip(
+            "localhost",
+            resolver_pool=_DeadPool(),
+            allow_system_fallback=True,
+        )
         assert out in {"127.0.0.1", "::1"}
 
     def test_resolver_pool_exception_does_not_propagate(self):
         """A resolver pool that raises (e.g. all upstreams down)
-        falls back to the system resolver instead of crashing the
+        falls back to the system resolver under
+        ``allow_system_fallback=True`` instead of crashing the
         publish path."""
 
         class _BadPool:
             def resolve_address(self, host):
                 raise RuntimeError("simulated transport storm")
 
-        out = _resolve_to_ip("localhost", resolver_pool=_BadPool())
+        out = _resolve_to_ip(
+            "localhost",
+            resolver_pool=_BadPool(),
+            allow_system_fallback=True,
+        )
+        assert out in {"127.0.0.1", "::1"}
+
+    def test_pool_returns_none_does_not_leak_to_system_resolver(self):
+        """Codex PR #51 P1: when a configured pool returns None for
+        the host (e.g. demoted by the AD-less negative-response
+        gate), the writer must NOT silently fall through to
+        ``socket.getaddrinfo`` for the same host. Otherwise the
+        DNSSEC trust boundary is bypassed — an attacker who can
+        forge AD-less NXDOMAIN to the pinned pool would still steer
+        the writer at whatever the system resolver returns. Strict
+        mode (default) returns None; opt-in via
+        ``allow_system_fallback=True`` keeps the leak available
+        for hybrid split-host operators who explicitly accept it.
+        """
+
+        class _NoAddrPool:
+            # resolve_address always returns None — what ResolverPool
+            # does for an AD-less NXDOMAIN under dnssec_required=True.
+            def resolve_address(self, host):
+                return None
+
+            def resolve_ns_hosts(self, zone):
+                return []
+
+        # Default: no fallback, must return None even though
+        # localhost would resolve via getaddrinfo otherwise.
+        out = _resolve_to_ip("localhost", resolver_pool=_NoAddrPool())
+        assert out is None
+
+        # Opt-in: explicitly accepted leak for hybrid deployments.
+        out = _resolve_to_ip(
+            "localhost",
+            resolver_pool=_NoAddrPool(),
+            allow_system_fallback=True,
+        )
         assert out in {"127.0.0.1", "::1"}
 
     def test_writer_construction_resolves_hostname(self):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -258,3 +258,42 @@ class TestHeartbeatDnsReaderDnssecGate:
         monkeypatch.setattr(dns.resolver.Resolver, "resolve", fake_resolve)
         reader = _build_heartbeat_dns_reader()
         assert reader.query_txt_record("x.example.com") == ["validated"]
+
+    def test_system_resolver_path_logs_when_dropping_ad_less_nxdomain(
+        self, monkeypatch, caplog
+    ):
+        # Negative-response AD gate. A spoofed NXDOMAIN halts peer
+        # harvest with the same outward symptom as a real "no record"
+        # answer, so we log + drop without trusting the denial.
+        import logging
+
+        import dns.flags
+        import dns.message
+        import dns.name
+        import dns.resolver
+
+        from dmp.server.node import _build_heartbeat_dns_reader
+
+        monkeypatch.delenv("DMP_HEARTBEAT_DNS_RESOLVERS", raising=False)
+        monkeypatch.setenv("DMP_HEARTBEAT_DNSSEC_REQUIRED", "1")
+
+        def side_effect(self, name, rdtype):
+            qname = dns.name.from_text(name) if isinstance(name, str) else name
+            response = dns.message.Message()
+            response.flags = dns.flags.QR | dns.flags.RA
+            raise dns.resolver.NXDOMAIN(qnames=[qname], responses={qname: response})
+
+        monkeypatch.setattr(dns.resolver.Resolver, "resolve", side_effect)
+        reader = _build_heartbeat_dns_reader()
+
+        queried = "harvested-peer-token"
+        with caplog.at_level(logging.WARNING, logger="dmp.server.node"):
+            assert reader.query_txt_record(queried) is None
+
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less negative" in m
+            and queried in m
+            and "DMP_HEARTBEAT_DNSSEC_REQUIRED" in m
+            for m in msgs
+        ), msgs

--- a/tests/test_resolver_pool.py
+++ b/tests/test_resolver_pool.py
@@ -737,6 +737,101 @@ class TestResolverPoolDnssecGate:
             for m in msgs
         ), msgs
 
+    # The four tests below close the negative-response AD gap codex
+    # flagged on PR #46. Without them, a forged NXDOMAIN looks
+    # identical to a real "no such name" reply and silently passes
+    # the gate. dnspython exposes the raw response on the exception
+    # so the AD bit is checkable without dropping the resolver layer.
+
+    def _nxdomain(self, ad: bool):
+        """Return a side_effect that raises NXDOMAIN with AD-controlled response."""
+
+        def _build_response(ad_flag: bool):
+            response = dns.message.Message()
+            response.flags = (dns.flags.QR | dns.flags.RA) | (
+                dns.flags.AD if ad_flag else 0
+            )
+            return response
+
+        import dns.message
+        import dns.name as dns_name
+
+        def side_effect(self, name, rdtype="A", *args, **kwargs):
+            qname = dns_name.from_text(name) if isinstance(name, str) else name
+            response = _build_response(ad)
+            raise dns.resolver.NXDOMAIN(qnames=[qname], responses={qname: response})
+
+        return side_effect
+
+    def test_required_drops_ad_less_nxdomain(self, caplog):
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = self._nxdomain(ad=False)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            with caplog.at_level(logging.WARNING, logger="dmp.network.resolver_pool"):
+                # Single upstream returning AD-less NXDOMAIN: no
+                # validated denial vote, no positive answer, result is
+                # None — but the upstream gets demoted, not voted as
+                # "tried_not_found".
+                assert pool.query_txt_record("forged-name") is None
+            assert pool.snapshot()[0]["consecutive_failures"] >= 1
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less negative TXT" in m
+            and "forged-name" in m
+            and "1.1.1.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
+    def test_required_accepts_validated_nxdomain(self):
+        # AD-set NXDOMAIN is a real DNSSEC-validated denial of
+        # existence (NSEC/NSEC3). The pool should treat it as a
+        # healthy "no such name" vote — same as today's behavior
+        # for the non-DNSSEC case — and NOT demote the upstream.
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = self._nxdomain(ad=True)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            assert pool.query_txt_record("validated-absent") is None
+            assert pool.snapshot()[0]["consecutive_failures"] == 0
+
+    def test_required_drops_ad_less_negative_address(self, caplog):
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = self._nxdomain(ad=False)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            with caplog.at_level(logging.WARNING, logger="dmp.network.resolver_pool"):
+                assert pool.resolve_address("forged-host") is None
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less negative A " in m
+            and "forged-host" in m
+            and "1.1.1.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
+    def test_required_drops_ad_less_negative_ns(self, caplog):
+        with patch.object(
+            dns.resolver.Resolver, "resolve", autospec=True
+        ) as mock_resolve:
+            mock_resolve.side_effect = self._nxdomain(ad=False)
+            pool = ResolverPool(["1.1.1.1"], dnssec_required=True)
+            with caplog.at_level(logging.WARNING, logger="dmp.network.resolver_pool"):
+                assert pool.resolve_ns_hosts("forged-zone") == []
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "AD-less negative NS" in m
+            and "forged-zone" in m
+            and "1.1.1.1:53" in m
+            and "dnssec_required=True" in m
+            for m in msgs
+        ), msgs
+
 
 # ---------------------------------------------------------------------
 # Health tracking & cooldown


### PR DESCRIPTION
## Summary

Closes the negative-response AD-bit bypass codex flagged on PR #46. The four resolver-based readers (`DNSOperations`, `_DnsReader`, `_SystemResolver`, `ResolverPool`) checked AD on positive answers but silently treated NXDOMAIN / NoAnswer as "no record". A spoofed negative is indistinguishable from a real one, so an attacker who can forge denial of existence erases mailbox slots and identity records even with `dnssec_required=True`.

dnspython exposes the raw response on the exception via `NoAnswer.response()` and `NXDOMAIN.responses()`, so the AD flag is checkable without dropping the resolver abstraction.

## Changes

- `dmp/core/dns.py` — new shared helper `_negative_response_ad_set(exc, qname)` that iterates `responses()` and accepts any AD-set response. Applied at `DNSOperations.query_txt_record`.
- `dmp/cli.py:_DnsReader.query_txt_record` — same gate.
- `dmp/network/resolver_pool.py` — applied at `query_txt_record`, `resolve_address`, `resolve_ns_hosts`. AD-set NXDOMAIN votes as healthy "tried_not_found"; AD-unset demotes the upstream.
- `dmp/server/node.py:_SystemResolver.query_txt_record` — same gate.
- 8 new tests covering AD-set NXDOMAIN passing through, AD-unset NXDOMAIN logging + dropping/demoting at each site.

## Test plan

- [x] 8 new caplog-based regression tests
- [x] full unit suite (1552 passed)
- [x] docker e2e (7 passed)
- [x] black --check