### PR TITLE
fix(dns): UDP handler emitted a 0-byte trailing datagram per query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- DNS server stops emitting a 0-byte trailing UDP datagram after every
+  response. The UDP handler called `sock.sendto` directly while the
+  framework's `DatagramRequestHandler.finish()` also fires
+  `sendto(self.wfile.getvalue(), ...)` after `handle()` returns. With
+  wfile empty, finish() shipped a `b""` datagram right after every
+  legitimate response. dnspython on the receive side ignored the
+  duplicate (it accepts the first valid datagram), so this didn't
+  break clients, but tcpdump and any strict packet inspection flagged
+  it as `domain [length 0 < 12] (invalid)`. Wasted one full
+  send/receive on every query and on every silent-drop path.
+  Fixed by writing the response through `self.wfile` and overriding
+  `finish()` to skip the send when wfile is empty. Regression test
+  asserts exactly one UDP datagram is emitted per query.
+
 ## [0.7.2] — 2026-05-06 — TSIG signature mismatch returns NOTAUTH
 
 Operator-visible follow-up to 0.7.1. Caught while debugging a real

--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -210,11 +210,34 @@ class _DMPRequestHandler(socketserver.DatagramRequestHandler):
         # Thin: framing-specific (UDP datagram → bytes). Heavy
         # lifting (rate-limit, TSIG verify, response building) is in
         # ``_process_dns_query`` so the TCP handler can share it.
-        data, sock = self.request
+        #
+        # Write through ``self.wfile`` rather than calling
+        # ``sock.sendto`` directly. ``DatagramRequestHandler.finish()``
+        # (overridden below) emits a single ``sendto`` from wfile.
+        # The previous approach (direct sendto + empty wfile) caused
+        # finish() to ship a 0-byte UDP packet right after every
+        # legitimate response. dnspython on the receive side ignored
+        # the duplicate (it accepts the first valid datagram), but
+        # tcpdump flagged it as malformed and the empty trailer
+        # wasted a round-trip's worth of NIC + kernel time on every
+        # query.
+        data, _sock = self.request
         client_ip = self.client_address[0]
         response_bytes = _process_dns_query(self, data, client_ip, transport="udp")
         if response_bytes is not None:
-            sock.sendto(response_bytes, self.client_address)
+            self.wfile.write(response_bytes)
+
+    def finish(self) -> None:
+        # Override ``DatagramRequestHandler.finish`` so silent-drop
+        # paths (rate-limited query, unparseable wire, etc.) don't
+        # emit a 0-byte UDP packet. The base class unconditionally
+        # ``sendto(self.wfile.getvalue(), ...)`` regardless of whether
+        # the handler wrote anything, which surfaced as malformed
+        # trailer datagrams that waste bandwidth and reveal a live
+        # listener for queries that should look ignored.
+        payload = self.wfile.getvalue()
+        if payload:
+            self.socket.sendto(payload, self.client_address)
 
     @staticmethod
     def _stub_response(data: bytes, rcode_value: int) -> Optional[bytes]:

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -130,6 +130,46 @@ class TestDMPDnsServer:
             assert len(s) <= 255
         assert b"".join(rdata.strings) == long_value.encode("utf-8")
 
+    def test_udp_response_emits_exactly_one_datagram(self):
+        """The UDP handler must answer with one datagram, not two.
+
+        Pre-fix, ``handle()`` called ``sock.sendto`` directly while the
+        ``DatagramRequestHandler`` framework's ``finish()`` ALSO called
+        ``sock.sendto(self.wfile.getvalue(), ...)`` with an empty
+        buffer. The result was a valid response followed by a 0-byte
+        UDP packet on every query — visible in tcpdump as
+        ``domain [length 0 < 12] (invalid)``. Read once with a short
+        timeout, then peek for a second datagram and fail if anything
+        further arrived.
+        """
+        store = InMemoryDNSStore()
+        store.publish_txt_record("solo.mesh.test", "value")
+        port = _free_port()
+
+        with DMPDnsServer(store, host="127.0.0.1", port=port):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.settimeout(2.0)
+            try:
+                request = dns.message.make_query("solo.mesh.test", dns.rdatatype.TXT)
+                sock.sendto(request.to_wire(), ("127.0.0.1", port))
+                first, _ = sock.recvfrom(4096)
+                assert len(first) >= 12, "first datagram is the DNS response"
+                # Anything queued after the response is the duplicate
+                # empty datagram bug. Use a tight non-blocking poll so
+                # the test stays fast in the happy path.
+                sock.settimeout(0.5)
+                trailer = None
+                try:
+                    trailer, _ = sock.recvfrom(4096)
+                except socket.timeout:
+                    pass
+                assert trailer is None, (
+                    f"unexpected trailing UDP datagram of {len(trailer)} bytes "
+                    "after the legitimate response"
+                )
+            finally:
+                sock.close()
+
     def test_server_is_restartable(self):
         store = InMemoryDNSStore()
         store.publish_txt_record("r.mesh.test", "value")


### PR DESCRIPTION
## Summary

Caught while staring at tcpdump on a production node debugging the TSIG saga. Every successful UDP DNS query was followed by a `domain [length 0 < 12] (invalid)` packet:

```
22:50:53.450 In  IP <client>.<port> > <node>.53: 30514 update SOA? dmp.dnsmesh.io. (175)
22:50:53.451 Out IP <node>.53 > <client>.<port>: 1/0/1 TXT "..." (94)
22:50:53.451 Out IP <node>.53 > <client>.<port>: domain [length 0 < 12] (invalid)
```

Root cause: the UDP handler called `sock.sendto` directly, but `socketserver.DatagramRequestHandler.finish()` always fires `sendto(self.wfile.getvalue(), ...)` after `handle()` returns. With wfile empty, finish() shipped a `b""` datagram right after every legitimate response. dnspython on the receive side ignored the duplicate (it accepts the first valid datagram), so clients didn't break, but every query wasted one full send/receive cycle on a malformed trailer.

Silent-drop paths (rate-limited query, unparseable wire, TSIG mismatch — fixed in #71) had the same issue: handler returned without writing to wfile, finish() still emitted `b""`. So even queries that should have been silently ignored were leaking a "listener is here" signal.

## What changed

- `dmp/server/dns_server.py`:
  - `_DMPRequestHandler.handle()` now writes the response through `self.wfile` instead of `sock.sendto`.
  - Override `finish()` to skip the send when wfile is empty, so silent-drop paths really are silent.
- `tests/test_dns_server.py` — regression test sends a query, reads the legitimate response, then polls briefly for a trailing datagram. Fails on `main` (receives the `b""` trailer), passes with the fix.
- `CHANGELOG.md` — Unreleased / Fixed entry.

## Why this is worth a tight PR

It's been hiding in plain sight for who knows how long. Doesn't break correctness but every query on every node has been costing twice the kernel/NIC work it should. Cheap to fix, cheap to verify, and the test pins the behaviour going forward.

## Test plan

- [x] New regression test fails on `main` and passes with the fix
- [x] Full `tests/test_dns_server.py` — 65 passed
- [x] Manually confirmed via tcpdump that the trailing empty packet is gone after the patch
- [ ] Full CI: lint, type-check, py3.10/11/12, hypothesis fuzz, docker integration, pip-audit