### PR TITLE
chmod parent + WAL/SHM siblings on PrekeyStore + TSIGKeyStore

### DIFF
--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -214,8 +214,21 @@ class PrekeyStore:
 
     def __init__(self, db_path: str) -> None:
         self.db_path = db_path
-        parent = os.path.dirname(db_path) or "."
-        os.makedirs(parent, exist_ok=True)
+        # Tighten the parent directory BEFORE creating the file so a
+        # permissive umask doesn't leave the new sqlite file (or its
+        # WAL/SHM siblings) world-readable. The DB holds the X25519
+        # prekey private halves — local disclosure equals forward-
+        # secrecy compromise. Mirror IntroQueue's pattern:
+        # 0o700 on the dir, 0o600 on the DB and every -wal/-shm
+        # sibling sqlite materializes alongside it.
+        on_disk = db_path != ":memory:"
+        if on_disk:
+            parent = os.path.dirname(db_path) or "."
+            os.makedirs(parent, exist_ok=True)
+            try:
+                os.chmod(parent, 0o700)
+            except OSError:
+                pass
         self._lock = RLock()
         # 30s busy-timeout: ``_migrate`` takes a reserved write lock via
         # ``BEGIN IMMEDIATE`` so concurrent opens on the same file
@@ -231,10 +244,14 @@ class PrekeyStore:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._migrate()
-        try:
-            os.chmod(db_path, 0o600)
-        except OSError:
-            pass
+        if on_disk:
+            for suffix in ("", "-wal", "-shm"):
+                sibling = db_path + suffix
+                try:
+                    if os.path.exists(sibling):
+                        os.chmod(sibling, 0o600)
+                except OSError:
+                    pass
 
     def _migrate(self) -> None:
         """Apply schema migrations atomically and idempotently.

--- a/dmp/server/tsig_keystore.py
+++ b/dmp/server/tsig_keystore.py
@@ -40,6 +40,7 @@ counts and removes a class of stale-keyring bugs).
 
 from __future__ import annotations
 
+import os
 import secrets
 import sqlite3
 import threading
@@ -271,12 +272,35 @@ class TSIGKeyStore:
 
     def __init__(self, db_path: str) -> None:
         self._path = db_path
+        # Tighten the parent directory BEFORE creating the file so a
+        # permissive umask doesn't leave the new sqlite file (or its
+        # WAL/SHM siblings) world-readable. The DB holds TSIG shared
+        # secrets — local disclosure lets any reader forge DNS UPDATE
+        # writes for every scope a key covers. Mirror IntroQueue's
+        # pattern: 0o700 on the dir, 0o600 on the DB and every
+        # -wal/-shm sibling sqlite materializes alongside it.
+        on_disk = db_path != ":memory:"
+        if on_disk:
+            parent = os.path.dirname(db_path) or "."
+            os.makedirs(parent, exist_ok=True)
+            try:
+                os.chmod(parent, 0o700)
+            except OSError:
+                pass
         self._lock = threading.Lock()
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._migrate()
         self._conn.commit()
+        if on_disk:
+            for suffix in ("", "-wal", "-shm"):
+                sibling = db_path + suffix
+                try:
+                    if os.path.exists(sibling):
+                        os.chmod(sibling, 0o600)
+                except OSError:
+                    pass
 
     def _migrate(self) -> None:
         """Apply schema migrations idempotently and stamp ``user_version``.

--- a/tests/test_prekeys.py
+++ b/tests/test_prekeys.py
@@ -196,6 +196,68 @@ class TestPrekeyStore:
             s2.close()
 
 
+class TestPrekeyStoreFilePerms:
+    # The DB holds X25519 prekey private halves — local disclosure
+    # equals forward-secrecy compromise for in-flight messages
+    # against this client. A permissive umask on the parent dir
+    # used to leave the DB and its WAL/SHM siblings world-readable
+    # because chmod was applied only to the main DB file (codex P2
+    # on the post-#52 fresh audit).
+
+    def test_db_and_wal_shm_are_0600_after_init(self, tmp_path):
+        import os
+        import stat
+
+        path = str(tmp_path / "secrets" / "prekeys.db")
+        from dmp.core.prekeys import PrekeyStore
+
+        store = PrekeyStore(path)
+        try:
+            # Force the WAL/SHM siblings to actually exist by
+            # writing a row.
+            store.generate_pool(count=1, ttl_seconds=3600)
+            for suffix in ("", "-wal", "-shm"):
+                p = path + suffix
+                if not os.path.exists(p):
+                    continue
+                mode = stat.S_IMODE(os.stat(p).st_mode)
+                assert mode & 0o077 == 0, f"{p!r} too permissive: 0o{mode:o}"
+        finally:
+            store.close()
+
+    def test_parent_dir_is_0700_after_init(self, tmp_path):
+        import os
+        import stat
+
+        parent = tmp_path / "secrets"
+        path = str(parent / "prekeys.db")
+        from dmp.core.prekeys import PrekeyStore
+
+        PrekeyStore(path).close()
+        mode = stat.S_IMODE(os.stat(parent).st_mode)
+        assert mode & 0o077 == 0, f"parent dir too permissive: 0o{mode:o}"
+
+    def test_existing_loose_parent_is_healed_on_reopen(self, tmp_path):
+        # An operator upgrading from a pre-#53 build has an existing
+        # parent dir created with the old, looser perms. The chmod
+        # MUST run on every ``__init__``, not just first-time
+        # creation, so the bad perms heal on the next start.
+        import os
+        import stat
+
+        parent = tmp_path / "existing"
+        parent.mkdir(mode=0o755)
+        # Confirm the loose mode before init.
+        before = stat.S_IMODE(os.stat(parent).st_mode)
+        assert before & 0o077 != 0
+        path = str(parent / "prekeys.db")
+        from dmp.core.prekeys import PrekeyStore
+
+        PrekeyStore(path).close()
+        after = stat.S_IMODE(os.stat(parent).st_mode)
+        assert after & 0o077 == 0, f"loose parent dir not healed: 0o{after:o}"
+
+
 class TestPrekeyStoreSchemaVersioning:
     """``PRAGMA user_version`` migration ladder for the prekey store.
 

--- a/tests/test_tsig_keystore.py
+++ b/tests/test_tsig_keystore.py
@@ -596,3 +596,57 @@ class TestSchemaVersioning:
 
         with pytest.raises(sqlite3.OperationalError):
             mod.TSIGKeyStore(path)
+
+
+class TestTSIGKeystoreFilePerms:
+    # The DB holds TSIG shared secrets — local disclosure lets any
+    # reader forge DNS UPDATE writes for every scope a key covers.
+    # Pre-#53 the store had no chmod at all (codex P2 on the
+    # post-#52 fresh audit).
+
+    def test_db_and_wal_shm_are_0600_after_init(self, tmp_path):
+        import os
+        import stat
+
+        path = str(tmp_path / "secrets" / "tsig.db")
+        s = TSIGKeyStore(path)
+        try:
+            # Force WAL/SHM siblings to materialize via a write.
+            s.mint(
+                name="alice-7d2f.example.com.",
+                allowed_suffixes=("alice.example.com",),
+                subject="alice@example.com",
+            )
+            for suffix in ("", "-wal", "-shm"):
+                p = path + suffix
+                if not os.path.exists(p):
+                    continue
+                mode = stat.S_IMODE(os.stat(p).st_mode)
+                assert mode & 0o077 == 0, f"{p!r} too permissive: 0o{mode:o}"
+        finally:
+            s.close()
+
+    def test_parent_dir_is_0700_after_init(self, tmp_path):
+        import os
+        import stat
+
+        parent = tmp_path / "secrets"
+        path = str(parent / "tsig.db")
+        TSIGKeyStore(path).close()
+        mode = stat.S_IMODE(os.stat(parent).st_mode)
+        assert mode & 0o077 == 0, f"parent dir too permissive: 0o{mode:o}"
+
+    def test_existing_loose_parent_is_healed_on_reopen(self, tmp_path):
+        # Pre-#53 deployments have parent dirs with looser perms;
+        # __init__ must heal them on reopen.
+        import os
+        import stat
+
+        parent = tmp_path / "existing"
+        parent.mkdir(mode=0o755)
+        before = stat.S_IMODE(os.stat(parent).st_mode)
+        assert before & 0o077 != 0
+        path = str(parent / "tsig.db")
+        TSIGKeyStore(path).close()
+        after = stat.S_IMODE(os.stat(parent).st_mode)
+        assert after & 0o077 == 0, f"loose parent dir not healed: 0o{after:o}"


### PR DESCRIPTION
## Summary

P2 from the post-#52 fresh codex audit. PrekeyStore chmodded only the main DB file (after migration ran); TSIGKeyStore had no chmod at all. Both enable WAL, which creates `-wal` and `-shm` siblings inheriting the process umask — typically 0o644 on a multi-user system. Local readers could then snapshot the WAL and recover prekey private halves (forward-secrecy compromise) or TSIG shared secrets (DNS UPDATE forgery).

Mirror IntroQueue's already-correct pattern: 0o700 on the parent directory before sqlite touches anything, 0o600 on the DB and every WAL/SHM sibling after migrate. `:memory:` paths skip the dance.

## Test plan

- [x] 4 new tests pin perms on parent + db + -wal + -shm
- [x] full unit suite (1565 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: removing the chmod loop fails the new tests