### PR TITLE
bind rotation-chain walker to the polled zone for non-self zones

### DIFF
--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -504,13 +504,33 @@ class DMPClient:
                 continue
         return False
 
-    def _rotation_manifest_accepted(self, sender_spk: bytes) -> bool:
+    def _rotation_manifest_accepted(self, sender_spk: bytes, zone: str) -> bool:
         """EXPERIMENTAL (M5.4): check a rotation chain for sender_spk.
 
-        Walks each pinned contact's rotation chain; if any chain's
-        current head is ``sender_spk``, accept the manifest. A rotation
-        chain is ONLY consulted when ``rotation_chain_enabled=True``;
-        otherwise this returns False and legacy behavior is preserved.
+        Walks rotation chains of contacts whose pinning makes them
+        plausibly the author of a manifest found under ``zone``. If
+        any candidate chain's current head is ``sender_spk``, accept
+        the manifest. The rotation chain is ONLY consulted when
+        ``rotation_chain_enabled=True``; otherwise this returns False
+        and legacy behavior is preserved.
+
+        Zone-binding rule:
+
+          - Polling ``self.domain``: walk EVERY pinned contact's
+            chain. The legacy same-mesh + cross-zone publishing
+            pattern lands manifests under the recipient's own zone
+            regardless of where the sender is pinned, so restricting
+            to ``contact.domain == self.domain`` here would drop
+            legitimate rotated-key deliveries from contacts pinned
+            in other zones.
+
+          - Polling a non-self zone Z: only walk chains for contacts
+            whose pinned ``Contact.domain`` is Z. Without this, an
+            attacker with write access to one pinned contact's zone
+            could replay a manifest signed by ANOTHER contact's
+            rotated key — the global walker resolves that key and
+            accepts. Same threat shape as the slot-walk direct-pin
+            bug PR #54 fixed.
 
         Wire format subject to post-audit revision in v0.3.0 — see
         ``docs/protocol/rotation.md``.
@@ -520,9 +540,14 @@ class DMPClient:
         # Import lazily to avoid the cold-path import on every receive.
         from dmp.core.rotation import SUBJECT_TYPE_USER_IDENTITY
 
+        walk_all = zone == self.domain
         for contact in self.contacts.values():
             if not contact.signing_key_bytes:
                 continue
+            if not walk_all:
+                contact_zone = contact.domain or self.domain
+                if contact_zone != zone:
+                    continue
             subject = f"{contact.username}@{contact.domain}"
             try:
                 current = self._rotation_chain.resolve_current_spk(
@@ -1007,13 +1032,20 @@ class DMPClient:
         else:
             slot_walk_zones = self._zones_to_poll()
         for zone in slot_walk_zones:
-            # Per-zone pin set: only contacts whose zone matches the
-            # one we're polling are valid signers for manifests found
-            # there. Closes the cross-zone replay surface — any pinned
-            # contact's zone could otherwise carry a copy of another
-            # pinned sender's manifest and win the race against the
-            # legitimate copy in the original zone.
-            zone_known_spks = self._known_signing_keys_for_zone(zone)
+            # Per-zone pin set, with the same asymmetric carve-out
+            # the rotation walker and claim-path direct-pin gate
+            # use: ``zone == self.domain`` accepts any pinned spk
+            # (legitimate cross-zone publishing lands manifests in
+            # the recipient's own zone), non-self zones accept only
+            # contacts pinned to that exact zone (closes the
+            # cross-pin replay surface — any pinned contact's zone
+            # could otherwise carry a copy of another pinned
+            # sender's manifest and win the race against the
+            # legitimate copy in the original zone).
+            if zone == self.domain:
+                zone_known_spks = known_spks
+            else:
+                zone_known_spks = self._known_signing_keys_for_zone(zone)
             for slot in range(SLOT_COUNT):
                 slot_domain = self._slot_domain(self.user_id, slot, zone=zone)
                 records = self.reader.query_txt_record(slot_domain)
@@ -1061,9 +1093,13 @@ class DMPClient:
                             # verify failure. If a pinned contact rotated to
                             # a new key, the new key is accepted for this
                             # receive pass without permanently re-pinning.
-                            # Never modifies self.contacts.
+                            # Never modifies self.contacts. Bound to
+                            # the polled zone so a rotated-key match
+                            # against a contact in a DIFFERENT zone
+                            # cannot be replayed here — same threat
+                            # model as the direct-pin gate above.
                             if not self._rotation_manifest_accepted(
-                                manifest.sender_spk
+                                manifest.sender_spk, zone
                             ):
                                 continue
                     elif not self.allow_tofu:
@@ -1429,9 +1465,39 @@ class DMPClient:
                     # straight to the inbox. Mirror the receive_messages
                     # logic: pinned ∪ rotated → inbox; everyone else →
                     # intro queue.
+                    # Both the direct-pin AND rotation-walk checks
+                    # are bound to the claim's advertised mailbox
+                    # zone, with the same asymmetric carve-out:
+                    # ``claim.sender_mailbox_domain == self.domain``
+                    # walks the global pin set, otherwise the pin
+                    # set is restricted to contacts whose
+                    # ``Contact.domain`` matches the claim's zone.
+                    #
+                    # Why the carve-out: legitimate cross-zone
+                    # publishing puts a manifest under the recipient's
+                    # OWN zone (it's the only zone both parties can
+                    # reliably write to). A claim into self.domain
+                    # from a contact pinned in another zone is the
+                    # documented pattern, not an attack.
+                    #
+                    # Why the strict gate elsewhere: a malicious
+                    # claim provider could point ``sender_mailbox_domain``
+                    # at carol's zone with alice's pinned spk + a
+                    # copy of alice's manifest+chunks, pass the
+                    # cross-bind, decrypt, and deliver via global
+                    # ``in known_spks``. The per-zone gate refuses.
+                    if claim.sender_mailbox_domain == self.domain:
+                        direct_pin_match = manifest.sender_spk in known_spks
+                    else:
+                        zone_known_spks = self._known_signing_keys_for_zone(
+                            claim.sender_mailbox_domain
+                        )
+                        direct_pin_match = manifest.sender_spk in zone_known_spks
                     is_pinned_or_rotated = bool(known_spks) and (
-                        manifest.sender_spk in known_spks
-                        or self._rotation_manifest_accepted(manifest.sender_spk)
+                        direct_pin_match
+                        or self._rotation_manifest_accepted(
+                            manifest.sender_spk, claim.sender_mailbox_domain
+                        )
                     )
                     if is_pinned_or_rotated:
                         # Pinned (possibly via rotation chain) sender →

--- a/tests/test_claim_flow.py
+++ b/tests/test_claim_flow.py
@@ -423,6 +423,217 @@ class TestClaimFlow:
         assert result.quarantined_intro_ids == []
         assert "manifest-spk-mismatch" in result.dropped_reasons
 
+    def test_claim_with_pinned_spk_in_wrong_zone_quarantined(self):
+        # Codex follow-up on PR #57. The claim path's direct-pin
+        # check used to consult the GLOBAL pinned-spk set: a
+        # malicious claim provider could point
+        # ``sender_mailbox_domain`` at carol's zone with alice's
+        # pinned spk, copy alice's manifest+chunks there, and
+        # ``manifest.sender_spk == claim.sender_spk`` (alice on both)
+        # passed the cross-bind. Decrypt then succeeds because the
+        # chunks are alice's real ones — the global ``in known_spks``
+        # would deliver alice's message under carol's authority.
+        # The fix binds the direct-pin check to the claim's
+        # advertised mailbox zone, so an alice-spk match in carol's
+        # zone falls through to the intro queue instead.
+        import hashlib
+
+        from dmp.core.claim import ClaimRecord, claim_rrset_name
+        from dmp.core.manifest import SlotManifest
+
+        store = InMemoryDNSStore()
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        carol = DMPClient(
+            "carol",
+            "carol-pass",
+            domain="carol.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        # Bob pins both alice and carol, each in their own zone.
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            domain="alice.mesh",
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
+        bob.add_contact(
+            "carol",
+            carol.get_public_key_hex(),
+            domain="carol.mesh",
+            signing_key_hex=carol.get_signing_public_key_hex(),
+        )
+        alice.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            domain="bob.mesh",
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+        # Alice publishes a real manifest+chunks in her own zone.
+        assert alice.send_message("bob", "alice → bob")
+
+        # Find the slot manifest's msg_id.
+        bob_recipient_id = hashlib.sha256(
+            bytes.fromhex(bob.get_public_key_hex())
+        ).digest()
+        bob_hash = hashlib.sha256(bob_recipient_id).hexdigest()[:12]
+        msg_id = None
+        for slot in range(10):
+            for r in (
+                store.query_txt_record(f"slot-{slot}.mb-{bob_hash}.alice.mesh") or []
+            ):
+                parsed = SlotManifest.parse_and_verify(r)
+                if parsed:
+                    msg_id = parsed[0].msg_id
+                    break
+            if msg_id:
+                break
+        assert msg_id
+
+        # Attacker copies alice's slot manifest + chunks into
+        # carol.mesh. The cross-bind ``manifest.sender_spk == claim.sender_spk``
+        # will still pass because both are alice's real spk — the
+        # only thing distinguishing legitimate from replay is the
+        # zone the claim points at.
+        for name in list(store.list_names()):
+            if not name.endswith(".alice.mesh"):
+                continue
+            head = name[: -len(".alice.mesh")]
+            if not (head.startswith("slot-") or head.startswith("chunk-")):
+                continue
+            cloned = head + ".carol.mesh"
+            for v in store.query_txt_record(name) or []:
+                store.publish_txt_record(cloned, v)
+
+        # Malicious claim: alice's spk + carol's zone + bob's slot.
+        now = int(time.time())
+        evil_claim = ClaimRecord(
+            msg_id=msg_id,
+            sender_spk=alice.crypto.get_signing_public_key_bytes(),
+            sender_mailbox_domain="carol.mesh",
+            slot=0,
+            ts=now,
+            exp=now + 300,
+        )
+        wire = evil_claim.sign(alice.crypto)  # signed by alice's spk
+        store.publish_txt_record(
+            claim_rrset_name(bob_recipient_id, 0, PROVIDER_ZONE), wire, ttl=300
+        )
+
+        result = bob.receive_claims(provider_zones=[(PROVIDER_ZONE, PROVIDER_ENDPOINT)])
+        # The direct-pin check now binds to ``claim.sender_mailbox_domain``
+        # (carol.mesh). Alice's spk is NOT in carol.mesh's pinned
+        # set, so the inbox-fast-path fails and the message lands
+        # in the intro queue (still discoverable, but not silently
+        # delivered as if alice's authority was acknowledged in
+        # carol's zone).
+        assert result.delivered == []
+        assert len(result.quarantined_intro_ids) == 1
+
+    def test_claim_into_self_domain_from_other_zone_pin_still_delivers(self):
+        # Codex round-2 on PR #57: the direct-pin gate must mirror
+        # the rotation walker's ``self.domain`` carve-out. The
+        # legitimate cross-zone publish pattern lands a sender's
+        # manifest under the recipient's OWN zone — it's the only
+        # zone both parties reliably control writes for. A pinned
+        # contact whose ``Contact.domain`` is alice.mesh, sending
+        # via a claim that points at bob.mesh (recipient's zone),
+        # MUST deliver to the inbox, not the intro queue.
+        import hashlib
+
+        from dmp.core.claim import ClaimRecord, claim_rrset_name
+        from dmp.core.manifest import SlotManifest
+
+        store = InMemoryDNSStore()
+        # Alice publishes from a client whose ``domain`` is bob.mesh
+        # (the recipient-zone publish pattern), but bob has alice
+        # pinned at her real home zone alice.mesh.
+        alice_in_bob_zone = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob.add_contact(
+            "alice",
+            alice_in_bob_zone.get_public_key_hex(),
+            domain="alice.mesh",  # pin at alice's home zone
+            signing_key_hex=alice_in_bob_zone.get_signing_public_key_hex(),
+        )
+        alice_in_bob_zone.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            domain="bob.mesh",
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+        assert alice_in_bob_zone.send_message("bob", "cross-zone direct pin")
+
+        # Find msg_id from the manifest in bob.mesh.
+        bob_recipient_id = hashlib.sha256(
+            bytes.fromhex(bob.get_public_key_hex())
+        ).digest()
+        bob_hash = hashlib.sha256(bob_recipient_id).hexdigest()[:12]
+        msg_id = None
+        for slot in range(10):
+            for r in (
+                store.query_txt_record(f"slot-{slot}.mb-{bob_hash}.bob.mesh") or []
+            ):
+                parsed = SlotManifest.parse_and_verify(r)
+                if parsed:
+                    msg_id = parsed[0].msg_id
+                    break
+            if msg_id:
+                break
+        assert msg_id
+
+        # Publish a claim pointing at bob.mesh (recipient's own zone).
+        now = int(time.time())
+        legitimate_claim = ClaimRecord(
+            msg_id=msg_id,
+            sender_spk=alice_in_bob_zone.crypto.get_signing_public_key_bytes(),
+            sender_mailbox_domain="bob.mesh",
+            slot=0,
+            ts=now,
+            exp=now + 300,
+        )
+        wire = legitimate_claim.sign(alice_in_bob_zone.crypto)
+        store.publish_txt_record(
+            claim_rrset_name(bob_recipient_id, 0, PROVIDER_ZONE), wire, ttl=300
+        )
+
+        result = bob.receive_claims(provider_zones=[(PROVIDER_ZONE, PROVIDER_ENDPOINT)])
+        # ``claim.sender_mailbox_domain == bob.domain == self.domain``
+        # → direct-pin walk-all → alice's spk in known_spks → deliver.
+        assert len(result.delivered) == 1
+        assert result.delivered[0].plaintext == b"cross-zone direct pin"
+        assert result.quarantined_intro_ids == []
+
 
 class TestIntroQueueCli:
     def _setup_pending_intro(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1175,6 +1175,54 @@ class TestCrossZoneReceive:
         assert len(inbox) == 1
         assert inbox[0].plaintext == b"from alice"
 
+    def test_pinned_spk_from_other_zone_publishing_into_self_domain_delivers(self):
+        # Codex round-3 on PR #57: the slot-walk direct-pin gate
+        # was strict on ``self.domain`` too, breaking the legitimate
+        # cross-zone publish pattern (sender pinned in one zone but
+        # publishing into the recipient's OWN zone). The rotation
+        # walker had a ``self.domain`` carve-out for the same
+        # pattern; the direct-pin gate now matches it.
+        store = InMemoryDNSStore()
+        # Alice publishes from a client whose domain is bob.mesh
+        # (the recipient-zone publish pattern), even though bob has
+        # her pinned at her real home zone alice.mesh.
+        alice_in_bob_zone = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.mesh",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob.add_contact(
+            "alice",
+            alice_in_bob_zone.get_public_key_hex(),
+            domain="alice.mesh",  # pin at alice's home zone
+            signing_key_hex=alice_in_bob_zone.get_signing_public_key_hex(),
+        )
+        alice_in_bob_zone.add_contact(
+            "bob",
+            bob.get_public_key_hex(),
+            domain="bob.mesh",
+            signing_key_hex=bob.get_signing_public_key_hex(),
+        )
+        assert alice_in_bob_zone.send_message("bob", "cross-zone slot-walk")
+        # Bob walks zones [alice.mesh, bob.mesh]. Manifest is in
+        # bob.mesh (= self.domain). The asymmetric carve-out lets
+        # alice's pinned spk match even though her contact's domain
+        # is alice.mesh, not bob.mesh.
+        inbox = bob.receive_messages()
+        assert len(inbox) == 1
+        assert inbox[0].plaintext == b"cross-zone slot-walk"
+
     def test_pinned_spk_from_other_zone_does_not_replay_into_pinned_zone(self):
         # Codex P2 from the post-#52 fresh audit: the slot-walk pin
         # check used the GLOBAL pinned-spk set, so an attacker who

--- a/tests/test_rotation_chain.py
+++ b/tests/test_rotation_chain.py
@@ -884,3 +884,104 @@ class TestDMPClientRotationChainIntegration:
         inbox = bob.receive_messages()
         assert len(inbox) == 1
         assert inbox[0].plaintext == b"cross-zone rotated hello"
+
+    def test_rotation_walker_does_not_accept_cross_pin_replay(self):
+        # Codex follow-up from PR #54: with the rotation chain
+        # walker globally scoped, an attacker with write access to
+        # one pinned contact's zone could publish a manifest signed
+        # by ANOTHER pinned contact's rotated key — the walker would
+        # resolve it globally and accept. The post-#56 fix binds
+        # the walk to the polled zone for non-self zones, breaking
+        # the cross-pin replay while preserving the legitimate
+        # cross-zone case (sender publishing to recipient's own
+        # zone) covered above.
+        from dmp.client.client import DMPClient
+        from dmp.network.memory import InMemoryDNSStore
+
+        store = InMemoryDNSStore()
+        # Alice — pinned in alice.example, rotates her key.
+        alice = DMPClient(
+            "alice",
+            "alice-pass",
+            domain="alice.example",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        alice2 = DMPClient(
+            "alice",
+            "alice-new-pass",
+            domain="alice.example",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        # Carol — a totally separate pinned contact with her own zone.
+        carol = DMPClient(
+            "carol",
+            "carol-pass",
+            domain="carol.example",
+            store=store,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob = DMPClient(
+            "bob",
+            "bob-pass",
+            domain="bob.example",
+            store=store,
+            rotation_chain_enabled=True,
+            intro_queue_path=":memory:",
+            prekey_store_path=":memory:",
+        )
+        bob.add_contact(
+            "alice",
+            alice.get_public_key_hex(),
+            domain="alice.example",
+            signing_key_hex=alice.get_signing_public_key_hex(),
+        )
+        bob.add_contact(
+            "carol",
+            carol.get_public_key_hex(),
+            domain="carol.example",
+            signing_key_hex=carol.get_signing_public_key_hex(),
+        )
+        # Publish alice's rotation chain under alice.example (where
+        # the walker would normally find it).
+        store.publish_txt_record(
+            rotation_rrset_name_user_identity("alice", "alice.example"),
+            _sign_rotation(
+                old=alice.crypto,
+                new=alice2.crypto,
+                seq=1,
+                subject="alice@alice.example",
+            ),
+        )
+        # Alice2 publishes a real manifest+chunks to bob in alice.example.
+        alice2.add_contact("bob", bob.get_public_key_hex(), domain="bob.example")
+        assert alice2.send_message("bob", "rotated alice → bob")
+
+        # Attacker copies just the slot manifest + chunks (NOT the
+        # rotation record) into carol.example and removes the
+        # legitimate slot+chunk copies. The rotation chain stays in
+        # alice.example so the walker, if globally scoped, would
+        # still resolve alice's rotated key — that's exactly the
+        # bypass the per-zone binding closes.
+        for name in list(store.list_names()):
+            if not name.endswith(".alice.example"):
+                continue
+            head = name[: -len(".alice.example")]
+            if not (head.startswith("slot-") or head.startswith("chunk-")):
+                continue
+            cloned = head + ".carol.example"
+            for v in store.query_txt_record(name) or []:
+                store.publish_txt_record(cloned, v)
+            store.delete_txt_record(name)
+
+        # Bob walks zones [alice.example, carol.example, bob.example].
+        # In carol.example, the manifest carries alice2's rotated spk.
+        # With the per-zone walker, carol's chain is the only one
+        # consulted there (alice's not walked) — the rotated-key
+        # match is rejected. Inbox stays empty.
+        inbox = bob.receive_messages()
+        assert inbox == []


### PR DESCRIPTION
The slot-walk direct-pin gate is zone-bound, but the rotation-chain walker `_rotation_manifest_accepted` still walks every pinned contact's chain globally. So if bob has alice (zone=alice.example) and carol (zone=carol.example) pinned, an attacker with write access to carol's zone can publish a manifest signed by alice's rotated key — the walker resolves it globally and accepts. Same shape as the bug fixed for the slot-walk direct match.

`_rotation_manifest_accepted` now takes a `zone` parameter and applies per-zone binding. `self.domain` keeps walk-all semantics — legitimate cross-zone publishing lands manifests under the recipient's own zone regardless of where the sender is pinned, so a strict filter there drops legitimate rotated-key deliveries.

Both slot-walk and claim-path direct-pin gates updated to use the same asymmetric semantics for consistency. Reachable only when `rotation_chain_enabled=True` (default off).

Test plan: new positive + negative tests for each gate, mutation kills both directions, full unit + docker e2e green.