### PR TITLE
refuse shared-pool token deletes on /v1/records

### DIFF
--- a/dmp/server/http_api.py
+++ b/dmp/server/http_api.py
@@ -126,8 +126,13 @@ class _DMPHttpHandler(BaseHTTPRequestHandler):
             return ""
         return header[len("Bearer ") :]
 
-    def _authorize_record_write(self, record_name: str) -> bool:
+    def _authorize_record_write(self, record_name: str, op: str = "publish") -> bool:
         """Mode-aware authorization for ``/v1/records/{name}`` writes.
+
+        ``op`` is ``"publish"`` or ``"delete"``. The operator-token
+        short-circuit accepts both, since operators can always do
+        either. The TokenStore branch passes ``op`` through so the
+        scope-class rules can refuse e.g. shared-pool deletes.
 
         ``auth_mode == "open"``: accept everything. Dev / trusted LAN only.
         ``auth_mode == "legacy"``: only the operator token is accepted
@@ -169,6 +174,7 @@ class _DMPHttpHandler(BaseHTTPRequestHandler):
             presented,
             record_name,
             remote_addr=self.client_address[0] if self.client_address else "",
+            op=op,
         )
         # Stash the AuthResult on the handler so the POST/DELETE
         # caller can translate ``throttled`` to HTTP 429 rather than
@@ -791,7 +797,7 @@ HTTPS exchange is the one-time TSIG-key registration step.</p>
             return 404
         if not self._check_rate_limit():
             return 429
-        if not self._authorize_record_write(name):
+        if not self._authorize_record_write(name, op="delete"):
             status, payload = self._auth_failure_response()
             self._send_json(status, payload)
             return status

--- a/dmp/server/tokens.py
+++ b/dmp/server/tokens.py
@@ -947,8 +947,16 @@ class TokenStore:
         *,
         remote_addr: str = "",
         log_use: bool = True,
+        op: str = "publish",
     ) -> AuthResult:
         """Classify ``record_name`` and check ``token`` against the scope.
+
+        ``op`` is ``"publish"`` or ``"delete"``. Shared-pool tokens
+        may publish into the chunk namespace (their whole purpose)
+        but MUST NOT delete: a stolen pool token would otherwise be
+        able to wipe other users' chunk RRsets it never authored.
+        Owner-exclusive tokens can delete their own scope (the user
+        deleting their identity / mailbox is a documented flow).
 
         Returns an :class:`AuthResult`. When ``log_use`` is True (the
         default), a successful authorization writes a row to the
@@ -1121,13 +1129,35 @@ class TokenStore:
                     self._conn.commit()
                 return AuthResult(True, row=row, scope=scope)
 
-            # Shared pool: any live token is fine. Deliberately do
-            # NOT populate token_hash / subject on the audit row —
-            # that's the split-audit policy. Per-token rate limit is
-            # enforced the same way as for owner-exclusive, but the
-            # throttled audit row ALSO drops token_hash/subject to
-            # keep the split-audit invariant: an operator with the DB
-            # cannot tell which user was throttled on a chunk write.
+            # Shared pool: any live token is fine to PUBLISH. Delete
+            # is operator-only at this layer — the chunk namespace
+            # has no per-record ownership record, so we cannot tell
+            # whether a given pool token authored the RRset it's
+            # asking to remove. Allowing pool deletes meant any live
+            # pool token could wipe co-resident chunks (codex P1
+            # round on the post-#51 audit). Operator tokens still
+            # delete via the operator-token short-circuit higher up.
+            if op == "delete":
+                if log_use:
+                    self._audit(
+                        "rejected",
+                        remote_addr=remote_addr,
+                        detail="shared-pool delete refused",
+                    )
+                    self._conn.commit()
+                return AuthResult(
+                    False,
+                    row=row,
+                    scope=scope,
+                    reason="shared-pool tokens may publish but not delete",
+                )
+            # Deliberately do NOT populate token_hash / subject on
+            # the audit row — that's the split-audit policy. Per-
+            # token rate limit is enforced the same way as for
+            # owner-exclusive, but the throttled audit row ALSO
+            # drops token_hash/subject to keep the split-audit
+            # invariant: an operator with the DB cannot tell which
+            # user was throttled on a chunk write.
             if not self._rate_limiter.allow(
                 token_hash, row.rate_per_sec, row.rate_burst
             ):

--- a/tests/test_http_auth_multi_tenant.py
+++ b/tests/test_http_auth_multi_tenant.py
@@ -214,6 +214,42 @@ class TestMultiTenantDelete:
         )
         assert r.status_code == 401
 
+    def test_shared_pool_token_cannot_delete_chunk(self, mt_setup):
+        # A pool token may publish into the chunk namespace (any user
+        # can deliver chunks for anyone) but must NOT delete chunks
+        # there. Without this gate, a stolen pool token would wipe
+        # other users' co-resident chunk RRsets.
+        api, store, tokens = mt_setup
+        # Operator seeds the chunk so DELETE has a target.
+        assert (
+            _post(api, "chunk-0001-abcdef012345.example.com", "op-token", "v1") == 201
+        )
+        alice_token, _ = tokens.issue("alice@example.com")
+        headers = {"Authorization": f"Bearer {alice_token}"}
+        r = requests.delete(
+            _url(api, "chunk-0001-abcdef012345.example.com"),
+            headers=headers,
+            timeout=2,
+        )
+        assert r.status_code == 401
+        # The chunk RRset still exists — DELETE was refused, not
+        # silently swallowed.
+        assert store.query_txt_record("chunk-0001-abcdef012345.example.com")
+
+    def test_operator_can_delete_chunk(self, mt_setup):
+        # Sanity: operator-token short-circuit still grants delete.
+        api, _, _ = mt_setup
+        assert (
+            _post(api, "chunk-0002-abcdef012345.example.com", "op-token", "v1") == 201
+        )
+        headers = {"Authorization": "Bearer op-token"}
+        r = requests.delete(
+            _url(api, "chunk-0002-abcdef012345.example.com"),
+            headers=headers,
+            timeout=2,
+        )
+        assert r.status_code == 204
+
 
 # ---------------------------------------------------------------------------
 # Back-compat: legacy + open modes must still behave like pre-M5.5.

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -493,6 +493,34 @@ class TestAuthorizeSharedPool:
         r = store.authorize_write(token, "chunk-0001-abcdef012345.example.com")
         assert not r.ok
 
+    def test_shared_pool_token_cannot_delete_chunk(self, store: TokenStore) -> None:
+        # The pool grants any live token publish access to chunks
+        # because chunks are content-addressed and the namespace has
+        # no per-record ownership. Delete must NOT inherit the same
+        # permissive policy: a stolen pool token would otherwise
+        # wipe co-resident RRsets it never authored.
+        token, _ = store.issue("alice@example.com")
+        r = store.authorize_write(
+            token, "chunk-0001-abcdef012345.example.com", op="delete"
+        )
+        assert not r.ok
+        assert "shared-pool" in r.reason.lower()
+        # Publish on the same name still succeeds — only delete is
+        # refused.
+        r2 = store.authorize_write(token, "chunk-0001-abcdef012345.example.com")
+        assert r2.ok
+
+    def test_shared_pool_token_cannot_delete_mailbox(self, store: TokenStore) -> None:
+        # Mailbox-slot delivery flows through the shared pool because
+        # any user can deliver to any mailbox. Delete therefore lands
+        # in the same branch and must be rejected.
+        token, _ = store.issue("alice@example.com")
+        r = store.authorize_write(
+            token, "slot-3.mb-abcdef012345.example.com", op="delete"
+        )
+        assert not r.ok
+        assert "shared-pool" in r.reason.lower()
+
 
 class TestAuthorizeOperatorOnly:
     def test_end_user_token_cannot_publish_cluster(self, store: TokenStore) -> None:


### PR DESCRIPTION
## Summary

Closes the P1 finding from the post-#51 fresh codex audit. `_authorize_record_write` checked scope but ignored HTTP method, so a live shared-pool token could DELETE chunk RRsets it never authored — wiping co-resident chunks for other users. The pool's permissive PUBLISH semantics work because chunks are content-addressed and anyone can deliver for anyone; DELETE has no symmetric ownership signal, so the same permissiveness is unsafe.

## Changes

- `dmp/server/tokens.py` — `TokenStore.authorize_write` now takes `op="publish"|"delete"`. The shared-pool branch refuses `op=delete` with an audit row and clear reason.
- `dmp/server/http_api.py` — `_handle_delete` plumbs `op="delete"`; `_authorize_record_write` forwards.
- Owner-exclusive flow unchanged (users can still delete their own identity / mailbox per the documented multi-tenant flow).
- Operator-token short-circuit unchanged.

## Out of scope (follow-up)

DNS UPDATE TSIG keys have the same gap — `update_authorizer(key_name, op, owner)` already receives `op` but the keystore-built authorizer doesn't differentiate add vs delete. Worth a separate tight PR with a `is_operator_key` distinction or per-record-class delete policy.

## Test plan

- [x] `tests/test_token_store.py::TestAuthorizeSharedPool::test_shared_pool_token_cannot_delete_chunk` and `_mailbox`
- [x] `tests/test_http_auth_multi_tenant.py::TestMultiTenantDelete::test_shared_pool_token_cannot_delete_chunk` and `test_operator_can_delete_chunk`
- [x] full unit suite (1561 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: removing the op=delete check fails both new tests