### PR TITLE
fix(dns): TSIG signature mismatch returns NOTAUTH instead of silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- TSIG signature mismatches now return a clean NOTAUTH instead of
+  silence. dnspython raises `dns.tsig.BadSignature` (a direct
+  subclass of `DNSException`, not of `PeerError`) when an incoming
+  UPDATE's TSIG verifies against a known keyring entry but the
+  signature itself doesn't match. The dispatcher's catch list only
+  covered `dns.tsig.PeerError`, so `BadSignature` (plus the parallel
+  `BadTime` and `BadKey` classes) fell into the generic "unparseable"
+  branch and `_process_dns_query` returned `None`. Result: no wire
+  bytes sent, requester saw a 0-byte UDP datagram, dnspython raised
+  `ShortHeader` on the receive side, and the operator got a publish
+  failure with no clue it was an auth failure. Added the bare
+  `dns.tsig.BadSignature` / `BadTime` / `BadKey` to the catch list
+  and a regression test that reproduces the exact `ShortHeader`
+  symptom without the fix.
+
 ## [0.7.1] — 2026-05-06 — TSIG UPDATE fix
 
 Operator-visible bug fix: TSIG-based DNS UPDATEs (the path

--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -859,12 +859,25 @@ def _process_dns_query(
         return None
 
     # Pass the keyring into ``from_wire`` so any TSIG signature on
-    # the incoming message is verified at parse time. dnspython raises:
-    #   - dns.tsig.PeerError (bad signature / time / truncation)
-    #   - dns.message.UnknownTSIGKey (key name not in keyring)
-    #   - dns.message.BadTSIG (malformed TSIG record)
-    # All three map to NOTAUTH — the request was authenticated by
-    # someone we can't or won't trust.
+    # the incoming message is verified at parse time. dnspython has
+    # two parallel TSIG-error hierarchies and we have to catch both:
+    #
+    #   - ``dns.tsig.PeerError`` family (PeerBadSignature, PeerBadKey,
+    #     PeerBadTime, PeerBadTruncation) — typically raised when WE
+    #     are validating a response we received. Subclasses of PeerError.
+    #   - ``dns.tsig.BadSignature`` / ``BadTime`` / ``BadKey`` — direct
+    #     subclasses of ``DNSException`` (NOT PeerError). Raised when
+    #     verifying an incoming UPDATE's TSIG against a known keyring
+    #     key whose secret doesn't match. Catching only ``PeerError``
+    #     misses these and the request falls into the generic
+    #     "unparseable" branch which returns ``None``: the requester
+    #     gets a 0-byte UDP datagram (dnspython surfaces it as
+    #     ``ShortHeader``) with no clue it was an auth failure.
+    #   - ``dns.message.UnknownTSIGKey`` — key name not in keyring.
+    #   - ``dns.message.BadTSIG`` — malformed TSIG record.
+    #
+    # All of these map to NOTAUTH: we authenticated the requester and
+    # don't (or can't) trust them.
     #
     # When a keystore is wired in, build a fresh keyring per packet
     # so newly-minted keys authorize without restarting the server.
@@ -877,6 +890,9 @@ def _process_dns_query(
         query = dns.message.from_wire(data, keyring=keyring)
     except (
         dns.tsig.PeerError,
+        dns.tsig.BadSignature,
+        dns.tsig.BadTime,
+        dns.tsig.BadKey,
         dns.message.UnknownTSIGKey,
         dns.message.BadTSIG,
     ) as e:

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -1208,6 +1208,54 @@ class TestDnsUpdate:
         assert response.rcode() == dns.rcode.NOTAUTH
         assert store.query_txt_record("foo.example.com") is None
 
+    def test_known_key_wrong_secret_is_notauth(self):
+        """A known key NAME with a mismatched secret must produce a
+        clean NOTAUTH response, not silence.
+
+        dnspython raises ``dns.tsig.BadSignature`` on signature
+        mismatch — a direct subclass of ``DNSException`` that does
+        NOT inherit from ``PeerError``. Pre-fix, the dispatcher only
+        caught the ``PeerError`` family + ``UnknownTSIGKey`` /
+        ``BadTSIG``, so ``BadSignature`` fell into the generic
+        "unparseable" branch and the handler returned ``None`` (no
+        wire bytes sent). The requester saw a 0-byte UDP datagram
+        and dnspython raised ``ShortHeader`` on the receive side,
+        masking what was really an auth failure.
+        """
+        store = InMemoryDNSStore()
+        # Server's keyring has the canonical secret for "alice.".
+        server_keyring = _keyring(name="alice.", secret=b"\x11" * 32)
+        port = _free_port()
+        with DMPDnsServer(
+            store,
+            host="127.0.0.1",
+            port=port,
+            writer=store,
+            tsig_keyring=server_keyring,
+            allowed_zones=("example.com",),
+        ):
+            # Client signs with the SAME key name but a DIFFERENT
+            # secret — the on-wire signature won't match what the
+            # server's HMAC computes.
+            upd = dns.update.UpdateMessage("example.com")
+            upd.add(
+                dns.name.from_text("foo.example.com."),
+                300,
+                "TXT",
+                '"intruder"',
+            )
+            upd.use_tsig(
+                _keyring(name="alice.", secret=b"\x22" * 32),
+                keyname=dns.name.from_text("alice."),
+            )
+            response = _send_update(upd, port)
+
+        assert response.rcode() == dns.rcode.NOTAUTH, (
+            "expected NOTAUTH on signature mismatch; pre-fix the server "
+            "returned no bytes and the client raised ShortHeader"
+        )
+        assert store.query_txt_record("foo.example.com") is None
+
     def test_zone_outside_allowed_list_is_notauth(self):
         """A signed UPDATE for a zone we don't claim authority for
         must be rejected even when the TSIG key is valid."""


### PR DESCRIPTION
## Summary

dnspython has two parallel TSIG-error hierarchies. The DNS server's dispatcher caught the `dns.tsig.PeerError` family (`PeerBadSignature`, `PeerBadKey`, `PeerBadTime`, `PeerBadTruncation`) plus `dns.message.UnknownTSIGKey` / `BadTSIG`. It did **not** catch the bare hierarchy: `dns.tsig.BadSignature` / `BadTime` / `BadKey`, which are direct subclasses of `DNSException` and are what dnspython actually raises when an incoming UPDATE's TSIG verifies against a known keyring entry whose secret doesn't match.

The bare exceptions fell into the generic "unparseable DNS packet" branch, `_process_dns_query` returned `None`, no wire bytes were sent. The requester saw a 0-byte UDP datagram and dnspython raised `ShortHeader` on the receive side — so a straightforward auth failure surfaced as a transport-layer mystery. I just spent an hour debugging this on a live node before realising it was a TSIG secret mismatch, because there was no log line and no rcode to point at.

## What changed

- `dmp/server/dns_server.py` — added `dns.tsig.BadSignature`, `BadTime`, `BadKey` to the catch list so the path returns a 12-byte NOTAUTH stub. Updated the comment block to document the two-hierarchy gotcha so the next person looking at this code sees why both are listed.
- `tests/test_dns_server.py` — `test_known_key_wrong_secret_is_notauth` reproduces the exact `ShortHeader` symptom on the unfixed code and asserts the fixed behaviour (NOTAUTH, no write).
- `CHANGELOG.md` — Unreleased / Fixed entry.

## Test plan

- [x] New regression test fails on `main` with `dns.message.ShortHeader` (the same exception the production client hit) and passes with the fix
- [x] Full `tests/test_dns_server.py` — 64 passed
- [ ] Full CI: lint, type-check, py3.10/11/12, hypothesis fuzz, docker integration, pip-audit