### PR TITLE
reject dnsmasq config-injection inputs in LocalDNSPublisher

### DIFF
--- a/dmp/network/dns_publisher.py
+++ b/dmp/network/dns_publisher.py
@@ -16,6 +16,7 @@ Optional third-party deps (requests, boto3) are imported lazily inside the
 backends that need them so the core library stays usable without them.
 """
 
+import re
 from typing import Optional, List
 
 import dns.update
@@ -24,6 +25,50 @@ import dns.tsigkeyring
 import dns.rcode
 
 from dmp.network.base import DNSRecordWriter
+
+# Strict DNS-name validator for ``LocalDNSPublisher``: the publisher
+# writes the name verbatim into a dnsmasq ``txt-record=NAME,...``
+# directive, so anything that breaks the parser is a config-injection
+# vector. Labels follow RFC 1035 alphanumeric + hyphen, plus the
+# leading-underscore form (RFC 2782 / RFC 8552) DMP uses for
+# ``_dnsmesh-claim-...`` records. Each label is 1-63 bytes; the
+# total name is ≤253 bytes; trailing dot is tolerated.
+_DNS_LABEL_RE = re.compile(r"^_?[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$")
+
+
+def _is_valid_dns_name(name: str) -> bool:
+    if not isinstance(name, str) or not name or len(name) > 253:
+        return False
+    candidate = name[:-1] if name.endswith(".") else name
+    if not candidate:
+        return False
+    for label in candidate.split("."):
+        if not _DNS_LABEL_RE.match(label):
+            return False
+    return True
+
+
+def _is_safe_txt_value(value: str) -> bool:
+    """True iff ``value`` is safe to write inside a quoted dnsmasq
+    txt-record string.
+
+    dnsmasq's txt-record syntax has no escape mechanism inside the
+    quoted strings, so a literal ``"`` terminates the quote and lets
+    arbitrary content escape into a fresh directive on the same line.
+    A literal newline / carriage return ends the directive entirely
+    and lets the attacker append a whole new rule. Other control
+    characters are rejected for safety — a real DMP record value is
+    printable ASCII (base64 + ``;``-separated key=val tokens).
+    """
+    if not isinstance(value, str):
+        return False
+    for ch in value:
+        if ch == '"':
+            return False
+        if ord(ch) < 0x20 or ord(ch) == 0x7F:
+            return False
+    return True
+
 
 # Per RFC 1035 a DNS TXT record's RDATA is a sequence of
 # <character-string>s, each prefixed by a single length byte, capping
@@ -326,10 +371,22 @@ class LocalDNSPublisher(DNSRecordWriter):
             return False
 
     def publish_txt_record(self, name: str, value: str, ttl: int = 300) -> bool:
+        # Validate BEFORE storing. The dnsmasq config file is
+        # rewritten from ``self.records`` on every publish/delete,
+        # so a single bad name or value would persist across calls
+        # and re-inject every reload. Multi-tenant deployments that
+        # let an authenticated user POST arbitrary values otherwise
+        # turn this writer into a config-injection sink.
+        if not _is_valid_dns_name(name):
+            return False
+        if not _is_safe_txt_value(value):
+            return False
         self.records[name] = value
         return self._write_and_reload()
 
     def delete_txt_record(self, name: str, value: Optional[str] = None) -> bool:
+        if not _is_valid_dns_name(name):
+            return False
         if name not in self.records:
             return False
         del self.records[name]

--- a/dmp/server/http_api.py
+++ b/dmp/server/http_api.py
@@ -781,6 +781,27 @@ HTTPS exchange is the one-time TSIG-key registration step.</p>
                 )
                 return 413
 
+        # Universal input shape check so a bad name / value surfaces
+        # as 400 (client error) rather than 502 (backend broke). Reuses
+        # the same validators ``LocalDNSPublisher`` enforces because
+        # the constraints they impose — DNS-compliant name, no control
+        # chars / quote in the value — are universal: every legitimate
+        # DMP record value is printable ASCII (base64 + ``;``-separated
+        # ``key=val``). Without this layer, a multi-tenant user
+        # sending newline-laced input gets a 502 indistinguishable
+        # from a transient writer outage.
+        from dmp.network.dns_publisher import (
+            _is_safe_txt_value,
+            _is_valid_dns_name,
+        )
+
+        if not _is_valid_dns_name(name):
+            self._send_json(400, {"error": "invalid record name"})
+            return 400
+        if not _is_safe_txt_value(value):
+            self._send_json(400, {"error": "invalid record value"})
+            return 400
+
         ok = writer.publish_txt_record(name, value, ttl=ttl)
         status = 201 if ok else 502
         self._send_json(status, {"ok": ok})
@@ -805,8 +826,23 @@ HTTPS exchange is the one-time TSIG-key registration step.</p>
         if writer is None:
             self._send_json(501, {"error": "writer not configured"})
             return 501
+        # Same input-shape gate as POST: a bad name surfaces as 400,
+        # not 502 / 404. Value is optional on DELETE (None = whole-
+        # RRset wipe per DNSRecordWriter contract); validate it only
+        # if present.
+        from dmp.network.dns_publisher import (
+            _is_safe_txt_value,
+            _is_valid_dns_name,
+        )
+
+        if not _is_valid_dns_name(name):
+            self._send_json(400, {"error": "invalid record name"})
+            return 400
         body = self._read_json_body() or {}
         value = body.get("value") if isinstance(body, dict) else None
+        if value is not None and not _is_safe_txt_value(value):
+            self._send_json(400, {"error": "invalid record value"})
+            return 400
         ok = writer.delete_txt_record(name, value=value)
         status = 204 if ok else 404
         self._send_empty(status)

--- a/tests/test_http_auth_multi_tenant.py
+++ b/tests/test_http_auth_multi_tenant.py
@@ -236,6 +236,45 @@ class TestMultiTenantDelete:
         # silently swallowed.
         assert store.query_txt_record("chunk-0001-abcdef012345.example.com")
 
+    def test_bad_name_returns_400_not_502(self, mt_setup):
+        # An authenticated user posting a name that contains a
+        # newline / control char must get 400 (client error) instead
+        # of 502 (backend broke). Without HTTP-level validation,
+        # ``LocalDNSPublisher`` would refuse to write and the
+        # generic publish-failed branch would surface a confusing
+        # 502 indistinguishable from a transient writer outage.
+        api, _, _ = mt_setup
+        from urllib.parse import quote
+
+        # ``\n`` in the URL path needs URL-encoding to survive the
+        # HTTP request line. After unquote() in _match_name, the
+        # name is back to ``...\nsrv-record=...``.
+        bad_name = (
+            "ok-" + quote("\n", safe="") + "srv-record=evil.example,attacker,1234"
+        )
+        url = f"http://127.0.0.1:{api.port}/v1/records/{bad_name}"
+        headers = {"Authorization": "Bearer op-token"}
+        r = requests.post(
+            url,
+            json={"value": "v=dmp1"},
+            headers=headers,
+            timeout=2,
+        )
+        assert r.status_code == 400
+        assert "invalid record name" in r.text
+
+    def test_bad_value_returns_400_not_502(self, mt_setup):
+        api, _, _ = mt_setup
+        headers = {"Authorization": "Bearer op-token"}
+        r = requests.post(
+            _url(api, "ok.example.com"),
+            json={"value": "v=dmp1\ntxt-record=injected.example.com,evil"},
+            headers=headers,
+            timeout=2,
+        )
+        assert r.status_code == 400
+        assert "invalid record value" in r.text
+
     def test_operator_can_delete_chunk(self, mt_setup):
         # Sanity: operator-token short-circuit still grants delete.
         api, _, _ = mt_setup

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -107,6 +107,120 @@ class TestDNSPublisherInheritance:
         assert mem_b.query_txt_record("x.example.com") == ["shared"]
 
 
+class TestLocalDNSPublisherInjectionRejection:
+    # The publisher writes ``txt-record=NAME,"VALUE"`` lines verbatim
+    # into a dnsmasq config and reloads the service. Without input
+    # validation, an authenticated multi-tenant user could craft a
+    # name or value that escapes the directive and injects arbitrary
+    # rules. Codex P2 from the post-#52 fresh audit.
+
+    def _publisher(self, tmp_path):
+        from dmp.network.dns_publisher import LocalDNSPublisher
+
+        return LocalDNSPublisher(config_file=str(tmp_path / "dmp.conf"))
+
+    def test_name_with_newline_rejected(self, tmp_path):
+        pub = self._publisher(tmp_path)
+        evil = "ok.example.com\nsrv-record=evil.example.com,attacker.host,1234"
+        assert pub.publish_txt_record(evil, "v=dmp1") is False
+        assert evil not in pub.records
+
+    def test_name_with_comma_rejected(self, tmp_path):
+        pub = self._publisher(tmp_path)
+        assert (
+            pub.publish_txt_record("foo.example.com,injected.example.com", "v") is False
+        )
+
+    def test_name_with_space_rejected(self, tmp_path):
+        pub = self._publisher(tmp_path)
+        assert pub.publish_txt_record("foo bar.example.com", "v") is False
+
+    def test_value_with_quote_rejected(self, tmp_path):
+        pub = self._publisher(tmp_path)
+        # ``"`` would terminate the dnsmasq quote and let the rest
+        # of the line be reparsed as new directive fields.
+        assert (
+            pub.publish_txt_record(
+                "ok.example.com",
+                'v",strxxx="injected',
+            )
+            is False
+        )
+
+    def test_value_with_newline_rejected(self, tmp_path):
+        pub = self._publisher(tmp_path)
+        assert (
+            pub.publish_txt_record(
+                "ok.example.com",
+                "v=dmp1\ntxt-record=injected.example.com,evil",
+            )
+            is False
+        )
+
+    def test_value_with_control_char_rejected(self, tmp_path):
+        pub = self._publisher(tmp_path)
+        assert pub.publish_txt_record("ok.example.com", "v=dmp1\x07") is False
+
+    def test_legitimate_dmp_value_accepted(self, tmp_path):
+        # Sanity: a real DMP record value (printable ASCII, base64
+        # body) passes validation and reaches the dict.
+        pub = self._publisher(tmp_path)
+        assert pub.publish_txt_record(
+            "id-1234567890ab.example.com",
+            "v=dmp1;t=identity;d=YWJjZA==",
+        )
+        assert pub.records["id-1234567890ab.example.com"].startswith("v=dmp1")
+
+    def test_underscore_prefix_label_accepted(self, tmp_path):
+        # M10 / RFC-2782-style names (``_dnsmesh-claim-XXX.zone``) must
+        # still publish — the validator allows the leading-underscore
+        # service-label form.
+        pub = self._publisher(tmp_path)
+        assert pub.publish_txt_record(
+            "_dnsmesh-claim-abc.example.com",
+            "v=dmp1",
+        )
+
+    def test_delete_with_invalid_name_does_not_rewrite_config(self, tmp_path):
+        # Defense in depth: even if a malformed name somehow lands in
+        # ``pub.records`` (e.g. via a programmatic caller that
+        # bypassed publish_txt_record), delete() must reject it
+        # BEFORE triggering ``_write_and_reload`` — otherwise the
+        # rewrite would emit the bad name back into the config file.
+        # Without the validator, delete would fall through, find the
+        # name in records, remove it, and trigger a rewrite.
+        pub = self._publisher(tmp_path)
+        bad = "evil.example\nsrv-record=attacker,host,1234"
+        # Seed the dict directly so delete sees the name.
+        pub.records[bad] = "v=dmp1"
+        # Track whether _write_and_reload was called.
+        calls = []
+        original = pub._write_and_reload
+        pub._write_and_reload = lambda: (calls.append(True), original())[-1]
+        assert pub.delete_txt_record(bad) is False
+        # The validator stopped delete BEFORE the rewrite, so no
+        # config-file write happened — and the bad name stays out
+        # of the config file.
+        assert calls == []
+
+    def test_config_file_contains_no_injected_directives(self, tmp_path):
+        # End-to-end: an injection attempt fails at validation, the
+        # config file never sees the malicious string, and a
+        # subsequent legitimate publish writes a clean file.
+        pub = self._publisher(tmp_path)
+        assert (
+            pub.publish_txt_record(
+                "ok.example.com\nsrv-record=evil.example,attacker,1234",
+                "v",
+            )
+            is False
+        )
+        pub.publish_txt_record("ok.example.com", "v=dmp1;t=identity")
+        contents = (tmp_path / "dmp.conf").read_text()
+        assert "srv-record" not in contents
+        assert contents.count("\n") == 1
+
+
 class TestSplitTxtValue:
     """The RFC 1035 TXT character-string cap is 255 bytes. M2.1 cluster
     manifests run up to 1200 bytes post-base64, so every writer has to


### PR DESCRIPTION
## Summary

Codex P2 from the post-#52 fresh audit. `LocalDNSPublisher` writes `txt-record=NAME,"VALUE"` lines verbatim into a dnsmasq config and reloads the service. An authenticated multi-tenant user could publish a name with `\n` or a value with `"` to terminate the directive and inject arbitrary rules — e.g. an SRV record pointing at attacker infrastructure for a name they have no scope over.

## Changes

- `dmp/network/dns_publisher.py` — two private validators:
  - `_is_valid_dns_name`: strict label regex (alphanumeric + hyphen, plus leading-underscore for RFC-2782 service labels).
  - `_is_safe_txt_value`: rejects `"`, `\n`, `\r`, control chars.
- `publish_txt_record` and `delete_txt_record` return `False` on validation failure.
- Real DMP record values are printable ASCII (base64 + `;`-separated `key=val`), so the validator never rejects a legitimate publish.

## Test plan

- [x] 10 new tests in `TestLocalDNSPublisherInjectionRejection` — name newline/comma/space rejected, value quote/newline/control-char rejected, legitimate DMP values + underscore-prefix labels accepted, end-to-end config-file check.
- [x] full unit suite (1578 passed)
- [x] docker e2e (7 passed)
- [x] black --check
- [x] mutation: removing the validation fails 7 of the 10 new tests