### PR TITLE
release: 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.2] — 2026-05-06 — TSIG signature mismatch returns NOTAUTH
+
+Operator-visible follow-up to 0.7.1. Caught while debugging a real
+TSIG secret mismatch on a deployed node — same family of "no
+diagnostic on a publish failure" bug we fixed in 0.7.1, different
+exception path.
+
 ### Fixed
 
 - TSIG signature mismatches now return a clean NOTAUTH instead of
@@ -22,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   failure with no clue it was an auth failure. Added the bare
   `dns.tsig.BadSignature` / `BadTime` / `BadKey` to the catch list
   and a regression test that reproduces the exact `ShortHeader`
-  symptom without the fix.
+  symptom without the fix (#71).
 
 ## [0.7.1] — 2026-05-06 — TSIG UPDATE fix
 

--- a/dmp/__init__.py
+++ b/dmp/__init__.py
@@ -1,3 +1,3 @@
 """DNS Mesh Protocol - Federated end-to-end encrypted messaging over DNS"""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # The import path stays `import dmp` — distribution name and
     # import name intentionally differ (same pattern as pyyaml → yaml).
     name="dnsmesh",
-    version="0.7.1",
+    version="0.7.2",
     author="Oscar Valenzuela B",
     author_email="oscar.valenzuela.b@gmail.com",
     description="A federated end-to-end encrypted messaging protocol delivered over DNS",


### PR DESCRIPTION
## Summary

Bug-fix release covering the TSIG signature-mismatch silent failure (#71). Same family as 0.7.1: a publish failure that surfaced as an opaque `ShortHeader` on the client because the server returned no bytes. Now returns NOTAUTH the way every other auth failure does.

No wire-format changes; safe drop-in over 0.7.1 / 0.7.0.

## What's in the release

- #71 — TSIG signature mismatch returns NOTAUTH instead of silence

## Bumped

- `dmp/__init__.py`: `__version__ = "0.7.2"`
- `setup.py`: `version="0.7.2"`
- `CHANGELOG.md`: 0.7.2 section

## Test plan

- [ ] CI green
- [ ] After merge: tag `cli-v0.7.2` and `sdk-v0.7.2`, GitHub release publishes wheel
- [ ] Run upgrade.sh on the three production nodes