### PR TITLE
fix(dns): TCP handler crashed on negative responses and TSIG UPDATEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- TSIG DNS UPDATEs (and any TCP-fallback query) crashed the DNS
+  server's response builder with `AttributeError` because
+  `_DMPTCPRequestHandler` aliased `_build_response` /
+  `_build_update_response` from the UDP handler but not the helper
+  methods they call (`_attach_negative_authority`,
+  `_build_apex_soa_rrset`). The dispatcher's blanket `except` turned
+  the crash into a SERVFAIL; for UPDATEs that surfaced as a 0-byte
+  UDP packet, which dnspython rejects with `ShortHeader`. Symptom on
+  the client side was a publish failure with no useful diagnostic.
+  Aliased the helpers and added a TCP NXDOMAIN regression test.
+- `dnsmesh identity publish` on the TSIG-based writer raised
+  `AttributeError: 'last_status'` from `_publish_failure_msg` instead
+  of printing a clean error. The helper now uses `getattr` with
+  defaults so any `DNSRecordWriter` backend produces a usable message.
+
 ## [0.7.0] — 2026-05-05 — security audit roundup
 
 Multi-pass security audit cycle with fifteen merged PRs (#52–#66)

--- a/dmp/cli.py
+++ b/dmp/cli.py
@@ -431,11 +431,17 @@ class _HttpWriter(DNSRecordWriter):
         return r.status_code == 204
 
 
-def _publish_failure_msg(writer: "_HttpWriter", name: str) -> str:
+def _publish_failure_msg(writer: DNSRecordWriter, name: str) -> str:
     """Build a one-line failure message that surfaces the actual HTTP
-    status + server-side reason instead of "see node logs"."""
-    status = writer.last_status
-    err = writer.last_error or ""
+    status + server-side reason instead of "see node logs".
+
+    Only ``_HttpWriter`` records ``last_status`` / ``last_error``; the
+    TSIG-based ``_DnsUpdateWriter`` and other backends don't, so guard
+    the attribute access. Without this, a publish failure on the TSIG
+    path crashed the CLI with AttributeError instead of a clean error.
+    """
+    status = getattr(writer, "last_status", None)
+    err = getattr(writer, "last_error", None) or ""
     base = f"publish to {name} failed"
     if status is None:
         return f"{base} — no response captured"

--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -992,6 +992,13 @@ class _DMPTCPRequestHandler(socketserver.BaseRequestHandler):
     # like normal methods when called on an instance.
     _build_response = _DMPRequestHandler._build_response
     _build_update_response = _DMPRequestHandler._build_update_response
+    # Helpers transitively called from ``_build_response`` —
+    # ``_build_apex_soa_rrset`` for positive-answer SOA assembly and
+    # ``_attach_negative_authority`` for NXDOMAIN / NoData responses.
+    # Without these aliases, a TCP-fallback query (e.g. a TSIG UPDATE
+    # too large for UDP) crashes with AttributeError mid-response.
+    _attach_negative_authority = _DMPRequestHandler._attach_negative_authority
+    _build_apex_soa_rrset = _DMPRequestHandler._build_apex_soa_rrset
 
     # Bound the per-connection read so a slow / hostile client can't
     # tie up a worker thread waiting for bytes that never come.

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -345,9 +345,7 @@ class TestDMPDnsServerApexAddressRecords:
             # An owner name that doesn't exist — exercises the
             # NXDOMAIN / empty-answer path that calls
             # ``_attach_negative_authority``.
-            request = dns.message.make_query(
-                "no-such.dmp.mesh.test", dns.rdatatype.TXT
-            )
+            request = dns.message.make_query("no-such.dmp.mesh.test", dns.rdatatype.TXT)
             response = dns.query.tcp(request, "127.0.0.1", port=port, timeout=2.0)
 
         # The handler must complete the negative response normally.

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -319,6 +319,52 @@ class TestDMPDnsServerApexAddressRecords:
         assert len(response.answer) == 1
         assert str(response.answer[0][0]) == "203.0.113.42"
 
+    def test_tcp_handler_aliases_negative_authority_helpers(self):
+        """A TCP query for a non-existent name must produce a clean
+        response, not crash. The TCP handler aliases ``_build_response``
+        from the UDP handler, so it has to also alias every helper that
+        ``_build_response`` calls — including ``_attach_negative_authority``
+        and ``_build_apex_soa_rrset``. A regression where only
+        ``_build_response`` was aliased (and not its transitive deps)
+        crashed the response builder mid-flight, leaving the listener
+        emitting 0-byte UDP / empty TCP frames. TSIG UPDATEs are the
+        canary because they're typically too large for UDP and fall back
+        to TCP for the actual write.
+        """
+        store = InMemoryDNSStore()
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            apex_zone="dmp.mesh.test",
+            apex_a="203.0.113.42",
+            apex_ns="ns1.dmp.mesh.test",
+            apex_soa_rname="hostmaster.dmp.mesh.test",
+        ):
+            # An owner name that doesn't exist — exercises the
+            # NXDOMAIN / empty-answer path that calls
+            # ``_attach_negative_authority``.
+            request = dns.message.make_query(
+                "no-such.dmp.mesh.test", dns.rdatatype.TXT
+            )
+            response = dns.query.tcp(request, "127.0.0.1", port=port, timeout=2.0)
+
+        # The handler must complete the negative response normally.
+        # Pre-fix, the AttributeError on ``self._attach_negative_authority``
+        # was caught by the dispatcher's blanket ``except Exception`` and
+        # converted to SERVFAIL — so a SERVFAIL on a clearly-NXDOMAIN
+        # query is the smoking gun for the missing alias.
+        assert response.rcode() != dns.rcode.SERVFAIL, (
+            "TCP handler returned SERVFAIL on NXDOMAIN — likely missing a "
+            "method alias from _DMPRequestHandler"
+        )
+        # And the apex SOA must be in AUTHORITY per RFC 2308 §3, which
+        # only happens if ``_attach_negative_authority`` actually ran.
+        assert any(
+            rrset.rdtype == dns.rdatatype.SOA for rrset in response.authority
+        ), "expected apex SOA in AUTHORITY section of negative response"
+
 
 class TestDMPDnsServerApexSoaNs:
     """Strict recursive resolvers (Google 8.8.8.8, Level3 4.2.2.x)


### PR DESCRIPTION
## Summary

The DNS server's TCP request handler aliases `_build_response` and `_build_update_response` from the UDP handler at class definition time, but it doesn't alias the two helper methods those call internally — `_attach_negative_authority` and `_build_apex_soa_rrset`. Any negative response over TCP (NXDOMAIN / NoData) and any TSIG UPDATE that exceeds the UDP MTU and falls back to TCP hit `AttributeError` mid-response.

The dispatcher's blanket `except Exception` swallowed the crash and produced SERVFAIL for normal queries. For UPDATE specifically, the response came out as a 0-byte UDP datagram that dnspython rejects with `ShortHeader` on the client side. End result: `dnsmesh identity publish` over the TSIG writer fails with no useful error.

I caught this debugging a real publish failure on a deployed v0.6.6 node — the same pattern is in main.

## What changed

- `dmp/server/dns_server.py` — aliased `_attach_negative_authority` and `_build_apex_soa_rrset` on `_DMPTCPRequestHandler`, with a comment explaining why all four aliases are needed together.
- `dmp/cli.py` — `_publish_failure_msg` read `writer.last_status` directly. That field exists on `_HttpWriter` only, so a TSIG-writer failure crashed the CLI's error path with `AttributeError` instead of printing a clean message. Switched to `getattr` with defaults so every `DNSRecordWriter` backend produces a useful diagnostic.
- `tests/test_dns_server.py` — added a TCP NXDOMAIN test. Without the fix it returns SERVFAIL with no SOA in AUTHORITY; with the fix it returns the expected negative response shape.
- `CHANGELOG.md` — Unreleased / Fixed entries.

## Test plan

- [x] `pytest tests/test_dns_server.py tests/test_cli.py` — 195 passed
- [x] Verified the new test fails on main without the fix (AttributeError → SERVFAIL → assertion fails) and passes with it
- [ ] Full CI: lint, type-check, py3.10/3.11/3.12, hypothesis fuzz, docker integration, pip-audit