### PR TITLE
refuse DELETE through wildcard TSIG suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- TSIG authorizer refuses DNS UPDATE `DELETE` through wildcard
+  suffixes. Self-service registration grants every user wildcard
+  scopes for the shared namespaces (`slot-*.mb-*`, `chunk-*-*`,
+  `claim-*.mb-*`, `_dnsmesh-claim-*`) so anyone can deliver to
+  anyone — but the same wildcards previously also let one user's
+  TSIG key delete other users' chunks or mailbox slots over DNS
+  UPDATE. `ADD` operations are unchanged. Literal-suffix `DELETE`
+  is still allowed: the user's own `mb-{hash}.{zone}` and
+  `_dnsmesh-claim-{spk16}.{zone}` continue to authorize delete of
+  the user's own records, and `DMP_TSIG_LOOSE_SCOPE=1` admin keys
+  with bare-zone scope retain full delete authority.
+  `DMP_TSIG_TIGHT_SCOPE=1` deployments are unaffected — tight
+  scope already drops the wildcards at mint time.
+
 ## [0.6.6] — 2026-05-01 — DNS 0x20 + free port 53 in installer
 
 Fourth and (genuinely this time) final round of strict-resolver

--- a/dmp/server/tsig_keystore.py
+++ b/dmp/server/tsig_keystore.py
@@ -258,6 +258,38 @@ class TSIGKey:
                 return True
         return False
 
+    def covers_for_op(self, owner: str, op: str) -> bool:
+        """True iff `owner` is in scope for this key AND `op` is allowed.
+
+        Adds operation-aware authorization on top of plain ``covers``.
+        Self-service registration grants wildcard suffixes for the
+        shared namespaces (``slot-*.mb-*``, ``chunk-*-*``,
+        ``claim-*.mb-*``, ``_dnsmesh-claim-*``) so any user can deliver
+        to any recipient — chunks are content-addressed and mailbox
+        slots are owned by the recipient, not the sender. That's
+        fine for ADDs but unsafe for DELETEs: a wildcard-scoped key
+        could otherwise wipe co-resident records it never authored.
+
+        Policy: a DELETE is allowed only when the matching suffix is
+        a literal owner-exclusive shape (no ``*`` wildcards in the
+        labels). The user's own ``mb-{hash}.{zone}`` and
+        ``_dnsmesh-claim-{spk16}.{zone}`` qualify; the four
+        shared-namespace wildcards do not. ADDs continue to use the
+        plain coverage check so legitimate publish flows are
+        unaffected.
+
+        DELETE under tight-scope deployments (``DMP_TSIG_TIGHT_SCOPE=1``)
+        is unaffected because tight-scope drops the wildcards at mint
+        time — every covering suffix in that mode is already literal.
+        """
+        for suffix in self.allowed_suffixes:
+            if not _suffix_match(owner, suffix):
+                continue
+            if op == "delete" and "*" in suffix:
+                continue
+            return True
+        return False
+
 
 class TSIGKeyStore:
     """Sqlite-backed TSIG key store.
@@ -713,7 +745,7 @@ class TSIGKeyStore:
             row = store.get(name_text)
             if row is None or not row.is_active(now=now):
                 return False
-            return row.covers(owner)
+            return row.covers_for_op(owner, op)
 
         return authorize
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -323,6 +323,19 @@ The keystore enforces these via wildcard suffix matching at
 authorization time. Operator caps (`max_ttl`, `max_value_bytes`,
 `max_values_per_name`) apply identically to UPDATE writes.
 
+**Wildcard suffixes are ADD-only.** `DELETE` through DNS UPDATE is
+refused for any owner name that matches only via a wildcard
+suffix — the shared namespaces have no per-record ownership, so
+allowing delete through them would let one user wipe another
+user's chunks or slots. The user's own literal `mb-<hash>.<zone>`
+(and `_dnsmesh-claim-<spk16>.<zone>`) authorizes delete of the
+user's own records, which is the intended path for republishing
+a rotated slot. `DMP_TSIG_LOOSE_SCOPE=1` admin-issued keys with
+bare-zone scope retain full delete authority.
+`DMP_TSIG_TIGHT_SCOPE=1` deployments are unchanged — tight scope
+drops the wildcards at mint time so every covering suffix is
+already literal and delete-capable.
+
 **The un-TSIG'd UPDATE exception:**
 
 Cross-zone first-contact claim publishes

--- a/tests/test_tsig_keystore.py
+++ b/tests/test_tsig_keystore.py
@@ -241,6 +241,175 @@ class TestAuthorizer:
         authorize = store.build_authorizer()
         assert not authorize(dns.name.from_text("ghost."), "add", "anything.example")
 
+    def test_wildcard_scoped_key_can_add_chunks(self, store):
+        # Self-service registration grants wildcard suffixes (the
+        # chunk namespace is shared across users), so ADD on any
+        # chunk name in scope must succeed.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("chunk-*-*.shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert authorize(
+            dns.name.from_text("alice."),
+            "add",
+            "chunk-0001-abc123def456.shared.example",
+        )
+
+    def test_wildcard_scoped_key_cannot_delete_chunks(self, store):
+        # The shared chunk namespace has no per-record ownership,
+        # so a wildcard-scoped key letting any holder DELETE other
+        # users' chunks is the same threat as the HTTP shared-pool
+        # delete bug fixed in #52, just on the DNS UPDATE side.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("chunk-*-*.shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert not authorize(
+            dns.name.from_text("alice."),
+            "delete",
+            "chunk-0001-abc123def456.shared.example",
+        )
+
+    def test_wildcard_slot_mailbox_cannot_delete(self, store):
+        # ``slot-*.mb-*`` is granted to every registrant so anyone
+        # can deliver to any mailbox. DELETE through it would let
+        # one user wipe another user's mailbox slot — refused.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("slot-*.mb-*.shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert authorize(
+            dns.name.from_text("alice."),
+            "add",
+            "slot-3.mb-abcdef012345.shared.example",
+        )
+        assert not authorize(
+            dns.name.from_text("alice."),
+            "delete",
+            "slot-3.mb-abcdef012345.shared.example",
+        )
+
+    def test_owner_exclusive_suffix_can_still_delete(self, store):
+        # The user's OWN mailbox suffix (literal, no wildcards) is
+        # owner-exclusive — they can ADD AND DELETE their own slot
+        # records. This is the legitimate rotate-old-publish-new
+        # path; if delete were globally refused it would block
+        # operators from cleaning up after themselves.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("mb-abcdef012345.shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert authorize(
+            dns.name.from_text("alice."),
+            "delete",
+            "slot-3.mb-abcdef012345.shared.example",
+        )
+
+    def test_underscore_claim_wildcard_cannot_delete(self, store):
+        # ``_dnsmesh-claim-*`` is the M10 first-contact claim
+        # namespace, also wildcard-granted. Same rule.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("_dnsmesh-claim-*.shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert authorize(
+            dns.name.from_text("alice."),
+            "add",
+            "_dnsmesh-claim-abc123.shared.example",
+        )
+        assert not authorize(
+            dns.name.from_text("alice."),
+            "delete",
+            "_dnsmesh-claim-abc123.shared.example",
+        )
+
+    def test_claim_mailbox_wildcard_cannot_delete(self, store):
+        # ``claim-*.mb-*`` is the same-zone claim namespace
+        # (granted to every registrant for self-service claim
+        # publishing). Same rule.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("claim-*.mb-*.shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert authorize(
+            dns.name.from_text("alice."),
+            "add",
+            "claim-3.mb-abcdef012345.shared.example",
+        )
+        assert not authorize(
+            dns.name.from_text("alice."),
+            "delete",
+            "claim-3.mb-abcdef012345.shared.example",
+        )
+
+    def test_literal_claim_owner_can_delete(self, store):
+        # ``_dnsmesh-claim-{spk16}.{zone}`` is the user's own
+        # claim record (literal, no wildcards). Owner-exclusive,
+        # delete authority is the legitimate "rotate-and-republish"
+        # path.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("_dnsmesh-claim-1234567890abcdef.shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert authorize(
+            dns.name.from_text("alice."),
+            "delete",
+            "_dnsmesh-claim-1234567890abcdef.shared.example",
+        )
+
+    def test_bare_zone_loose_scope_can_delete(self, store):
+        # ``DMP_TSIG_LOOSE_SCOPE=1`` admin-issued keys carry the
+        # bare zone as the only scope. The bare zone is literal —
+        # no wildcards — so DELETE remains authorized: the
+        # operator escape hatch is preserved.
+        store.put(
+            name="admin",
+            secret=b"\x01" * 32,
+            allowed_suffixes=("shared.example",),
+        )
+        authorize = store.build_authorizer()
+        assert authorize(
+            dns.name.from_text("admin."),
+            "delete",
+            "anything.shared.example",
+        )
+
+    def test_mixed_literal_and_wildcard_for_same_owner_allows_delete(self, store):
+        # If a key has BOTH a wildcard AND a literal suffix that
+        # match the same owner name, the literal must still
+        # authorize DELETE — the wildcard is skipped only on a
+        # delete and the loop continues to find the literal.
+        store.put(
+            name="alice",
+            secret=b"\x01" * 32,
+            allowed_suffixes=(
+                "slot-*.mb-*.shared.example",
+                "mb-abcdef012345.shared.example",
+            ),
+        )
+        authorize = store.build_authorizer()
+        # Slot under alice's own mailbox: matches BOTH the wildcard
+        # and the literal mailbox suffix. DELETE must be allowed.
+        assert authorize(
+            dns.name.from_text("alice."),
+            "delete",
+            "slot-3.mb-abcdef012345.shared.example",
+        )
+
 
 class TestEndToEndWithDnsServer:
     """Sanity-check that dns_server picks up the keystore-built


### PR DESCRIPTION
The TSIG authorizer received an `op` parameter but ignored it. Self-service registration grants every user wildcard suffixes for the shared namespaces (`slot-*.mb-*`, `chunk-*-*`, `claim-*.mb-*`, `_dnsmesh-claim-*`) so any sender can deliver to any recipient — chunks are content-addressed, slots are owned by the recipient. ADD on those is fine. But the same wildcards also let one user's TSIG key DELETE another user's chunk or mailbox slot via DNS UPDATE, since the authorizer only checked that the owner name matched some allowed suffix. This is the DNS UPDATE side of the same threat #52 closed at the HTTP layer.

`TSIGKey.covers_for_op(owner, op)` refuses DELETE when the matching suffix contains a `*`. ADDs and literal-suffix DELETEs (the user's own `mb-{hash}.{zone}` and `_dnsmesh-claim-{spk16}.{zone}`) are unchanged. `DMP_TSIG_TIGHT_SCOPE=1` deployments are unaffected because tight-scope drops the wildcards at mint time.

Test plan: 5 new authorizer tests (wildcard ADD allowed, wildcard DELETE refused for chunk / slot / claim namespaces, literal-suffix DELETE still allowed). Mutation kills the negative tests when authorizer reverts to the op-ignoring version.