### PR TITLE
require X25519 proof-of-possession on TSIG registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+- Self-service TSIG registration requires X25519 proof-of-possession.
+  The challenge response now carries a server-issued ephemeral X25519
+  pubkey; the registrant computes a DH against it with their X25519
+  private half, HMACs the shared secret over (challenge, subject,
+  claimed pub), and posts the result as `x25519_pop` on
+  `/v1/registration/tsig-confirm`. Without this, an attacker could
+  read a victim's published `x25519_pub` from their identity record,
+  register their own subject + Ed25519 key but claim the victim's
+  pubkey, and have the server mint a TSIG key scoped to
+  `mb-{hash12(victim_x25519_pub)}.{zone}` — a direct write into the
+  victim's mailbox under `DMP_TSIG_TIGHT_SCOPE=1`. Legacy clients
+  that POST `x25519_pub` without `x25519_pop` keep working but lose
+  the literal `mb-{hash}.{zone}` suffix; identity / prekey / own-claim
+  literal suffixes are unaffected, and the loose-mode wildcards still
+  apply.
 - TSIG authorizer refuses DNS UPDATE `DELETE` through wildcard
   suffixes. Self-service registration grants every user wildcard
   scopes for the shared namespaces (`slot-*.mb-*`, `chunk-*-*`,

--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -3706,6 +3706,29 @@ def cmd_tsig_register(args: argparse.Namespace) -> int:
     )
     signature_hex = crypto.sign_data(payload).hex()
 
+    # X25519 proof-of-possession: prove we hold the X25519 private
+    # half corresponding to ``x25519_pub`` so the server is willing to
+    # scope the minted TSIG key to the literal ``mb-{hash}.{zone}``
+    # owner. Without this, the registration flow would let an attacker
+    # claim a victim's published X25519 pubkey and have the server
+    # mint a TSIG key for the victim's mailbox.
+    server_x25519_pub_hex = ch.get("server_x25519_pub", "")
+    x25519_pop_hex = ""
+    if server_x25519_pub_hex:
+        try:
+            from dmp.core.crypto import build_x25519_registration_pop
+
+            x25519_priv = crypto.get_private_key_bytes()
+            x25519_pop_hex = build_x25519_registration_pop(
+                server_eph_pub=bytes.fromhex(server_x25519_pub_hex),
+                x25519_priv=x25519_priv,
+                challenge_hex=challenge_hex,
+                subject=subject,
+                claimed_x25519_pub=bytes.fromhex(x25519_pub_hex),
+            ).hex()
+        except Exception as exc:
+            _die(2, f"x25519 proof-of-possession failed locally: {exc}")
+
     try:
         r2 = requests.post(
             f"{base}/v1/registration/tsig-confirm",
@@ -3717,6 +3740,7 @@ def cmd_tsig_register(args: argparse.Namespace) -> int:
                 # M9.2.3 + M9.2.5: shipping the X25519 public key extends
                 # the minted scope to mailbox / claim records.
                 "x25519_pub": x25519_pub_hex,
+                "x25519_pop": x25519_pop_hex,
             },
             timeout=10,
         )

--- a/dmp/core/crypto.py
+++ b/dmp/core/crypto.py
@@ -386,3 +386,38 @@ class MessageEncryption:
             associated_data=header_aad,
             private_key=private_key,
         )
+
+
+def build_x25519_registration_pop(
+    server_eph_pub: bytes,
+    x25519_priv: bytes,
+    challenge_hex: str,
+    subject: str,
+    claimed_x25519_pub: bytes,
+) -> bytes:
+    """Compute the X25519 proof-of-possession for TSIG self-service registration.
+
+    The TSIG-mint flow uses this to prove the registrant holds the
+    X25519 private half corresponding to a claimed ``x25519_pub`` —
+    without it, an attacker could read a victim's published pubkey
+    and have the server scope the minted TSIG key to the victim's
+    mailbox owner. The server side recomputes the same HMAC against
+    the matching ephemeral private half it stored when it issued the
+    challenge.
+
+    Lives in ``dmp.core.crypto`` (not ``dmp.server.registration``) so
+    the CLI can import it without depending on server-side modules.
+    """
+    import hashlib
+    import hmac
+
+    from cryptography.hazmat.primitives.asymmetric.x25519 import (
+        X25519PrivateKey,
+        X25519PublicKey,
+    )
+
+    priv = X25519PrivateKey.from_private_bytes(x25519_priv)
+    server_pub_obj = X25519PublicKey.from_public_bytes(server_eph_pub)
+    shared = priv.exchange(server_pub_obj)
+    msg = bytes.fromhex(challenge_hex) + subject.encode("utf-8") + claimed_x25519_pub
+    return hmac.new(shared, msg, hashlib.sha256).digest()

--- a/dmp/server/http_api.py
+++ b/dmp/server/http_api.py
@@ -896,6 +896,14 @@ HTTPS exchange is the one-time TSIG-key registration step.</p>
                 "challenge": pc.challenge_hex,
                 "node": pc.node,
                 "expires_at": pc.expires_at,
+                # Ephemeral X25519 public half for the TSIG-mint
+                # X25519 proof-of-possession flow. The client uses
+                # this to compute their DH side and HMACs the
+                # shared secret over (challenge, subject, claimed
+                # x25519_pub). Server retains the matching ephemeral
+                # private half in the ChallengeStore for
+                # verification on tsig-confirm.
+                "server_x25519_pub": pc.server_x25519_eph_pub.hex(),
                 "version": 1,
             },
         )

--- a/dmp/server/registration.py
+++ b/dmp/server/registration.py
@@ -108,6 +108,17 @@ class PendingChallenge:
     challenge_hex: str
     node: str
     expires_at: int
+    # Server-side ephemeral X25519 keypair issued alongside the
+    # nonce. The TSIG-mint flow uses these for the X25519 proof-of-
+    # possession check that closes the ``mb-{hash(victim_x25519_pub)}``
+    # forgery surface: the registrant computes
+    # ``HMAC(DH(server_x25519_eph_pub, x25519_priv), nonce||subject||claimed_pub)``
+    # and the server recomputes the same with its private half.
+    # Zero-length bytes indicate "challenge predates the PoP flow"
+    # (only used by tests that pre-construct PendingChallenge
+    # directly without going through ``issue``).
+    server_x25519_eph_priv: bytes = b""
+    server_x25519_eph_pub: bytes = b""
 
 
 class ChallengeStore:
@@ -130,12 +141,34 @@ class ChallengeStore:
         self._max_pending = max_pending
 
     def issue(self, node: str, now: Optional[int] = None) -> PendingChallenge:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.x25519 import (
+            X25519PrivateKey,
+        )
+
         now = now if now is not None else int(time.time())
         challenge_hex = secrets.token_bytes(32).hex()
+        # Server-side ephemeral X25519 keypair for the registration
+        # PoP check on the TSIG-mint path. Stored alongside the nonce
+        # so the consume() path can recover the private half. Public
+        # half is sent in the challenge response and used by the
+        # client to compute their DH side.
+        eph = X25519PrivateKey.generate()
+        eph_priv = eph.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        eph_pub = eph.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
         pc = PendingChallenge(
             challenge_hex=challenge_hex,
             node=node,
             expires_at=now + CHALLENGE_TTL_SECONDS,
+            server_x25519_eph_priv=eph_priv,
+            server_x25519_eph_pub=eph_pub,
         )
         with self._lock:
             self._pending[challenge_hex] = pc
@@ -176,6 +209,63 @@ class ChallengeStore:
 
 
 # ---------------------------------------------------------------------------
+# X25519 proof-of-possession for the TSIG-mint flow.
+#
+# Without this, the registrant could claim ANY ``x25519_pub`` (even a
+# victim's, which is published in their identity record) and have the
+# minted TSIG key scoped to ``mb-{hash12(victim_x25519_pub)}.{zone}``.
+# Under DMP_TSIG_TIGHT_SCOPE that's a direct write into the victim's
+# mailbox; under loose scope the wildcards already grant the same, but
+# the literal mailbox suffix is still privilege the attacker shouldn't
+# have. The proof binds the registrant to (challenge, subject, claimed
+# pubkey) and requires possession of the matching X25519 private key.
+# ---------------------------------------------------------------------------
+
+
+_X25519_POP_LEN = 32
+
+
+# The PoP builder lives in ``dmp.core.crypto`` so the CLI can compute
+# it without importing server modules (codex layering nit on PR #61).
+# Re-exported here under the original name for existing call sites.
+from dmp.core.crypto import build_x25519_registration_pop as build_x25519_pop
+
+
+def verify_x25519_pop(
+    pc: PendingChallenge,
+    claimed_x25519_pub: bytes,
+    pop: bytes,
+    subject: str,
+) -> bool:
+    """True iff ``pop`` proves the registrant holds the X25519 private
+    half corresponding to ``claimed_x25519_pub``.
+
+    Constant-time compare so an attacker can't binary-search the proof
+    via timing. Returns False on any internal error to fail closed.
+    """
+    import hashlib
+    import hmac
+
+    if len(pop) != _X25519_POP_LEN:
+        return False
+    if not pc.server_x25519_eph_priv:
+        # Pre-PoP challenge (only happens in tests that hand-craft
+        # PendingChallenge). Fail closed.
+        return False
+    try:
+        from cryptography.hazmat.primitives.asymmetric.x25519 import (
+            X25519PrivateKey,
+            X25519PublicKey,
+        )
+
+        eph_priv = X25519PrivateKey.from_private_bytes(pc.server_x25519_eph_priv)
+        client_pub = X25519PublicKey.from_public_bytes(claimed_x25519_pub)
+        shared = eph_priv.exchange(client_pub)
+    except Exception:
+        return False
+    msg = bytes.fromhex(pc.challenge_hex) + subject.encode("utf-8") + claimed_x25519_pub
+    expected = hmac.new(shared, msg, hashlib.sha256).digest()
+    return hmac.compare_digest(expected, pop)
 
 
 def _parse_hex(value: str, expected_bytes: int, field: str) -> bytes:
@@ -745,6 +835,34 @@ def mint_tsig_via_registration(
     # server. Documented limitation; CLI passes the pubkey by default.
     x_pub_raw = body.get("x25519_pub")
     x_pub_hex = x_pub_raw.strip().lower() if isinstance(x_pub_raw, str) else ""
+    # Proof-of-possession check. If the registrant claims an
+    # ``x25519_pub`` they MUST also include ``x25519_pop`` proving
+    # they hold the matching private key — otherwise an attacker can
+    # claim a victim's published X25519 pub and have the minted key
+    # scoped to the victim's mailbox.
+    #   - pop missing: legacy client. Drop ``x25519_pub`` from scope
+    #     derivation (still mints with wildcard scope; the literal
+    #     ``mb-{hash}.{zone}`` is the only thing the pubkey gates).
+    #   - pop present + invalid: active forgery attempt. Reject 401.
+    #   - pop present + valid: keep ``x25519_pub`` for scope.
+    pop_raw = body.get("x25519_pop")
+    if x_pub_hex:
+        try:
+            x_pub_bytes = _parse_hex(x_pub_hex, 32, "x25519_pub")
+        except RegistrationError:
+            raise
+        if isinstance(pop_raw, str) and pop_raw:
+            pop_bytes = _parse_hex(pop_raw, 32, "x25519_pop")
+            if not verify_x25519_pop(pc, x_pub_bytes, pop_bytes, subject):
+                raise SignatureInvalid(
+                    "x25519_pop verification failed: registrant did not "
+                    "prove possession of the claimed X25519 key"
+                )
+        else:
+            # Legacy client without proof. Drop the claimed pubkey so
+            # the minted scope can't include the literal mailbox
+            # suffix the attacker would otherwise inject.
+            x_pub_hex = ""
     suffixes = _suffixes_for(
         subject, local_part, spk_hex, zone, x25519_pub_hex=x_pub_hex
     )

--- a/tests/test_compose_cluster.py
+++ b/tests/test_compose_cluster.py
@@ -248,8 +248,13 @@ class TestComposeCluster:
         """Publish at node-a; node-b and node-c catch up via anti-entropy."""
         # Sync interval is 2s (see docker/cluster/node-*.env). Give the
         # worker a handful of ticks to propagate.
+        # Non-DMP value at a non-reserved owner name — exercises the
+        # anti-entropy convergence path without tripping the chunk
+        # structural-validation that #60 added (chunks need a real
+        # ``wrap_block`` payload, which this convergence test doesn't
+        # care about).
         name = "converge.mesh.test"
-        value = "v=dmp1;t=chunk;d=test-converge-abc"
+        value = "test-converge-abc"
         assert _publish(compose_cluster["http_ports"]["node-a"], name, value) == 201
 
         # node-a should already have it (direct write).
@@ -266,9 +271,11 @@ class TestComposeCluster:
 
     def test_kill_and_rejoin_node_catches_up(self, compose_cluster):
         """Stop node-b, write to node-a, restart node-b; it backfills."""
+        # See test_all_three_nodes_converge_on_publish for why the
+        # values are non-DMP shape.
         name = "rejoin.mesh.test"
-        value_before = "v=dmp1;t=chunk;d=written-while-b-was-up"
-        value_during = "v=dmp1;t=chunk;d=written-while-b-was-DOWN"
+        value_before = "written-while-b-was-up"
+        value_during = "written-while-b-was-DOWN"
 
         # Seed a record so node-b has the baseline.
         assert (

--- a/tests/test_registration_tsig.py
+++ b/tests/test_registration_tsig.py
@@ -165,13 +165,30 @@ class TestMintTsigViaRegistration:
         assert f"id-{full_hash16}.ops.example" not in minted.allowed_suffixes
 
     def test_x25519_pub_extends_scope_to_mailbox(self, keystore, config, challenges):
-        """When the registration body includes ``x25519_pub`` the
-        minted key gains ``mb-<hash12>.<zone>`` — the user's own
-        mailbox alias. Works in default (tight) mode."""
+        """When the registration body includes ``x25519_pub`` AND a
+        valid ``x25519_pop``, the minted key gains
+        ``mb-<hash12>.<zone>`` — the user's own mailbox alias."""
         import hashlib
-        import os
 
-        x_pub = os.urandom(32)
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.x25519 import (
+            X25519PrivateKey,
+        )
+
+        from dmp.server.registration import build_x25519_pop
+
+        # Real X25519 keypair so we can compute a valid PoP.
+        x_priv_obj = X25519PrivateKey.generate()
+        x_priv = x_priv_obj.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        x_pub = x_priv_obj.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+
         pc = challenges.issue(config.node_hostname)
         body, _ = _signed_body(
             subject="alice@ops.example",
@@ -179,6 +196,13 @@ class TestMintTsigViaRegistration:
             node=pc.node,
         )
         body["x25519_pub"] = x_pub.hex()
+        body["x25519_pop"] = build_x25519_pop(
+            server_eph_pub=pc.server_x25519_eph_pub,
+            x25519_priv=x_priv,
+            challenge_hex=pc.challenge_hex,
+            subject="alice@ops.example",
+            claimed_x25519_pub=x_pub,
+        ).hex()
         minted = mint_tsig_via_registration(
             keystore=keystore,
             challenges=challenges,
@@ -465,6 +489,216 @@ class TestMintTsigViaRegistration:
             body=body2,
         )
         assert second.name != first.name
+
+
+class TestX25519ProofOfPossession:
+    # The forgery surface is: an attacker reads a victim's published
+    # ``x25519_pub`` from their identity record, registers under their
+    # OWN subject + Ed25519 key but claims the victim's ``x25519_pub``,
+    # and the server mints a TSIG key scoped to
+    # ``mb-{hash12(victim_x25519_pub)}.{zone}``. Under
+    # DMP_TSIG_TIGHT_SCOPE that's a direct write into the victim's
+    # mailbox; under loose scope the wildcards already grant the same
+    # but the literal mailbox suffix is privilege the attacker shouldn't
+    # have. The PoP check requires the registrant to prove possession
+    # of the X25519 private half before that scope is granted.
+
+    def _real_x25519_keypair(self):
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.x25519 import (
+            X25519PrivateKey,
+        )
+
+        priv_obj = X25519PrivateKey.generate()
+        priv = priv_obj.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pub = priv_obj.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        return priv, pub
+
+    def _build_pop(self, pc, *, x_priv, x_pub, subject):
+        from dmp.server.registration import build_x25519_pop
+
+        return build_x25519_pop(
+            server_eph_pub=pc.server_x25519_eph_pub,
+            x25519_priv=x_priv,
+            challenge_hex=pc.challenge_hex,
+            subject=subject,
+            claimed_x25519_pub=x_pub,
+        ).hex()
+
+    def test_valid_pop_grants_mailbox_scope(self, keystore, config, challenges):
+        x_priv, x_pub = self._real_x25519_keypair()
+        pc = challenges.issue(config.node_hostname)
+        body, _ = _signed_body(
+            subject="alice@ops.example",
+            challenge_hex=pc.challenge_hex,
+            node=pc.node,
+        )
+        body["x25519_pub"] = x_pub.hex()
+        body["x25519_pop"] = self._build_pop(
+            pc, x_priv=x_priv, x_pub=x_pub, subject="alice@ops.example"
+        )
+        minted = mint_tsig_via_registration(
+            keystore=keystore,
+            challenges=challenges,
+            config=config,
+            body=body,
+        )
+        # Confirms the literal ``mb-{hash12}.{zone}`` suffix lands.
+        import hashlib
+
+        recipient_id = hashlib.sha256(x_pub).digest()
+        mailbox_hash = hashlib.sha256(recipient_id).hexdigest()[:12]
+        assert f"mb-{mailbox_hash}.ops.example" in minted.allowed_suffixes
+
+    def test_pop_mismatched_pub_refused(self, keystore, config, challenges):
+        # Attacker holds x_priv_attacker but claims x_pub_victim. The
+        # PoP they can compute is over their own keypair; the server
+        # tries to verify against the CLAIMED victim pub and the DH
+        # shared-secret won't match.
+        attacker_priv, attacker_pub = self._real_x25519_keypair()
+        _, victim_pub = self._real_x25519_keypair()
+
+        pc = challenges.issue(config.node_hostname)
+        body, _ = _signed_body(
+            subject="attacker@ops.example",
+            challenge_hex=pc.challenge_hex,
+            node=pc.node,
+        )
+        body["x25519_pub"] = victim_pub.hex()
+        # Attacker computes a "PoP" with their own private key but
+        # claims the victim's pubkey. Server's DH against the claimed
+        # pub yields a different shared secret, HMAC fails.
+        body["x25519_pop"] = self._build_pop(
+            pc,
+            x_priv=attacker_priv,
+            x_pub=attacker_pub,
+            subject="attacker@ops.example",
+        )
+        with pytest.raises(SignatureInvalid):
+            mint_tsig_via_registration(
+                keystore=keystore,
+                challenges=challenges,
+                config=config,
+                body=body,
+            )
+
+    def test_pop_garbage_bytes_refused(self, keystore, config, challenges):
+        _, x_pub = self._real_x25519_keypair()
+        pc = challenges.issue(config.node_hostname)
+        body, _ = _signed_body(
+            subject="alice@ops.example",
+            challenge_hex=pc.challenge_hex,
+            node=pc.node,
+        )
+        body["x25519_pub"] = x_pub.hex()
+        body["x25519_pop"] = "00" * 32  # 32 bytes of zeros, not a valid HMAC
+        with pytest.raises(SignatureInvalid):
+            mint_tsig_via_registration(
+                keystore=keystore,
+                challenges=challenges,
+                config=config,
+                body=body,
+            )
+
+    def test_pop_bound_to_subject(self, keystore, config, challenges):
+        # Attacker captured a victim's valid (challenge, pop, subject)
+        # tuple from a real registration, then tries to replay it
+        # under their own subject. The server's HMAC check binds the
+        # subject into the message so the attacker's substitution
+        # invalidates the proof.
+        x_priv, x_pub = self._real_x25519_keypair()
+        pc = challenges.issue(config.node_hostname)
+        # Victim built a pop for THEIR subject.
+        victim_pop = self._build_pop(
+            pc, x_priv=x_priv, x_pub=x_pub, subject="alice@ops.example"
+        )
+        # Attacker tries to use it under a different subject.
+        body, _ = _signed_body(
+            subject="mallory@ops.example",
+            challenge_hex=pc.challenge_hex,
+            node=pc.node,
+        )
+        body["x25519_pub"] = x_pub.hex()
+        body["x25519_pop"] = victim_pop
+        with pytest.raises(SignatureInvalid):
+            mint_tsig_via_registration(
+                keystore=keystore,
+                challenges=challenges,
+                config=config,
+                body=body,
+            )
+
+    def test_pop_replay_across_challenges_refused(self, keystore, config, challenges):
+        # An attacker captures a valid (challenge_A, x25519_pub, pop_A)
+        # tuple. They can't replay pop_A against a fresh challenge_B
+        # because the server's ephemeral X25519 private differs per
+        # challenge — the DH shared secret won't match.
+        x_priv, x_pub = self._real_x25519_keypair()
+
+        # Issue and immediately consume challenge A so we have a valid
+        # pop bound to A's ephemeral key, then issue challenge B.
+        pc_a = challenges.issue(config.node_hostname)
+        pop_a = self._build_pop(
+            pc_a, x_priv=x_priv, x_pub=x_pub, subject="alice@ops.example"
+        )
+        # Consume A so the next confirm uses challenge B (a confirm
+        # only consumes its OWN challenge — fresh issue gives the
+        # attacker a different nonce).
+        pc_b = challenges.issue(config.node_hostname)
+        body, _ = _signed_body(
+            subject="alice@ops.example",
+            challenge_hex=pc_b.challenge_hex,
+            node=pc_b.node,
+        )
+        body["x25519_pub"] = x_pub.hex()
+        body["x25519_pop"] = pop_a  # pop bound to challenge A, not B
+        with pytest.raises(SignatureInvalid):
+            mint_tsig_via_registration(
+                keystore=keystore,
+                challenges=challenges,
+                config=config,
+                body=body,
+            )
+
+    def test_legacy_client_no_pop_drops_pubkey_silently(
+        self, keystore, config, challenges
+    ):
+        # Legacy clients that POST ``x25519_pub`` without
+        # ``x25519_pop`` keep working but lose the literal
+        # ``mb-{hash}.{zone}`` suffix. Identity / prekey / own-claim
+        # literal suffixes are unaffected, and the wildcard scopes
+        # in loose mode still apply.
+        _, x_pub = self._real_x25519_keypair()
+        pc = challenges.issue(config.node_hostname)
+        body, _ = _signed_body(
+            subject="alice@ops.example",
+            challenge_hex=pc.challenge_hex,
+            node=pc.node,
+        )
+        body["x25519_pub"] = x_pub.hex()
+        # Deliberately omit x25519_pop.
+        minted = mint_tsig_via_registration(
+            keystore=keystore,
+            challenges=challenges,
+            config=config,
+            body=body,
+        )
+        # Wildcard scope still present.
+        assert any("slot-*.mb-*" in s for s in minted.allowed_suffixes)
+        # Literal mailbox suffix NOT present (since the pubkey was
+        # dropped from scope derivation without proof).
+        import hashlib
+
+        recipient_id = hashlib.sha256(x_pub).digest()
+        mailbox_hash = hashlib.sha256(recipient_id).hexdigest()[:12]
+        assert f"mb-{mailbox_hash}.ops.example" not in minted.allowed_suffixes
 
 
 class TestHttpEndpoint:


### PR DESCRIPTION
The TSIG-mint flow accepted a caller-supplied `x25519_pub` and used it to derive the literal `mb-{hash12(x25519_pub)}.{zone}` mailbox suffix without proving the registrant held the matching private key. An attacker could read a victim's identity record (public TXT lookup), extract their published `x25519_pub`, and register their own subject + Ed25519 key but claim the victim's pubkey. Under `DMP_TSIG_TIGHT_SCOPE=1` the minted TSIG key was scoped to the victim's mailbox literal — direct DNS UPDATE write authority into the victim's mailbox slots.

The challenge response now carries a server-issued ephemeral X25519 pubkey. The registrant computes a DH against it with their X25519 private half, HMAC-SHA256s the shared secret over `(challenge_hex_bytes || subject_utf8 || claimed_x25519_pub)`, and posts the 32-byte result as `x25519_pop` on tsig-confirm. Server retains the matching ephemeral private half on the ChallengeStore entry and recomputes the same HMAC against the CLAIMED pubkey on consume — DH outputs match iff the registrant holds the X25519 private corresponding to the claimed pub.

Backward compat: clients that POST `x25519_pub` without `x25519_pop` keep working but lose the literal mailbox suffix (the wildcards still apply in loose mode). Tight-scope deployments need clients on the new flow. `x25519_pop` present but invalid is a hard reject.

CLI computes and posts the proof automatically when minting.

Also unblocks two compose-cluster tests that were broken by #60's chunk structural validation (they used a fake `v=dmp1;t=chunk;d=...` payload that's no longer accepted opaquely; switched to non-DMP values at non-reserved names — the test intent was anti-entropy convergence, not chunk handling).

Test plan: 5 new PoP tests (valid pop grants mailbox scope, mismatched pub refused, garbage bytes refused, proof bound to subject, legacy no-pop drops pubkey silently). Mutation kills 3 of 5 when verification is skipped. Full unit (1605) + docker (7) + compose cluster (3) green.