### PR TITLE
refuse unknown v=dmp records on the anti-entropy sync path

### DIFF
--- a/dmp/server/anti_entropy.py
+++ b/dmp/server/anti_entropy.py
@@ -101,6 +101,7 @@ from urllib import error as urlerror
 from urllib import request as urlrequest
 
 from dmp.core.bootstrap import RECORD_PREFIX as _BOOTSTRAP_PREFIX
+from dmp.core.chunking import MessageChunker
 from dmp.core.claim import RECORD_PREFIX as _CLAIM_PREFIX
 from dmp.core.claim import ClaimRecord
 from dmp.core.cluster import ClusterManifest
@@ -110,8 +111,62 @@ from dmp.core.identity import RECORD_PREFIX as _IDENTITY_PREFIX
 from dmp.core.manifest import RECORD_PREFIX as _MANIFEST_PREFIX
 from dmp.core.manifest import SlotManifest
 from dmp.core.prekeys import RECORD_PREFIX as _PREKEY_PREFIX
+from dmp.core.rotation import (
+    RECORD_PREFIX_REVOCATION,
+    RECORD_PREFIX_ROTATION,
+    RevocationRecord,
+    RotationRecord,
+)
 
 log = logging.getLogger(__name__)
+
+# Generic DMP-record prefix. Every DMP record type starts with
+# ``v=dmp1;t=<typename>;``; non-DMP TXT records (SPF, DKIM, ad-hoc
+# operator records hosted in the same zone) do not. ``verify_record``
+# uses this to distinguish "future-protocol record this binary
+# doesn't recognize" (refuse) from "legitimate non-DMP zone hygiene"
+# (accept).
+_DMP_GENERIC_PREFIX = "v=dmp"
+
+# Owner-name patterns DMP records publish under. Anti-entropy
+# refuses non-DMP TXT values at these names so a peer can't sync
+# ``v=spf1 ...`` (or any opaque blob) into ``slot-0.mb-{victim}.zone``
+# and pollute the victim's mailbox slot. Operator-hosted records
+# (DKIM at ``_domainkey.``, SPF at the apex, etc.) are fine because
+# their owners don't match these patterns.
+_DMP_RESERVED_NAME_RES = (
+    re.compile(r"^slot-\d+\.mb-[a-f0-9]+\."),
+    re.compile(r"^chunk-\d+-[a-f0-9]+\."),
+    re.compile(r"^mb-[a-f0-9]+\."),
+    re.compile(r"^id-[a-f0-9]+\."),
+    re.compile(r"^prekeys\.id-[a-f0-9]+\."),
+    re.compile(r"^_dnsmesh-"),
+    re.compile(r"^claim-\d+\.mb-[a-f0-9]+\."),
+    # Cluster manifest at ``cluster.<zone>``.
+    re.compile(r"^cluster\."),
+    # Bootstrap at ``_dmp.<user_domain>``.
+    re.compile(r"^_dmp\."),
+    # Zone-anchored identity at ``dmp.<zone>`` and hashed identity at
+    # ``dmp.<hash>.<domain>``.
+    re.compile(r"^dmp\."),
+    # Rotation + revocation RRsets ``rotate.<...>``.
+    re.compile(r"^rotate\."),
+)
+
+
+def _is_dmp_reserved_name(name: str) -> bool:
+    """True iff the owner name matches a DMP record-name pattern.
+
+    Used by ``verify_record`` to refuse non-DMP TXT values at owners
+    a DMP record would normally publish under, closing the alias
+    surface where a peer could push e.g. SPF text into a mailbox
+    slot via anti-entropy and have the local DNS server return it.
+    """
+    if not isinstance(name, str) or not name:
+        return False
+    lower = name.lower()
+    return any(pat.match(lower) for pat in _DMP_RESERVED_NAME_RES)
+
 
 # Transport limits exposed as module constants so tests can poke them.
 DEFAULT_HTTP_TIMEOUT = 5.0
@@ -361,7 +416,8 @@ def _peers_from_wire(
 
 def _classify_record(value: str) -> str:
     """Return a short tag for the record type: manifest/identity/prekey/
-    cluster/bootstrap/chunk/claim/unknown. Used only for logging + dispatch."""
+    cluster/bootstrap/chunk/claim/rotation/revocation/non-dmp/unknown-dmp.
+    Used only for logging + dispatch."""
     if value.startswith(_MANIFEST_PREFIX):
         return "manifest"
     if value.startswith(_IDENTITY_PREFIX):
@@ -376,7 +432,18 @@ def _classify_record(value: str) -> str:
         return "chunk"
     if value.startswith(_CLAIM_PREFIX):
         return "claim"
-    return "unknown"
+    if value.startswith(RECORD_PREFIX_ROTATION):
+        return "rotation"
+    if value.startswith(RECORD_PREFIX_REVOCATION):
+        return "revocation"
+    # ``v=dmp...`` payloads we don't recognize are future-protocol
+    # records this binary can't validate. They MUST NOT replicate
+    # — see ``verify_record``. Truly non-DMP TXT (SPF, DKIM, etc.)
+    # gets a separate tag so the operator's zone hygiene records
+    # keep syncing.
+    if value.startswith(_DMP_GENERIC_PREFIX):
+        return "unknown-dmp"
+    return "non-dmp"
 
 
 def _structural_parse_signed(value: str, prefix: str) -> bool:
@@ -402,6 +469,7 @@ def verify_record(
     value: str,
     *,
     cluster_operator_spk: Optional[bytes] = None,
+    name: str = "",
 ) -> bool:
     """Re-verify a record as if it had been published to us directly.
 
@@ -409,14 +477,23 @@ def verify_record(
     False otherwise. The anti-entropy worker is the only caller; the
     public publish path goes through HTTP and does its own validation.
 
-    Records with self-identifying signers (manifest, identity) undergo
-    full signature verification. Cluster manifests verify against
-    ``cluster_operator_spk`` if the node has one pinned; otherwise a
-    structural parse is used. Prekey / bootstrap records don't expose
-    the signer key at this layer; we use a structural parse and the
-    *client* reading the record later will re-verify with the real key.
-    Chunks and unknown blobs are accepted as opaque (the signed manifest
-    that references a chunk is the thing that binds it).
+    Records with self-identifying signers (manifest, identity, claim,
+    rotation, revocation) undergo full signature verification.
+    Cluster manifests verify against ``cluster_operator_spk`` if the
+    node has one pinned; otherwise a structural parse is used.
+    Prekey / bootstrap records don't expose the signer key at this
+    layer; we use a structural parse and the *client* reading the
+    record later will re-verify with the real key. Chunks structurally
+    validate via ``unwrap_block`` — a content-binding manifest
+    addition is tracked for v0.7. Future-protocol DMP records the
+    classifier doesn't recognize are refused.
+
+    Non-DMP TXT (SPF, DKIM, etc.) is accepted ONLY when the owner
+    ``name`` doesn't match a DMP-reserved pattern; otherwise refused
+    so a peer can't alias e.g. SPF text into ``slot-0.mb-{victim}.zone``.
+    Callers that pass an empty ``name`` skip the alias check, which is
+    safe for the existing test fixtures that target ``verify_record``
+    directly with no name context.
     """
     if not isinstance(value, str) or not value:
         return False
@@ -443,9 +520,50 @@ def verify_record(
         # tampered claim would let a malicious peer poison every
         # downstream provider's namespace.
         return ClaimRecord.parse_and_verify(value) is not None
-    # chunks and unknown — accept. Chunks are bound by their manifest;
-    # unknown types are future-proofing.
-    return True
+    if kind == "rotation":
+        # Self-verifying: the body carries both old + new spk and
+        # both signatures. parse_and_verify rejects forgeries.
+        return RotationRecord.parse_and_verify(value) is not None
+    if kind == "revocation":
+        # Self-verifying: the body carries the revoked spk and its
+        # own signature.
+        return RevocationRecord.parse_and_verify(value) is not None
+    if kind == "chunk":
+        # Chunks are bound by their signed manifest at receive time,
+        # but the manifest doesn't currently commit to per-chunk
+        # content (tracked for v0.7). Accepting them fully opaque
+        # turns anti-entropy into a chunk-poisoning surface. As
+        # defense in depth, structurally validate via ``unwrap_block``
+        # — refuses raw-garbage payloads. Doesn't close the bug for
+        # an attacker who calls ``wrap_block(garbage)``, but raises
+        # the bar from "any TXT works" to "valid wrapped block".
+        try:
+            payload = value[len(_CHUNK_PREFIX) :]
+            raw = base64.b64decode(payload, validate=True)
+        except Exception:
+            return False
+        chunker = MessageChunker(enable_error_correction=True)
+        return chunker.unwrap_block(raw) is not None
+    if kind == "non-dmp":
+        # Operator-hosted zone records (SPF, DKIM, A/MX co-resident
+        # with DMP records). Anti-entropy must replicate these to
+        # keep cluster nodes serving consistent zones. They are not
+        # DMP-shaped so they can't pose as future-protocol DMP
+        # records — but they CAN alias DMP owner names if the peer
+        # is malicious (e.g. publish ``v=spf1 ...`` at
+        # ``slot-0.mb-{victim}.zone``). Refuse non-DMP at any owner
+        # matching a DMP-reserved pattern; everywhere else trust as
+        # opaque.
+        if name and _is_dmp_reserved_name(name):
+            return False
+        return True
+    # ``unknown-dmp``: a ``v=dmp...`` record this binary doesn't
+    # recognize. Refuse — anti-entropy used to accept these as
+    # "future-proofing", but that turns sync into a write proxy
+    # for any DMP-shaped record type the binary lacks a validator
+    # for. New types must be wired into ``_classify_record`` and
+    # ``verify_record`` before they can replicate.
+    return False
 
 
 # Transport — isolated behind a small callable so tests can inject a fake
@@ -1254,7 +1372,9 @@ class AntiEntropyWorker:
             self.stats.records_pulled += 1
             # Re-verify signed record types. If verification fails, drop.
             if not verify_record(
-                value, cluster_operator_spk=self._cluster_operator_spk
+                value,
+                cluster_operator_spk=self._cluster_operator_spk,
+                name=name,
             ):
                 log.warning(
                     "anti-entropy: peer %s returned unverifiable record for %s",

--- a/docs/deployment/cluster.md
+++ b/docs/deployment/cluster.md
@@ -124,9 +124,19 @@ Each node runs a background thread (`AntiEntropyWorker`) that every
    locally — OR present but with a stale TTL — goes on the pull list.
 3. POSTs `http://<peer>/v1/sync/pull` with the pull list. The peer
    returns the full TXT values.
-4. **Re-verifies signatures** on signed record types
-   (`ClusterManifest`, `IdentityRecord`, `Prekey`, `SlotManifest`,
-   `BootstrapRecord`) before writing. Peers are untrusted.
+4. **Re-verifies records** before writing. Peers are untrusted.
+   Full signature verification on `ClusterManifest`, `IdentityRecord`,
+   `SlotManifest`, `ClaimRecord`, `RotationRecord`, `RevocationRecord`.
+   Structural-only on `Prekey` and `BootstrapRecord` (the signer key
+   isn't in this layer's context; the client that reads the record
+   later does its own real verification). Chunks are structurally
+   validated via the RS+checksum unwrap. `v=dmp...` records the
+   binary doesn't recognize are refused — future-protocol record
+   types must be added to the verifier before they can replicate.
+   Non-DMP TXT (SPF, DKIM, etc.) keeps replicating for zone hygiene
+   but is refused at any owner name matching a DMP record-name
+   pattern (so a peer can't alias arbitrary text into a victim's
+   mailbox slot).
 5. Writes validated records to the local store and advances the
    per-peer watermark (compound cursor `(ts, name, value_hash)`).
 

--- a/tests/test_anti_entropy.py
+++ b/tests/test_anti_entropy.py
@@ -112,11 +112,170 @@ class TestVerifyRecord:
         wire, _ = _signed_cluster()
         assert verify_record(wire) is True  # structural-only accepts valid wire
 
-    def test_chunk_accepted_as_opaque(self):
-        assert verify_record("v=dmp1;t=chunk;d=YWJj") is True
+    def test_chunk_structurally_validated(self):
+        # Anti-entropy structurally validates chunks (RS+checksum
+        # via ``unwrap_block``) as defense in depth before the
+        # planned v0.7 manifest-side content binding lands.
+        # Raw garbage in the base64 payload is rejected.
+        from dmp.core.chunking import MessageChunker
 
-    def test_unknown_prefix_accepted(self):
+        # 3-byte payload — fails the ``len(wire) > 8`` check inside
+        # unwrap_block → refused.
+        assert verify_record("v=dmp1;t=chunk;d=YWJj") is False
+        # A real wrapped block decodes successfully.
+        chunker = MessageChunker(enable_error_correction=True)
+        block = b"\xaa" * MessageChunker.DATA_PER_CHUNK
+        wrapped_b64 = base64.b64encode(chunker.wrap_block(block)).decode("ascii")
+        assert verify_record(f"v=dmp1;t=chunk;d={wrapped_b64}") is True
+        # Bad base64 → refused.
+        assert verify_record("v=dmp1;t=chunk;d=$$$") is False
+
+    def test_non_dmp_at_dmp_reserved_owner_refused(self):
+        # A peer trying to alias arbitrary TXT into a DMP-reserved
+        # owner name (slot/chunk/mailbox/identity/etc.) MUST be
+        # refused — anti-entropy used to write the value through
+        # without checking the owner shape, letting an attacker
+        # poison a victim's mailbox slot with e.g. SPF text.
+        # Covers every owner pattern in ``_DMP_RESERVED_NAME_RES``.
+        for reserved in [
+            "slot-0.mb-abcdef012345.example.com",
+            "chunk-0001-abcdef012345.example.com",
+            "mb-abcdef012345.example.com",
+            "id-1234567890abcdef.example.com",
+            "prekeys.id-abcdef012345.example.com",
+            "_dnsmesh-claim-abc123.example.com",
+            "_dnsmesh-heartbeat.example.com",
+            "claim-3.mb-abcdef012345.example.com",
+            "cluster.example.com",
+            "_dmp.example.com",
+            "dmp.example.com",
+            "dmp.abcdef012345.example.com",
+            "rotate.dmp.abcdef012345.example.com",
+            "rotate._dmp.example.com",
+            "rotate.cluster.example.com",
+        ]:
+            assert (
+                verify_record("v=spf1 -all", name=reserved) is False
+            ), f"non-DMP value at reserved {reserved!r} should be refused"
+        # A non-reserved owner — operator's apex DMARC record,
+        # generic A-record companion, etc. — keeps replicating.
+        for ok in [
+            "_dmarc.example.com",
+            "example.com",
+            "_acme-challenge.example.com",
+            "www.example.com",
+        ]:
+            assert (
+                verify_record("v=spf1 -all", name=ok) is True
+            ), f"non-DMP value at non-reserved {ok!r} should still replicate"
+
+    def test_non_dmp_record_accepted_as_zone_hygiene(self):
+        # Operator-hosted records that share the cluster zone with
+        # DMP records (SPF, DKIM, A/MX, etc.) must replicate so all
+        # cluster nodes serve a consistent zone view.
         assert verify_record("random-string") is True
+        assert verify_record("v=spf1 -all") is True
+        assert verify_record('"v=DMARC1; p=reject"') is True
+
+    def test_unknown_dmp_prefix_refused(self):
+        # A ``v=dmp...`` record this binary doesn't recognize is a
+        # future-protocol payload that must NOT replicate. Anti-
+        # entropy used to accept it as opaque "future-proofing",
+        # which let a malicious peer push any DMP-shaped TXT into
+        # the local store. New types must be wired into
+        # ``_classify_record`` and ``verify_record`` first.
+        assert verify_record("v=dmp1;t=futuretype;d=AAAA") is False
+        assert verify_record("v=dmp2;t=manifest;d=AAAA") is False
+        # Prefix-only — no body at all — also refused.
+        assert verify_record("v=dmp") is False
+
+    def test_valid_rotation_passes(self):
+        # Anti-entropy needs to replicate rotation records so the
+        # cluster's chain-walker can see them on any node. Verify
+        # the self-verifying parse path accepts a real rotation.
+        from dmp.core.rotation import (
+            RECORD_PREFIX_ROTATION,
+            RotationRecord,
+            SUBJECT_TYPE_USER_IDENTITY,
+        )
+        import time as _time
+
+        old = DMPCrypto()
+        new = DMPCrypto()
+        now = int(_time.time())
+        wire = RotationRecord(
+            subject_type=SUBJECT_TYPE_USER_IDENTITY,
+            subject="alice@mesh.test",
+            old_spk=old.get_signing_public_key_bytes(),
+            new_spk=new.get_signing_public_key_bytes(),
+            seq=1,
+            ts=now,
+            exp=now + 86400,
+        ).sign(old, new)
+        assert wire.startswith(RECORD_PREFIX_ROTATION)
+        assert verify_record(wire) is True
+
+    def test_tampered_rotation_refused(self):
+        # A forged rotation that flips the body must not replicate.
+        from dmp.core.rotation import (
+            RotationRecord,
+            SUBJECT_TYPE_USER_IDENTITY,
+        )
+        import time as _time
+
+        old = DMPCrypto()
+        new = DMPCrypto()
+        now = int(_time.time())
+        wire = RotationRecord(
+            subject_type=SUBJECT_TYPE_USER_IDENTITY,
+            subject="alice@mesh.test",
+            old_spk=old.get_signing_public_key_bytes(),
+            new_spk=new.get_signing_public_key_bytes(),
+            seq=1,
+            ts=now,
+            exp=now + 86400,
+        ).sign(old, new)
+        tampered = wire[:-5] + "AAAAA"
+        assert verify_record(tampered) is False
+
+    def test_valid_revocation_passes(self):
+        from dmp.core.rotation import (
+            RECORD_PREFIX_REVOCATION,
+            RevocationRecord,
+            SUBJECT_TYPE_USER_IDENTITY,
+        )
+        import time as _time
+
+        revoked = DMPCrypto()
+        now = int(_time.time())
+        wire = RevocationRecord(
+            subject_type=SUBJECT_TYPE_USER_IDENTITY,
+            subject="alice@mesh.test",
+            revoked_spk=revoked.get_signing_public_key_bytes(),
+            reason_code=1,
+            ts=now,
+        ).sign(revoked)
+        assert wire.startswith(RECORD_PREFIX_REVOCATION)
+        assert verify_record(wire) is True
+
+    def test_tampered_revocation_refused(self):
+        from dmp.core.rotation import (
+            RevocationRecord,
+            SUBJECT_TYPE_USER_IDENTITY,
+        )
+        import time as _time
+
+        revoked = DMPCrypto()
+        now = int(_time.time())
+        wire = RevocationRecord(
+            subject_type=SUBJECT_TYPE_USER_IDENTITY,
+            subject="alice@mesh.test",
+            revoked_spk=revoked.get_signing_public_key_bytes(),
+            reason_code=1,
+            ts=now,
+        ).sign(revoked)
+        tampered = wire[:-5] + "AAAAA"
+        assert verify_record(tampered) is False
 
     def test_valid_claim_passes(self):
         """M8.4 — anti-entropy gossip must accept signed claims."""


### PR DESCRIPTION
`verify_record` accepted unknown record types as opaque on the rationale that they were "future-proofing" for new record types. That turns sync into a write proxy: a peer can push any DMP-shaped TXT through anti-entropy and the local store serves it authoritatively, without the binary ever validating the content.

Tighten the policy:

- `v=dmp...` records that don't match any known prefix (classifier returns `unknown-dmp`) are refused. New DMP record types must be wired into `_classify_record` and `verify_record` with their own validator before they can replicate. Cost is a one-line change when a new prefix lands; the alternative is an open accept-everything sink.
- Truly non-DMP TXT (SPF, DKIM, A-record companion records, etc.) hosted in the cluster zone alongside DMP records keeps syncing — operator zone hygiene is preserved.
- Rotation and revocation records, previously falling through as opaque, now have explicit self-verifying validators.

Test plan: 4 new tests cover non-DMP acceptance, unknown-DMP refusal, valid rotation accepted, tampered rotation refused. Mutation flips the strict refusal back to accept; the unknown-DMP refusal test fails.