### PR TITLE
release: 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-05-06 — TSIG UPDATE fix
+
+Operator-visible bug fix: TSIG-based DNS UPDATEs (the path
+`dnsmesh identity publish` uses when the config has a TSIG block)
+silently failed because the DNS server's TCP request handler crashed
+on the response-building path. Caught while debugging a real publish
+failure on a v0.6.6 deployed node; same bug in main.
+
 ### Fixed
 
 - TSIG DNS UPDATEs (and any TCP-fallback query) crashed the DNS
@@ -18,11 +26,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the crash into a SERVFAIL; for UPDATEs that surfaced as a 0-byte
   UDP packet, which dnspython rejects with `ShortHeader`. Symptom on
   the client side was a publish failure with no useful diagnostic.
-  Aliased the helpers and added a TCP NXDOMAIN regression test.
+  Aliased the helpers and added a TCP NXDOMAIN regression test
+  (#68).
 - `dnsmesh identity publish` on the TSIG-based writer raised
   `AttributeError: 'last_status'` from `_publish_failure_msg` instead
   of printing a clean error. The helper now uses `getattr` with
-  defaults so any `DNSRecordWriter` backend produces a usable message.
+  defaults so any `DNSRecordWriter` backend produces a usable message
+  (#68).
+
+### Tests
+
+- Added a docker-compose harness for cross-zone end-to-end validation
+  (`docker-compose.cross-zone.yml` + `tests/test_cross_zone_v07.py`).
+  The harness runs two nodes in distinct zones and exercises the
+  send/receive path operators actually deploy, plus a structural
+  check that v0.7.0's per-chunk `chunk_hashes` round-trip through the
+  manifest. Skipped automatically when the compose project isn't up,
+  so default CI behavior is unchanged (#69).
 
 ## [0.7.0] — 2026-05-05 — security audit roundup
 

--- a/dmp/__init__.py
+++ b/dmp/__init__.py
@@ -1,3 +1,3 @@
 """DNS Mesh Protocol - Federated end-to-end encrypted messaging over DNS"""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # The import path stays `import dmp` — distribution name and
     # import name intentionally differ (same pattern as pyyaml → yaml).
     name="dnsmesh",
-    version="0.7.0",
+    version="0.7.1",
     author="Oscar Valenzuela B",
     author_email="oscar.valenzuela.b@gmail.com",
     description="A federated end-to-end encrypted messaging protocol delivered over DNS",


### PR DESCRIPTION
## Summary

Bug-fix release covering the TSIG DNS UPDATE crash that broke `dnsmesh identity publish` on TSIG-configured clients (#68) and the CLI error-path AttributeError that masked it. Also lands the cross-zone end-to-end test harness from #69 (operator-only, skipped by default in CI).

No wire-format changes — 0.7.1 is drop-in over 0.7.0; nodes can roll forward without coordinating with their peers.

## What's in the release

- #68 — TCP handler crashed on negative responses and TSIG UPDATEs
- #69 — Cross-zone end-to-end fixture for v0.7.0 wire format

## Bumped

- `dmp/__init__.py`: `__version__ = "0.7.1"`
- `setup.py`: `version="0.7.1"`
- `CHANGELOG.md`: 0.7.1 section

## Test plan

- [ ] CI green
- [ ] After merge: tag `cli-v0.7.1` and `sdk-v0.7.1`, GitHub release publishes wheel
- [ ] Run `deploy/native-ubuntu/upgrade.sh` on the three production nodes (.io, .de, .pro)
- [ ] Re-run `dnsmesh identity publish` end-to-end via TSIG UPDATE