### PR TITLE
bind chunk content into the slot manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+- `SlotManifest` commits to per-chunk content via SHA-256 hashes
+  signed alongside the rest of the manifest body. Receivers verify
+  each fetched chunk record against its expected hash before adding
+  the unwrapped block to the erasure share set, refusing
+  `wrap_block(garbage)` poison values appended to a chunk RRset by
+  any pool-token holder. Wire-format change is backward-compatible:
+  manifests with empty `chunk_hashes` parse as v0.6 and trigger the
+  legacy best-effort decode (still vulnerable to poison until the
+  sender upgrades). Manifest size grows by 32 bytes per chunk;
+  multi-chunk manifests now span multiple TXT character-strings on
+  the wire and are split at publish time by `_split_txt_value` (no
+  per-string is over 255 bytes).
 - Self-service TSIG registration requires X25519 proof-of-possession.
   The challenge response now carries a server-issued ephemeral X25519
   pubkey; the registrant computes a DH against it with their X25519

--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -787,8 +787,17 @@ class DMPClient:
         # erasure layer runs. Drop the metadata dict from the wire record
         # — chunk_num and msg_key are already in the domain name and
         # encoding them again would push us over the 255-byte TXT limit.
+        # Collect SHA-256 of each wrapped chunk so the manifest can
+        # commit to the chunk contents — receivers verify each fetched
+        # candidate against its expected hash, refusing
+        # ``wrap_block(garbage)`` poison values appended to a chunk
+        # RRset by any pool-token holder.
+        import hashlib as _hashlib
+
+        chunk_hashes: List[bytes] = []
         for chunk_num, share in enumerate(shares):
             wire_chunk = self.chunker.wrap_block(share)
+            chunk_hashes.append(_hashlib.sha256(wire_chunk).digest())
             record = DMPDNSRecord(
                 version=1,
                 record_type="chunk",
@@ -812,6 +821,7 @@ class DMPClient:
             prekey_id=prekey_id,
             ts=now,
             exp=now + ttl,
+            chunk_hashes=tuple(chunk_hashes),
         )
         slot_record = manifest.sign(self.crypto)
         # Append semantics in the store make slot choice effectively cosmetic:
@@ -1674,6 +1684,17 @@ class DMPClient:
         # Walk every chunk position up to total_chunks, collecting valid
         # shares into a dict keyed by share_id. Stop early once we have k
         # shares — erasure.decode only needs k of n.
+        import hashlib as _hashlib
+
+        # Manifest-bound chunk hashes (v0.7+ senders). When present,
+        # each fetched candidate must SHA-256-match the expected
+        # hash before being added to the share set — closes the
+        # ``wrap_block(garbage)`` poison vector where a pool-token
+        # holder appends a parseable-but-bad block to a chunk RRset.
+        # Empty tuple = legacy manifest from a pre-0.7 sender; fall
+        # back to first-decodable behavior (still vulnerable, no
+        # better than the old code path).
+        expected_hashes: Tuple[bytes, ...] = manifest.chunk_hashes
         shares: Dict[int, bytes] = {}
         for chunk_num in range(manifest.total_chunks):
             if len(shares) >= manifest.data_chunks:
@@ -1683,20 +1704,28 @@ class DMPClient:
             )
             if not records:
                 continue
-            dmp_record: Optional[DMPDNSRecord] = None
             for txt in records:
-                if txt.startswith("v=dmp"):
-                    try:
-                        dmp_record = DMPDNSRecord.from_txt_record(txt)
-                        break
-                    except Exception:
+                if not txt.startswith("v=dmp"):
+                    continue
+                try:
+                    dmp_record = DMPDNSRecord.from_txt_record(txt)
+                except Exception:
+                    continue
+                if dmp_record.record_type != "chunk":
+                    continue
+                # Manifest-bound hash check first — refuses poison
+                # before the cost of an unwrap_block call.
+                if expected_hashes:
+                    if (
+                        _hashlib.sha256(dmp_record.data).digest()
+                        != expected_hashes[chunk_num]
+                    ):
                         continue
-            if dmp_record is None or dmp_record.record_type != "chunk":
-                continue
-            block = self.chunker.unwrap_block(dmp_record.data)
-            if block is None:
-                continue
-            shares[chunk_num] = block
+                block = self.chunker.unwrap_block(dmp_record.data)
+                if block is None:
+                    continue
+                shares[chunk_num] = block
+                break
 
         if len(shares) < manifest.data_chunks:
             return None

--- a/dmp/core/manifest.py
+++ b/dmp/core/manifest.py
@@ -47,9 +47,22 @@ from typing import Dict, Optional, Tuple
 from dmp.core.crypto import DMPCrypto
 
 RECORD_PREFIX = "v=dmp1;t=manifest;d="
-_BODY_LEN = 16 + 32 + 32 + 4 + 4 + 4 + 8 + 8  # 108 bytes (adds prekey_id)
+# Header layout (fixed 108 bytes): msg_id, sender_spk, recipient_id,
+# total_chunks, data_chunks, prekey_id, ts, exp.
+_HEADER_LEN = 16 + 32 + 32 + 4 + 4 + 4 + 8 + 8  # 108 bytes
+# Per-chunk content-binding hashes are appended after the header, one
+# 32-byte SHA-256 per chunk (length = 32 * total_chunks). Optional for
+# backward compatibility with v0.6 manifests that have no hashes —
+# recipients that find chunk_hashes empty fall back to the previous
+# best-effort decode and may be poisoned by ``wrap_block(garbage)``
+# from any pool-token holder; recipients that find chunk_hashes
+# populated verify each fetched chunk against its expected hash before
+# adding it to the erasure share set, closing the poison vector.
+_CHUNK_HASH_LEN = 32
+# Legacy alias kept for the few external callers that imported it.
+_BODY_LEN = _HEADER_LEN
 _SIG_LEN = 64
-_WIRE_LEN = _BODY_LEN + _SIG_LEN  # 172 bytes
+_WIRE_LEN = _BODY_LEN + _SIG_LEN  # 172 bytes (legacy minimum)
 DEFAULT_MANIFEST_TTL = 300
 
 # Upper bound on how far in the future a manifest's signed `exp`
@@ -89,6 +102,16 @@ class SlotManifest:
     prekey_id: int  # recipient prekey used for ECDH; 0 = long-term key
     ts: int  # unix seconds when the sender published
     exp: int  # unix seconds after which recipient should drop
+    # Per-chunk SHA-256 of the wrapped chunk wire bytes (the same
+    # bytes ``MessageChunker.wrap_block`` produces and DMPDNSRecord
+    # carries in ``data``). Length must equal ``total_chunks`` when
+    # populated. Empty tuple on legacy manifests parsed from old
+    # senders. Receivers that see populated hashes hard-verify each
+    # fetched chunk against its expected hash before adding to the
+    # erasure share set; receivers that see empty hashes fall back
+    # to the legacy best-effort decode and remain susceptible to
+    # ``wrap_block(garbage)`` poisoning from pool-token holders.
+    chunk_hashes: Tuple[bytes, ...] = ()
 
     def to_body_bytes(self) -> bytes:
         """Binary representation of the manifest fields, used as the signed payload."""
@@ -107,7 +130,18 @@ class SlotManifest:
             )
         if not (0 <= self.prekey_id < (1 << 32)):
             raise ValueError("prekey_id out of range")
-        return (
+        # When chunk_hashes are present they MUST cover every chunk;
+        # a partial set would leave gaps the receiver couldn't
+        # distinguish from poisoning.
+        if self.chunk_hashes and len(self.chunk_hashes) != self.total_chunks:
+            raise ValueError(
+                "chunk_hashes length must equal total_chunks "
+                f"({len(self.chunk_hashes)} vs {self.total_chunks})"
+            )
+        for h in self.chunk_hashes:
+            if len(h) != _CHUNK_HASH_LEN:
+                raise ValueError(f"each chunk hash must be {_CHUNK_HASH_LEN} bytes")
+        header = (
             self.msg_id
             + self.sender_spk
             + self.recipient_id
@@ -117,12 +151,14 @@ class SlotManifest:
             + self.ts.to_bytes(8, "big")
             + self.exp.to_bytes(8, "big")
         )
+        return header + b"".join(self.chunk_hashes)
 
     @classmethod
     def from_body_bytes(cls, body: bytes) -> "SlotManifest":
-        if len(body) != _BODY_LEN:
+        if len(body) < _HEADER_LEN:
             raise ValueError(
-                f"manifest body must be {_BODY_LEN} bytes, got {len(body)}"
+                f"manifest body must be at least {_HEADER_LEN} bytes, "
+                f"got {len(body)}"
             )
         total_chunks = int.from_bytes(body[80:84], "big")
         data_chunks = int.from_bytes(body[84:88], "big")
@@ -134,6 +170,28 @@ class SlotManifest:
                 f"total_chunks {total_chunks} exceeds protocol max "
                 f"{MAX_TOTAL_CHUNKS}"
             )
+        # Body length must be either the legacy header-only shape OR
+        # header + 32 * total_chunks. Anything else is malformed —
+        # ambiguous trailing bytes could otherwise mask a tampered
+        # manifest.
+        if len(body) == _HEADER_LEN:
+            chunk_hashes: Tuple[bytes, ...] = ()
+        else:
+            expected = _HEADER_LEN + _CHUNK_HASH_LEN * total_chunks
+            if len(body) != expected:
+                raise ValueError(
+                    f"manifest body length {len(body)} does not match "
+                    f"either legacy ({_HEADER_LEN}) or content-bound "
+                    f"({expected}) layout"
+                )
+            chunk_hashes = tuple(
+                body[
+                    _HEADER_LEN
+                    + i * _CHUNK_HASH_LEN : _HEADER_LEN
+                    + (i + 1) * _CHUNK_HASH_LEN
+                ]
+                for i in range(total_chunks)
+            )
         return cls(
             msg_id=body[0:16],
             sender_spk=body[16:48],
@@ -143,6 +201,7 @@ class SlotManifest:
             prekey_id=prekey_id,
             ts=int.from_bytes(body[92:100], "big"),
             exp=int.from_bytes(body[100:108], "big"),
+            chunk_hashes=chunk_hashes,
         )
 
     def sign(self, sender_crypto: DMPCrypto) -> str:
@@ -167,16 +226,29 @@ class SlotManifest:
             wire = base64.b64decode(record[len(RECORD_PREFIX) :])
         except Exception:
             return None
-        if len(wire) != _WIRE_LEN:
+        # Wire layout is variable-length now: header (108) + N×32
+        # chunk hashes + 64-byte signature. The signature comes
+        # after the variable-length body, so we recover total_chunks
+        # from the header to compute where the body ends.
+        if len(wire) < _HEADER_LEN + _SIG_LEN:
             return None
-
-        body = wire[:_BODY_LEN]
-        signature = wire[_BODY_LEN:]
-        try:
-            manifest = cls.from_body_bytes(body)
-        except ValueError:
-            return None
-        if not DMPCrypto.verify_signature(body, signature, manifest.sender_spk):
+        total_chunks = int.from_bytes(wire[80:84], "big")
+        # Two valid body shapes: legacy header-only, or header + N×32.
+        # Anything else fails ``from_body_bytes`` below.
+        body_candidates = (_HEADER_LEN, _HEADER_LEN + _CHUNK_HASH_LEN * total_chunks)
+        for body_len in body_candidates:
+            if len(wire) != body_len + _SIG_LEN:
+                continue
+            body = wire[:body_len]
+            signature = wire[body_len:]
+            try:
+                manifest = cls.from_body_bytes(body)
+            except ValueError:
+                return None
+            if not DMPCrypto.verify_signature(body, signature, manifest.sender_spk):
+                return None
+            break
+        else:
             return None
         # Refuse manifests whose expiry is too far in the future. A
         # legitimate sender publishes messages with TTLs of minutes to

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -123,13 +123,19 @@ class TestSendReceive:
         assert alice.add_contact("badhex", "zz") is False
         assert alice.add_contact("shortkey", "aabb") is False
 
-    def test_txt_records_fit_in_single_dns_string(self):
-        """Every published TXT value must be <= 255 bytes to fit a single DNS string.
+    def test_txt_records_split_to_dns_string_limits(self):
+        """Each character-string in a TXT record must be <= 255 bytes.
 
-        Real DNS backends (BIND UPDATE, Route53, dnsmasq) publish one string
-        per record by default. A record that exceeds 255 bytes either gets
-        truncated, rejected, or silently splits in backend-specific ways.
+        DNS TXT records carry multiple character-strings per RR; the
+        wire limit is 255 bytes PER STRING, not per logical value.
+        Real backends (BIND UPDATE, Route53, dnsmasq) call
+        ``_split_txt_value`` to chunk long values into multiple
+        strings before transmission. The check here mirrors that —
+        every per-string fragment must fit, regardless of the
+        logical value's total size.
         """
+        from dmp.network.dns_publisher import _split_txt_value
+
         store = InMemoryDNSStore()
         alice, bob = _pair(store)
 
@@ -138,9 +144,10 @@ class TestSendReceive:
 
         for name in store.list_names():
             for value in store.query_txt_record(name) or []:
-                assert (
-                    len(value.encode("utf-8")) <= 255
-                ), f"TXT record at {name} is {len(value)} bytes — exceeds DNS per-string limit"
+                for fragment in _split_txt_value(value):
+                    assert (
+                        len(fragment.encode("utf-8")) <= 255
+                    ), f"TXT record at {name} produces a {len(fragment)}-byte fragment — exceeds DNS per-string limit"
 
     def test_transient_chunk_miss_does_not_blacklist(self):
         """Replay cache must not record a manifest until decrypt succeeds.
@@ -642,6 +649,78 @@ class TestSendReceive:
         )
         for chunk_num in range(parity):  # delete the first `parity` data chunks
             store.delete_txt_record(alice._chunk_domain(msg_key, chunk_num))
+
+        inbox = bob.receive_messages()
+        assert len(inbox) == 1
+        assert inbox[0].plaintext == payload
+
+    def test_chunk_rrset_wrap_block_garbage_refused_via_manifest_hashes(self):
+        # ``MessageChunker.unwrap_block`` is keyless (RS+checksum
+        # only), so an attacker can publish
+        # ``DMPDNSRecord(t=chunk, data=wrap_block(garbage))`` and
+        # the chunker accepts it. Without per-chunk content
+        # binding in the manifest, the receive path stored the
+        # garbage block, erasure decode produced corrupt bytes,
+        # AEAD failed → permanent message-level DoS.
+        #
+        # The manifest now carries SHA-256 of every wrapped chunk
+        # wire. The receiver hashes each candidate before
+        # ``unwrap_block`` and refuses anything that doesn't match
+        # the expected hash for that slot. A pool-token attacker
+        # can still APPEND to the RRset, but their appendage's
+        # hash can't match (the manifest is sender-signed).
+        import hashlib
+
+        from dmp.core.chunking import MessageChunker
+        from dmp.core.dns import DMPDNSRecord
+        from dmp.core.manifest import SlotManifest
+
+        store = InMemoryDNSStore()
+        alice, bob = _pair(store)
+        payload = b"A" * 800
+        assert alice.send_message("bob", payload.decode())
+
+        bob_recipient_id = hashlib.sha256(
+            bytes.fromhex(bob.get_public_key_hex())
+        ).digest()
+        manifest = None
+        for name in store.list_names():
+            if not name.startswith("slot-"):
+                continue
+            for value in store.query_txt_record(name) or []:
+                parsed = SlotManifest.parse_and_verify(value)
+                if parsed and parsed[0].recipient_id == bob_recipient_id:
+                    manifest = parsed[0]
+                    break
+            if manifest:
+                break
+        assert manifest is not None
+        assert manifest.chunk_hashes  # signed-in by send_message
+
+        msg_key = alice._msg_key(
+            manifest.msg_id, manifest.recipient_id, manifest.sender_spk
+        )
+
+        # Build a parseable + structurally-valid wrapped garbage
+        # block. ``unwrap_block`` accepts it; only the manifest's
+        # signed hash separates legit from poison.
+        chunker = MessageChunker(enable_error_correction=True)
+        garbage_block = b"\xcc" * MessageChunker.DATA_PER_CHUNK
+        garbage_wrapped = chunker.wrap_block(garbage_block)
+        garbage_record = DMPDNSRecord(
+            version=1, record_type="chunk", data=garbage_wrapped, metadata={}
+        ).to_txt_record()
+
+        # Force worst-case ordering: garbage BEFORE legit at every
+        # chunk RRset, so the receive loop has to skip past garbage
+        # to find the verified legit value.
+        for chunk_num in range(manifest.total_chunks):
+            chunk_name = alice._chunk_domain(msg_key, chunk_num)
+            legit_values = store.query_txt_record(chunk_name) or []
+            store.delete_txt_record(chunk_name)
+            store.publish_txt_record(chunk_name, garbage_record)
+            for v in legit_values:
+                store.publish_txt_record(chunk_name, v)
 
         inbox = bob.receive_messages()
         assert len(inbox) == 1


### PR DESCRIPTION
The chunker's `unwrap_block` is keyless — RS+checksum only — so any pool-token holder can compute `wrap_block(garbage_128_bytes)`, publish it as a chunk record, and have it sort ahead of the legitimate share in the RRset. Bob's receive path used to take the first decodable candidate; the garbage block landed in the erasure share dict, decode produced corrupt bytes, AEAD failed. Net: per-message DoS for any sender using the cluster.

Add per-chunk SHA-256 commitments to `SlotManifest`. The signed body now carries `chunk_hashes` (length = total_chunks, 32 bytes each). Sender hashes each wrapped chunk wire and embeds the digest list pre-signature. Receiver verifies each fetched candidate's hash against `manifest.chunk_hashes[chunk_num]` before unwrap; mismatches drop. The manifest is sender-signed so an attacker can't substitute a hash list.

Wire format is variable-length now (was fixed 172 bytes). Backward compat: an empty `chunk_hashes` parses as v0.6 and the receiver falls back to legacy best-effort decode (still poisonable until both sides upgrade). Manifest size grows by 32×total_chunks; the post-base64 record exceeds the 255-byte single-string DNS limit on multi-chunk messages, so publishers split via `_split_txt_value` at the wire layer (existing mechanism, now also covers manifests).

Test plan: new poison test forces worst-case ordering (garbage first, legit second) at every chunk slot — hash check skips garbage, finds legit, message delivers. Mutation removing the hash check fails the test. Existing `test_txt_records_split_to_dns_string_limits` updated to check per-string fragments after `_split_txt_value` instead of the obsolete single-string-≤255 assertion. Full unit + docker e2e green.