### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-05 — security audit roundup
+
+Multi-pass security audit cycle with fifteen merged PRs (#52–#66)
+plus three follow-up issues (#63 KDF transcript binding, #64
+canonical AAD, #65 Cloudflare/Route53 publisher overwrite) tracked
+for future cycles.
+
+The wire format gained per-chunk content-binding hashes inside
+`SlotManifest` and the TSIG-mint flow now requires X25519
+proof-of-possession via a challenge-response. Receivers refuse
+pre-#62 manifests outright, so v0.7.0 senders MUST be paired with
+v0.7.0 receivers — there is no in-flight legacy-compat window.
+
 ### Security
 
 - Receive path no longer burns the recipient's one-time prekey on

--- a/dmp/__init__.py
+++ b/dmp/__init__.py
@@ -1,3 +1,3 @@
 """DNS Mesh Protocol - Federated end-to-end encrypted messaging over DNS"""
 
-__version__ = "0.6.6"
+__version__ = "0.7.0"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # The import path stays `import dmp` — distribution name and
     # import name intentionally differ (same pattern as pyyaml → yaml).
     name="dnsmesh",
-    version="0.6.6",
+    version="0.7.0",
     author="Oscar Valenzuela B",
     author_email="oscar.valenzuela.b@gmail.com",
     description="A federated end-to-end encrypted messaging protocol delivered over DNS",


### PR DESCRIPTION
Closes the security-audit cycle from this session — fifteen merged PRs (#52–#66) plus three follow-up issues (#63, #64, #65) tracked for later.

**Wire format**: per-chunk content binding inside `SlotManifest` (#62), TSIG self-service registration now requires X25519 proof-of-possession (#61). Receivers refuse pre-#62 manifests outright (#66). v0.7.0 senders MUST be paired with v0.7.0 receivers — no in-flight legacy-compat window.

**Operational tightening**: HTTP API refuses to start with `auth_mode='open'` on non-loopback bind without explicit opt-in; DNS UPDATE handler decodes TXT rdata as strict UTF-8; legacy publishers (LocalDNSPublisher) reject dnsmasq config-injection inputs; anti-entropy refuses unknown DMP records and aliases at reserved owner names; TSIG keys can't DELETE through wildcard suffixes.

**Crypto hardening**: typed `DnssecValidationError` for the cluster reader; rotation-chain walker bound to polled zone; slot-walk sender_spk pin bound to polled zone; AD-bit gate on positive AND negative DNS responses; AD-less drops logged at every reader.

**Storage**: `PrekeyStore` + `TSIGKeyStore` parent-dir + WAL/SHM file perms tightened; `IntroQueue` requires explicit path; `DMPClient` requires explicit prekey/intro paths; shared-pool tokens can't DELETE chunks.

Full per-PR detail in CHANGELOG.

After merge: tag `cli-v0.7.0` and `sdk-v0.7.0` to match existing release naming.