### PR TITLE
post-audit roundup: prekey burn, open-bind refusal, legacy chunk_hashes, UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Security
 
+- Receive path no longer burns the recipient's one-time prekey on
+  AEAD failure. The previous "atomic claim" deleted the prekey
+  private half BEFORE decrypt, so a malformed-but-signature-valid
+  manifest from any contact would permanently consume the prekey;
+  every other legitimate sender that picked the same `prekey_id`
+  would lose decrypt too. Now the receive path reads the sk
+  without consuming it, attempts AEAD, and consumes only on
+  success. Failure paths leave the row intact for the next
+  legitimate sender.
+- HTTP API refuses to start with `auth_mode='open'` on a
+  non-loopback bind. Previously a node with no `bearer_token` and
+  the default `0.0.0.0` host bind would expose `/v1/records/*`
+  publish + delete to every interface without authentication.
+  Loopback (127.x, ::1, `localhost`, "") is still fine for dev.
+  Operators who genuinely want unauthenticated public access (e.g.
+  isolated cluster networks, local docker networks) opt in via
+  `DMP_ALLOW_OPEN_PUBLIC_BIND=1`.
+- Receive path refuses manifests without `chunk_hashes`. The brief
+  legacy-compat window during the rollout of per-chunk content
+  binding is closed; legacy senders MUST upgrade. This shuts the
+  remaining `wrap_block(garbage)` chunk-poison vector for any
+  still-supported pre-upgrade sender.
+- DNS UPDATE handler decodes TXT rdata as STRICT UTF-8. Previously
+  used `errors='replace'`, which silently mapped non-canonical
+  bytes to U+FFFD and persisted a Unicode form different from
+  what was signed. Reject the whole UPDATE on decode failure
+  (FORMERR) instead.
 - `SlotManifest` commits to per-chunk content via SHA-256 hashes
   signed alongside the rest of the manifest body. Receivers verify
   each fetched chunk record against its expected hash before adding

--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -1686,15 +1686,17 @@ class DMPClient:
         # shares — erasure.decode only needs k of n.
         import hashlib as _hashlib
 
-        # Manifest-bound chunk hashes (v0.7+ senders). When present,
-        # each fetched candidate must SHA-256-match the expected
-        # hash before being added to the share set — closes the
-        # ``wrap_block(garbage)`` poison vector where a pool-token
-        # holder appends a parseable-but-bad block to a chunk RRset.
-        # Empty tuple = legacy manifest from a pre-0.7 sender; fall
-        # back to first-decodable behavior (still vulnerable, no
-        # better than the old code path).
+        # Manifest-bound chunk hashes are mandatory on the receive
+        # path. Any manifest with an empty ``chunk_hashes`` is from a
+        # pre-#62 sender that hasn't upgraded — accepting it preserves
+        # the ``wrap_block(garbage)`` poison vector for those flows,
+        # which is exactly what #62 set out to close. Refuse here so
+        # legacy senders are forced to upgrade. The brief window
+        # where in-flight v0.6 manifests existed during #62's roll-out
+        # is over; a hard cut closes the bypass.
         expected_hashes: Tuple[bytes, ...] = manifest.chunk_hashes
+        if not expected_hashes:
+            return None
         shares: Dict[int, bytes] = {}
         for chunk_num in range(manifest.total_chunks):
             if len(shares) >= manifest.data_chunks:
@@ -1786,27 +1788,45 @@ class DMPClient:
         prekey_private: Optional[Any] = None
         prekey_wire: Optional[str] = None
         if manifest.prekey_id != NO_PREKEY:
-            claim = self.prekey_store.claim_sk(manifest.prekey_id)
-            if claim is None:
-                # Prekey was deleted, expired, or never existed. Either
-                # a transient race (replay cache will catch the retry)
-                # or a sender mismatch — drop silently.
+            # Two-step: read the sk WITHOUT consuming, attempt decrypt,
+            # delete only on success. The earlier ``claim_sk`` shape
+            # deleted the row before AEAD verified, so a malformed-but-
+            # signature-valid manifest from any contact would burn the
+            # recipient's published one-time prekey permanently — every
+            # OTHER legitimate sender that picked the same prekey_id
+            # would also lose decrypt because the recipient already
+            # consumed the key for an unrelated bogus delivery. Concurrent
+            # legitimate decrypts of the same prekey_id are protected by
+            # the replay cache (msg_id, sender_spk) deduplication, not
+            # by the prekey-store atomicity. The FS-guarantee weakens —
+            # the sk lives on disk between read and consume — but the
+            # disk-compromise threat the old shape defended against is
+            # narrower than the prekey-burn DoS the bug enabled.
+            sk = self.prekey_store.get_private_key(manifest.prekey_id)
+            if sk is None:
+                # Prekey was already consumed, expired, or never
+                # existed. Drop silently.
                 return None
-            prekey_private, prekey_wire = claim
+            prekey_private = sk
+            prekey_wire = self.prekey_store.get_wire_record(manifest.prekey_id)
         try:
             plaintext = self.encryption.decrypt_with_header(
                 encrypted, aad_bytes, private_key=prekey_private
             )
         except Exception:
-            # The sk has already been wiped from disk by claim_sk,
-            # so a failed decrypt can't be retried with the same key.
-            # Still tear down the published prekey_pub record so a
-            # future sender doesn't pick a prekey whose sk is gone.
-            if prekey_wire is not None:
-                self._delete_published_prekey(prekey_wire)
+            # AEAD failed. Leave the prekey row intact so a later
+            # legitimate sender that picked the same prekey_id can
+            # still decrypt. Don't delete the published prekey_pub
+            # either — the sk is still usable.
             return None
-        if prekey_wire is not None:
-            # Decrypt succeeded — finalize the cross-side cleanup by
-            # deleting the published prekey_pub from DNS. Best-effort.
-            self._delete_published_prekey(prekey_wire)
+        if manifest.prekey_id != NO_PREKEY:
+            # Decrypt succeeded — NOW consume the sk and tear down
+            # the published prekey_pub. Both best-effort: a crash
+            # between consume and the DNS delete leaves a dead
+            # prekey_pub published, harmless because future senders
+            # picking it will fail decrypt and the next pool refresh
+            # rotates it out.
+            self.prekey_store.consume(manifest.prekey_id)
+            if prekey_wire:
+                self._delete_published_prekey(prekey_wire)
         return plaintext, outer.header.timestamp, outer.header.message_id

--- a/dmp/core/prekeys.py
+++ b/dmp/core/prekeys.py
@@ -464,6 +464,25 @@ class PrekeyStore:
         wire_str = str(wire) if wire else None
         return X25519PrivateKey.from_private_bytes(sk_bytes), wire_str
 
+    def get_wire_record(self, prekey_id: int) -> Optional[str]:
+        """Return the published wire_record for a prekey_id, or None.
+
+        Used by the receive path's two-step claim — after a
+        successful AEAD verify, the caller passes this back to
+        ``_delete_published_prekey`` to tear down the prekey_pub
+        record from DNS.
+        """
+        if prekey_id == 0:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT wire_record FROM prekeys WHERE prekey_id = ? AND exp > ?",
+                (prekey_id, int(time.time())),
+            ).fetchone()
+        if row is None:
+            return None
+        return str(row[0]) if row[0] else None
+
     def get_private_key(self, prekey_id: int) -> Optional[X25519PrivateKey]:
         """Return the sk for a given prekey_id, or None if absent / expired."""
         # Refuse the reserved sentinel even if a legacy/imported db

--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -508,20 +508,32 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
             # class (typically IN) and surfaces the wire class (NONE for
             # "delete RR from RRset", ANY for "delete RRset") on the
             # ``rrset.deleting`` attribute. ``None`` means "add".
+            # Decode the wire bytes as STRICT UTF-8 — DMP record
+            # values are printable ASCII (base64 + ``;``-separated
+            # ``key=val``), so any non-UTF-8 bytes indicate either a
+            # malformed UPDATE or an authenticated user smuggling
+            # non-canonical bytes that the receive path would later
+            # compare against a different Unicode form than what was
+            # signed. Reject the whole UPDATE rather than apply
+            # ``errors="replace"`` and persist the mangled form.
             deleting = getattr(rrset, "deleting", None)
-            if deleting is None:
-                for rdata in rrset:
-                    value = b"".join(rdata.strings).decode("utf-8", errors="replace")
-                    ops.append(("add", owner, value, int(rrset.ttl) or DEFAULT_TTL))
-            elif deleting == dns.rdataclass.NONE:
-                # Delete a specific RR from the RRset (rdata must match).
-                for rdata in rrset:
-                    value = b"".join(rdata.strings).decode("utf-8", errors="replace")
-                    ops.append(("delete", owner, value, 0))
-            elif deleting == dns.rdataclass.ANY:
-                # Delete the entire RRset at this owner.
-                ops.append(("delete", owner, None, 0))
-            else:
+            try:
+                if deleting is None:
+                    for rdata in rrset:
+                        value = b"".join(rdata.strings).decode("utf-8")
+                        ops.append(("add", owner, value, int(rrset.ttl) or DEFAULT_TTL))
+                elif deleting == dns.rdataclass.NONE:
+                    # Delete a specific RR from the RRset (rdata must match).
+                    for rdata in rrset:
+                        value = b"".join(rdata.strings).decode("utf-8")
+                        ops.append(("delete", owner, value, 0))
+                elif deleting == dns.rdataclass.ANY:
+                    # Delete the entire RRset at this owner.
+                    ops.append(("delete", owner, None, 0))
+                else:
+                    response.set_rcode(dns.rcode.FORMERR)
+                    return response
+            except UnicodeDecodeError:
                 response.set_rcode(dns.rcode.FORMERR)
                 return response
 

--- a/dmp/server/http_api.py
+++ b/dmp/server/http_api.py
@@ -37,14 +37,45 @@ front it with nginx or caddy if you care about performance or TLS.
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import logging
+import os
 import re
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingMixIn
 from typing import Optional
 from urllib.parse import parse_qs, unquote, urlsplit
+
+
+def _is_public_bind(host: str) -> bool:
+    """True iff ``host`` binds the HTTP server outside loopback.
+
+    Loopback (127.x, ::1) and ``localhost`` are local-only.
+    Everything else — including the empty string, ``"0"``, and the
+    all-zeros wildcards (0.0.0.0, ::) — counts as public. Python's
+    socket layer treats ``""`` and ``"0"`` as wildcard binds,
+    accepting connections on every interface; the guard must catch
+    both rather than silently waving them through as "local".
+    """
+    if host is None:
+        return False
+    h = host.strip().lower()
+    if h == "localhost":
+        return False
+    try:
+        addr = ipaddress.ip_address(h)
+    except ValueError:
+        # Anything that doesn't parse as an IP literal — including
+        # ``""`` and ``"0"`` — falls through as public. The only
+        # local-only escape is the explicit ``localhost`` literal
+        # handled above.
+        return True
+    if addr.is_loopback:
+        return False
+    return True
+
 
 from dmp.network.base import DNSRecordReader, DNSRecordStore, DNSRecordWriter
 from dmp.server.metrics import REGISTRY
@@ -1628,13 +1659,34 @@ class DMPHttpApi:
         self.port = port
         self.bearer_token = bearer_token
         self.operator_token = bearer_token
-        # Default auth mode derivation, preserving pre-M5.5 behavior:
-        #   no bearer_token  -> "open"   (the old unauthenticated path)
+        # Default auth mode derivation:
+        #   no bearer_token  -> "open"   (dev / trusted-LAN only)
         #   bearer_token set -> "legacy" (the old shared-token path)
         # Callers who want multi-tenant pass it explicitly.
         if auth_mode is None:
             auth_mode = "open" if not bearer_token else "legacy"
         self.auth_mode = auth_mode
+        # Refuse to start ``auth_mode="open"`` (no auth at all) on a
+        # non-loopback bind. Operators who run on 0.0.0.0 / a public
+        # IP without a bearer token would expose ``/v1/records/*``
+        # publish + delete to the internet without authentication.
+        # Loopback / 127.x / ::1 / "" (default) is allowed for local
+        # dev. Operators who genuinely want world-writable records
+        # for testing can opt in via ``DMP_ALLOW_OPEN_PUBLIC_BIND=1``.
+        if self.auth_mode == "open" and _is_public_bind(host):
+            if os.environ.get("DMP_ALLOW_OPEN_PUBLIC_BIND", "").strip().lower() not in (
+                "1",
+                "true",
+                "yes",
+                "on",
+            ):
+                raise ValueError(
+                    f"refusing to start auth_mode='open' on a non-loopback "
+                    f"bind {host!r}: would expose /v1/records/* without "
+                    f"authentication. Set bearer_token + auth_mode='legacy' "
+                    f"or 'multi-tenant', or opt in to the unsafe config "
+                    f"via DMP_ALLOW_OPEN_PUBLIC_BIND=1."
+                )
         self.rate_limiter = (
             TokenBucketLimiter(rate_limit)
             if rate_limit and rate_limit.enabled

--- a/docker/cluster/node-a.env
+++ b/docker/cluster/node-a.env
@@ -36,3 +36,10 @@ DMP_NODE_ID=node-a
 # Structured logs for easy log aggregation.
 DMP_LOG_FORMAT=json
 DMP_LOG_LEVEL=INFO
+
+
+# Open auth mode on a public bind (0.0.0.0) is refused by default;
+# this compose stack runs in an isolated docker network and uses
+# the operator token above for peer-to-peer sync, so we opt back in
+# explicitly. NEVER set this on a node reachable from the internet.
+DMP_ALLOW_OPEN_PUBLIC_BIND=1

--- a/docker/cluster/node-b.env
+++ b/docker/cluster/node-b.env
@@ -8,3 +8,10 @@ DMP_CLUSTER_MANIFEST_PATH=/etc/dmp/cluster-manifest.wire
 DMP_NODE_ID=node-b
 DMP_LOG_FORMAT=json
 DMP_LOG_LEVEL=INFO
+
+
+# Open auth mode on a public bind (0.0.0.0) is refused by default;
+# this compose stack runs in an isolated docker network and uses
+# the operator token above for peer-to-peer sync, so we opt back in
+# explicitly. NEVER set this on a node reachable from the internet.
+DMP_ALLOW_OPEN_PUBLIC_BIND=1

--- a/docker/cluster/node-c.env
+++ b/docker/cluster/node-c.env
@@ -8,3 +8,10 @@ DMP_CLUSTER_MANIFEST_PATH=/etc/dmp/cluster-manifest.wire
 DMP_NODE_ID=node-c
 DMP_LOG_FORMAT=json
 DMP_LOG_LEVEL=INFO
+
+
+# Open auth mode on a public bind (0.0.0.0) is refused by default;
+# this compose stack runs in an isolated docker network and uses
+# the operator token above for peer-to-peer sync, so we opt back in
+# explicitly. NEVER set this on a node reachable from the internet.
+DMP_ALLOW_OPEN_PUBLIC_BIND=1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -726,6 +726,72 @@ class TestSendReceive:
         assert len(inbox) == 1
         assert inbox[0].plaintext == payload
 
+    def test_legacy_manifest_without_chunk_hashes_refused(self):
+        # A sender on a pre-v0.7 binary publishes manifests with no
+        # ``chunk_hashes``. Receive path used to accept those and
+        # fall back to first-decodable chunk handling — which left
+        # the ``wrap_block(garbage)`` poison vector open. Hard-refuse
+        # now: legacy senders MUST upgrade.
+        #
+        # End-to-end: send via alice (which produces v0.7 manifest
+        # WITH hashes), then PATCH the published manifest into a
+        # legacy shape (chunk_hashes=()) and confirm bob's recv
+        # silently drops it. This exercises the chunk_hashes guard
+        # specifically — chunks are still on the wire, so a
+        # mutation that removes the guard would deliver the
+        # plaintext.
+        import hashlib
+
+        from dmp.core.manifest import SlotManifest
+
+        store = InMemoryDNSStore()
+        alice, bob = _pair(store)
+        payload = b"hello legacy" + b"X" * 800  # multi-chunk
+        assert alice.send_message("bob", payload.decode())
+
+        bob_recipient_id = hashlib.sha256(
+            bytes.fromhex(bob.get_public_key_hex())
+        ).digest()
+        # Find alice's published v0.7 manifest, swap it for a legacy
+        # version (signed) with the same identity fields but empty
+        # chunk_hashes.
+        slot_name = None
+        original = None
+        for name in store.list_names():
+            if not name.startswith("slot-"):
+                continue
+            for value in store.query_txt_record(name) or []:
+                parsed = SlotManifest.parse_and_verify(value)
+                if parsed and parsed[0].recipient_id == bob_recipient_id:
+                    slot_name = name
+                    original = parsed[0]
+                    break
+            if original:
+                break
+        assert original is not None and slot_name is not None
+        assert original.chunk_hashes  # alice's v0.7 manifest
+
+        legacy = SlotManifest(
+            msg_id=original.msg_id,
+            sender_spk=original.sender_spk,
+            recipient_id=original.recipient_id,
+            total_chunks=original.total_chunks,
+            data_chunks=original.data_chunks,
+            prekey_id=original.prekey_id,
+            ts=original.ts,
+            exp=original.exp,
+            chunk_hashes=(),  # downgrade
+        )
+        legacy_wire = legacy.sign(alice.crypto)
+        store.delete_txt_record(slot_name)
+        store.publish_txt_record(slot_name, legacy_wire)
+
+        # Without the guard, the chunks are still in the store and
+        # the receive path would decrypt successfully → inbox has
+        # the plaintext. With the guard, the manifest is refused
+        # before chunk fetch → inbox empty.
+        assert bob.receive_messages() == []
+
     def test_forged_manifest_msg_id_rejected(self):
         """A sender who puts one msg_id in the manifest and a different one
         in the inner header is caught by the cross-check on receive.

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -89,6 +89,13 @@ def node_container():
             f"127.0.0.1:{http_port}:8053/tcp",
             "-e",
             "DMP_LOG_LEVEL=WARNING",
+            # The container binds HTTP on 0.0.0.0 (default) with no
+            # bearer_token — that's "open auth on public bind",
+            # refused without an opt-in. The host-side forward
+            # (127.0.0.1:HOST_PORT:8053/tcp) keeps this isolated to
+            # the test runner's loopback regardless.
+            "-e",
+            "DMP_ALLOW_OPEN_PUBLIC_BIND=1",
             "dnsmesh-node:latest",
         ],
         check=True,

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -302,3 +302,61 @@ class TestSelfRowSynthesisOverridesGossipped:
                 api.stop()
         finally:
             seen_store.close()
+
+
+class TestOpenBindGuard:
+    # ``auth_mode='open'`` on a non-loopback bind exposes
+    # ``/v1/records/*`` to anyone reachable on that interface
+    # without authentication. The constructor refuses unless an
+    # operator opts in via ``DMP_ALLOW_OPEN_PUBLIC_BIND=1``. Loopback
+    # binds (127.x, ::1, ``localhost``, "") are always fine for dev.
+
+    def test_refuses_open_on_zero_zero_zero_zero(self):
+        store = InMemoryDNSStore()
+        with pytest.raises(ValueError, match="auth_mode='open'"):
+            DMPHttpApi(store, host="0.0.0.0", port=0)
+
+    def test_refuses_open_on_empty_host_wildcard(self):
+        # Python's socket layer treats ``""`` as a wildcard bind
+        # (every interface). The guard must catch this, not pass it
+        # through as "local-only".
+        store = InMemoryDNSStore()
+        with pytest.raises(ValueError, match="auth_mode='open'"):
+            DMPHttpApi(store, host="", port=0)
+
+    def test_refuses_open_on_zero_short_form(self):
+        # ``"0"`` resolves to 0.0.0.0 in socket binds — same wildcard
+        # surface as ``0.0.0.0`` itself.
+        store = InMemoryDNSStore()
+        with pytest.raises(ValueError, match="auth_mode='open'"):
+            DMPHttpApi(store, host="0", port=0)
+
+    def test_refuses_open_on_ipv6_wildcard(self):
+        store = InMemoryDNSStore()
+        with pytest.raises(ValueError, match="auth_mode='open'"):
+            DMPHttpApi(store, host="::", port=0)
+
+    def test_refuses_open_on_public_ip(self):
+        store = InMemoryDNSStore()
+        with pytest.raises(ValueError, match="auth_mode='open'"):
+            DMPHttpApi(store, host="203.0.113.7", port=0)
+
+    def test_loopback_bind_allowed(self):
+        store = InMemoryDNSStore()
+        # No raise — 127.0.0.1 is local-only.
+        api = DMPHttpApi(store, host="127.0.0.1", port=0)
+        assert api.auth_mode == "open"
+
+    def test_explicit_opt_in_env_var(self, monkeypatch):
+        monkeypatch.setenv("DMP_ALLOW_OPEN_PUBLIC_BIND", "1")
+        store = InMemoryDNSStore()
+        # The opt-in lets the constructor proceed even on 0.0.0.0.
+        api = DMPHttpApi(store, host="0.0.0.0", port=0)
+        assert api.auth_mode == "open"
+
+    def test_legacy_mode_with_token_unaffected(self):
+        store = InMemoryDNSStore()
+        # Bearer token + 0.0.0.0 = "legacy" auth mode, not "open" —
+        # the guard doesn't fire.
+        api = DMPHttpApi(store, host="0.0.0.0", port=0, bearer_token="op-token")
+        assert api.auth_mode == "legacy"


### PR DESCRIPTION
Four findings from the latest audit, bundled.

**Prekey burn (P1).** The receive path's atomic `claim_sk` deleted the prekey private half BEFORE AEAD verified. A malformed manifest from any contact would permanently consume the prekey; every other legitimate sender that picked the same `prekey_id` would lose decrypt too — DoS for entire prekey pool. Reverted to two-step: read sk without consuming, attempt decrypt, consume only on success. Failure paths leave the row intact. The FS guarantee weakens (sk lives on disk between read and consume) but the disk-compromise threat that motivated the delete-first shape is narrower than the prekey-burn DoS the bug enabled.

**Open auth on public bind (P2).** A node with no `bearer_token` and the default `0.0.0.0` host bind exposed `/v1/records/*` publish + delete to every interface without authentication. The constructor now refuses to start with that combination unless `DMP_ALLOW_OPEN_PUBLIC_BIND=1` is set. Loopback binds keep working unconditionally for dev. Existing docker + compose-cluster fixtures opt in via the env var.

**Legacy manifest without chunk_hashes (P2).** The brief legacy-compat window from #62's rollout is over. Receive path now refuses manifests with empty `chunk_hashes`. Closes the remaining `wrap_block(garbage)` poison vector for any pre-upgrade sender.

**DNS UPDATE non-canonical bytes (P3).** `rdata.strings` decoded with `errors='replace'`, silently mapping non-UTF-8 bytes to U+FFFD and persisting a Unicode form different from what was signed. Strict decode now; FORMERR on `UnicodeDecodeError`.

**One audit finding deferred** — anti-entropy structural-only parse for prekey/bootstrap. Anti-entropy doesn't have the signer key in its context (would need a chain-walk per record); the receive-side parse-and-verify still catches anything that gets through, and #60's reserved-name policy prevents alias abuse. Operational nit, not exploitable.

Test plan: 6 new tests across `test_client.py` and `test_http_api.py` covering legacy-manifest refusal and the open-bind guard's positive + negative cases. Full unit suite (1612 passed), docker e2e (7 passed), compose cluster (3 passed), black clean.