### PR TITLE
bind slot-walk sender_spk pin to the zone being polled

### DIFF
--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -428,6 +428,30 @@ class DMPClient:
             c.signing_key_bytes for c in self.contacts.values() if c.signing_key_bytes
         }
 
+    def _known_signing_keys_for_zone(self, zone: str) -> set[bytes]:
+        """Signing keys of pinned contacts whose zone matches ``zone``.
+
+        The slot-walk receive path uses this to bind ``sender_spk``
+        acceptance to the zone the manifest was found in. Without
+        this binding, a manifest signed by Bob's pinned key would be
+        accepted under Carol's zone too — letting any pinned contact
+        replay another pinned sender's manifest into their own zone
+        and win the race against the legitimate copy. Codex P2 on
+        the post-#52 fresh audit.
+
+        Empty ``Contact.domain`` (legacy back-compat: contacts added
+        before per-contact zones existed) folds into ``self.domain``
+        so single-zone deployments keep delivering.
+        """
+        out: set[bytes] = set()
+        for c in self.contacts.values():
+            if not c.signing_key_bytes:
+                continue
+            contact_zone = c.domain or self.domain
+            if contact_zone == zone:
+                out.add(c.signing_key_bytes)
+        return out
+
     def enable_tofu(self) -> None:
         """Opt back into Trust-On-First-Use delivery on the slot-walk path.
 
@@ -983,6 +1007,13 @@ class DMPClient:
         else:
             slot_walk_zones = self._zones_to_poll()
         for zone in slot_walk_zones:
+            # Per-zone pin set: only contacts whose zone matches the
+            # one we're polling are valid signers for manifests found
+            # there. Closes the cross-zone replay surface — any pinned
+            # contact's zone could otherwise carry a copy of another
+            # pinned sender's manifest and win the race against the
+            # legitimate copy in the original zone.
+            zone_known_spks = self._known_signing_keys_for_zone(zone)
             for slot in range(SLOT_COUNT):
                 slot_domain = self._slot_domain(self.user_id, slot, zone=zone)
                 records = self.reader.query_txt_record(slot_domain)
@@ -998,10 +1029,10 @@ class DMPClient:
                     if manifest.is_expired():
                         continue
                     # Pinned signers gate + revocation check. Cases:
-                    #   1) known_spks non-empty + match → check revocation
+                    #   1) known_spks non-empty + zone match → check revocation
                     #      (a pinned key that was later revoked by its
                     #      owner via rotate-then-revoke must drop).
-                    #   2) known_spks non-empty + miss → rotation-walk.
+                    #   2) known_spks non-empty + zone miss → rotation-walk.
                     #      No revocation check on the new head — that's
                     #      a different key, and chain-walk acceptance
                     #      already verified its current trust state.
@@ -1009,8 +1040,14 @@ class DMPClient:
                     #      (TOFU still respects revoked-by-issuer).
                     #   4) known_spks EMPTY + not allow_tofu → drop.
                     #      Default-deny first-contact gate (P0-3).
+                    #
+                    # The "match" check is bound to ``zone_known_spks``
+                    # (this zone's pinned contacts only), not the global
+                    # ``known_spks``. The outer ``if known_spks:`` gate
+                    # stays global so TOFU semantics don't break — any
+                    # pin anywhere disables TOFU site-wide.
                     if known_spks:
-                        if manifest.sender_spk in known_spks:
+                        if manifest.sender_spk in zone_known_spks:
                             # EXPERIMENTAL (M5.4): a sender who published
                             # (rotation A→B) + (revocation of A) would
                             # otherwise have manifests signed by A still

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1175,6 +1175,85 @@ class TestCrossZoneReceive:
         assert len(inbox) == 1
         assert inbox[0].plaintext == b"from alice"
 
+    def test_pinned_spk_from_other_zone_does_not_replay_into_pinned_zone(self):
+        # Codex P2 from the post-#52 fresh audit: the slot-walk pin
+        # check used the GLOBAL pinned-spk set, so an attacker who
+        # could write into a pinned contact's zone could replay a
+        # different pinned sender's manifest there and have it
+        # accepted. Now the pin is bound to the zone being polled —
+        # only contacts whose ``Contact.domain`` matches the zone
+        # qualify as valid signers for manifests found in it.
+        #
+        # To exercise the gate (not the replay cache that fronts it),
+        # the test stages alice's manifest+chunks ONLY in carol.mesh
+        # — no legitimate copy in alice.mesh. Without the per-zone
+        # binding, bob accepts the carol.mesh copy because alice's
+        # spk is globally pinned. With it, the gate refuses and the
+        # inbox stays empty.
+        store = InMemoryDNSStore()
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        carol = DMPClient(
+            "carol",
+            "carol-pass",
+            domain="carol.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        # Bob pins both alice (in alice.mesh) and carol (in carol.mesh).
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            domain="alice.mesh",
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
+        bob.add_contact(
+            "carol",
+            carol.get_public_key_hex(),
+            domain="carol.mesh",
+            signing_key_hex=carol.get_signing_public_key_hex(),
+        )
+        alice.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            domain="bob.mesh",
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+
+        # Alice publishes a real manifest + chunks for bob in alice.mesh.
+        assert alice.send_message("bob", "real message")
+
+        # Attacker copies the records into carol.mesh AND removes the
+        # alice.mesh originals — so the only copy bob can find lives
+        # under the wrong zone.
+        for name in list(store.list_names()):
+            if not name.endswith(".alice.mesh"):
+                continue
+            cloned = name[: -len(".alice.mesh")] + ".carol.mesh"
+            for v in store.query_txt_record(name) or []:
+                store.publish_txt_record(cloned, v)
+            store.delete_txt_record(name)
+
+        # The carol.mesh copy carries alice's pinned spk — globally
+        # known, but NOT bound to carol.mesh. The fixed gate drops
+        # it. Result: nothing delivered.
+        assert bob.receive_messages() == []
+
 
 class TestPersistencePathsRequired:
     # Both ``intro_queue_path`` and ``prekey_store_path`` were


### PR DESCRIPTION
## Summary

Codex P2 from the post-#52 fresh audit. The slot-walk receive path used the GLOBAL set of pinned signing keys, so if Bob pinned Alice (alice.mesh) and Carol (carol.mesh), an attacker who could copy Alice's manifest + chunks into carol.mesh would win the race: Bob's poll over carol.mesh would see Alice's spk in `known_spks` and accept the replay as legitimate.

New helper `_known_signing_keys_for_zone(zone)` returns only the spks of contacts whose `Contact.domain` matches the zone being polled. The inner sender_spk match in the slot-walk uses this per-zone set. The outer `if known_spks:` gate stays global so TOFU semantics don't break — any pin anywhere disables TOFU site-wide. Empty `Contact.domain` (legacy back-compat) folds into `self.domain`, preserving single-zone deployments.

## Out of scope

The rotation-chain walker (`_rotation_manifest_accepted`) is the same shape but gated by `rotation_chain_enabled=False` by default. Separate follow-up PR.

## Test plan

- [x] new `test_pinned_spk_from_other_zone_does_not_replay_into_pinned_zone` stages a copy of Alice's manifest in carol.mesh and DELETES the alice.mesh originals so the only copy is in the wrong zone — without the fix, bob accepts and delivers; with it, inbox is empty.
- [x] full unit suite (1568 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: reverting to `manifest.sender_spk in known_spks` fails the new test