### PR TITLE
type the cluster reader's DNSSEC raise as DnssecValidationError

### DIFF
--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -853,11 +853,16 @@ class _NodeDnsReader(DNSRecordReader):
         # NXDOMAIN responses for signed zones. If the operator
         # opted into `dnssec_required`, an AD-less NXDOMAIN is
         # indistinguishable from a spoofed one and must NOT pass
-        # as a healthy "no record" answer. Raising treats it as a
-        # per-node transport failure so UnionReader demotes the
-        # upstream rather than blackholing reads.
+        # as a healthy "no record" answer. Raising
+        # ``DnssecValidationError`` treats this as a per-node
+        # transport failure so UnionReader demotes the upstream
+        # rather than blackholing reads. The asymmetry vs the
+        # resolver-based readers (which return None) is intentional
+        # — see the ``DnssecValidationError`` docstring.
         if self._dnssec_required and not (response.flags & dns.flags.AD):
-            raise RuntimeError(
+            from dmp.core.dns import DnssecValidationError
+
+            raise DnssecValidationError(
                 f"DNSSEC AD flag missing from {self._host} reply for {name}"
             )
         rcode = response.rcode()

--- a/dmp/core/dns.py
+++ b/dmp/core/dns.py
@@ -15,6 +15,40 @@ import dns.name
 log = logging.getLogger(__name__)
 
 
+class DnssecValidationError(RuntimeError):
+    """Raised when a DNS reader rejects an answer because the upstream
+    recursor failed to DNSSEC-validate it (AD bit missing on a
+    positive answer or on a NXDOMAIN/NoAnswer denial).
+
+    Subclasses ``RuntimeError`` so existing ``except RuntimeError:``
+    handlers keep catching this — it is a transport-class failure
+    from a caller's perspective. New code that wants to distinguish
+    DNSSEC rejection from other failures (UnionReader per-node
+    demotion, metrics, dashboards) should catch this type by name.
+
+    Reader behavior is asymmetric on purpose:
+
+    - ``DNSOperations`` (``dmp.core.dns``), ``_DnsReader`` (``dmp.cli``),
+      ``_SystemResolver`` (``dmp.server.node`` heartbeat fallback), and
+      ``ResolverPool`` (``dmp.network.resolver_pool``) all log a
+      WARNING and return ``None`` when they drop an AD-less answer.
+      Their callers treat ``query_txt_record`` as Optional[List[str]];
+      raising would cascade as a behavior change through every
+      consumer that handles a missing record gracefully.
+      ``ResolverPool`` additionally demotes the offending upstream via
+      its internal ``_mark_failure`` so the next query prefers a
+      different resolver — the per-pool demotion is not lost.
+
+    - ``_NodeDnsReader`` (``dmp.cli``) raises this exception instead.
+      It is wired into a ``UnionReader`` pool whose health bookkeeping
+      depends on raised exceptions to demote misbehaving nodes
+      (``UnionReader._safe_query``). Returning ``None`` here would let
+      a single AD-stripped node be treated as a healthy empty answer
+      and never demoted — letting an attacker who can flip AD on one
+      cluster node permanently halt cluster reads from that node.
+    """
+
+
 def _negative_response_ad_set(exc, qname: str) -> bool:
     """True iff every response on a negative reply carries the AD flag.
 
@@ -247,6 +281,9 @@ class DNSOperations:
                 # without validation when the operator opted in.
                 # Warn so operators can correlate vanished records
                 # with their DNSSEC opt-in rather than guessing.
+                # Returns None rather than raising
+                # ``DnssecValidationError`` — see that class's
+                # docstring for the reader-by-reader contract.
                 log.warning(
                     "DNSOperations: dropping AD-less TXT answer for "
                     "%s (dnssec_required=True)",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2745,10 +2745,15 @@ class TestNodeDnsReaderDnssecGate:
         """A reply without AD is treated as a per-node transport
         failure (raised), not as a healthy "no records" outcome.
         UnionReader counts it against the node so a non-validating
-        upstream gets demoted instead of silently passing through."""
+        upstream gets demoted instead of silently passing through.
+        The raised type is ``DnssecValidationError`` so callers (and
+        future metrics/dashboards) can distinguish DNSSEC rejection
+        from generic transport failures; it subclasses ``RuntimeError``
+        so legacy ``except RuntimeError:`` keeps working."""
         import dns.query
 
         from dmp.cli import _NodeDnsReader
+        from dmp.core.dns import DnssecValidationError
 
         reader = _NodeDnsReader("127.0.0.1:9999", dnssec_required=True)
 
@@ -2758,8 +2763,11 @@ class TestNodeDnsReaderDnssecGate:
             )
 
         monkeypatch.setattr(dns.query, "udp", fake_udp)
-        with pytest.raises(RuntimeError, match="AD flag missing"):
+        with pytest.raises(DnssecValidationError, match="AD flag missing"):
             reader.query_txt_record("x.example.com.")
+        # Subclass relationship: legacy ``except RuntimeError:``
+        # handlers must still catch this.
+        assert issubclass(DnssecValidationError, RuntimeError)
 
     def test_required_sets_do_bit_on_outgoing_query(self, monkeypatch):
         """Without the DO bit on the outgoing query, many recursors


### PR DESCRIPTION
## Summary

Resolves the codex P3 from PR #51's review: `_NodeDnsReader` raised bare `RuntimeError` on AD-less drops while the other readers return `None`. Codex called out the inconsistency — "weaker than `_NodeDnsReader`", worth tracking.

The asymmetry turns out to be correct, not accidental:
- `_NodeDnsReader` is wired into a `UnionReader` pool whose health bookkeeping (`UnionReader._safe_query`) catches exceptions and demotes the offending node. Returning `None` there would let an attacker who can flip AD on one cluster node have it treated as a healthy empty answer indefinitely.
- The resolver-based readers (`DNSOperations`, `_DnsReader`, `_SystemResolver`, `ResolverPool`) either have no pool to demote (and just log+return None) or run their own `_mark_failure` demotion (`ResolverPool`). Raising would cascade through every consumer that handles "no record" gracefully — hundreds of test sites and production callers.

## Changes

- New `DnssecValidationError(RuntimeError)` in `dmp.core.dns` whose docstring spells out the reader-by-reader contract.
- `_NodeDnsReader` raises this typed exception instead of bare `RuntimeError` so callers (UnionReader demotion, future metrics) can catch it specifically. Subclasses `RuntimeError` so existing handlers keep catching.
- Cross-reference comment at the `DNSOperations` drop site so the asymmetry is grep-able.

## Test plan

- [x] `tests/test_cli.py::TestNodeDnsReaderDnssecGate::test_required_raises_when_ad_unset` updated to assert `DnssecValidationError` and the subclass relationship.
- [x] full unit suite (1568 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: reverting to `raise RuntimeError(...)` fails the new test