### PR TITLE
release: 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.3] — 2026-05-06 — drop trailing empty UDP datagrams
+
+Operator-visible cleanup. No correctness change, but every UDP query
+on every node was costing twice the kernel/NIC work it should and
+silent-drop paths were leaking a "listener present" signal via
+malformed trailer datagrams.
+
 ### Fixed
 
 - DNS server stops emitting a 0-byte trailing UDP datagram after every
@@ -16,12 +23,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   wfile empty, finish() shipped a `b""` datagram right after every
   legitimate response. dnspython on the receive side ignored the
   duplicate (it accepts the first valid datagram), so this didn't
-  break clients, but tcpdump and any strict packet inspection flagged
-  it as `domain [length 0 < 12] (invalid)`. Wasted one full
-  send/receive on every query and on every silent-drop path.
+  break clients, but tcpdump flagged it as
+  `domain [length 0 < 12] (invalid)`. Silent-drop paths
+  (rate-limited, unparseable wire, TSIG mismatch) had the same issue
+  and leaked "listener is here" via a single empty datagram.
   Fixed by writing the response through `self.wfile` and overriding
   `finish()` to skip the send when wfile is empty. Regression test
-  asserts exactly one UDP datagram is emitted per query.
+  asserts exactly one UDP datagram is emitted per query (#73).
 
 ## [0.7.2] — 2026-05-06 — TSIG signature mismatch returns NOTAUTH
 

--- a/dmp/__init__.py
+++ b/dmp/__init__.py
@@ -1,3 +1,3 @@
 """DNS Mesh Protocol - Federated end-to-end encrypted messaging over DNS"""
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # The import path stays `import dmp` — distribution name and
     # import name intentionally differ (same pattern as pyyaml → yaml).
     name="dnsmesh",
-    version="0.7.2",
+    version="0.7.3",
     author="Oscar Valenzuela B",
     author_email="oscar.valenzuela.b@gmail.com",
     description="A federated end-to-end encrypted messaging protocol delivered over DNS",


### PR DESCRIPTION
## Summary

Drop the trailing empty UDP datagram the server emitted after every query (#73). Cleanup, not a correctness fix — clients on 0.7.0/0.7.1/0.7.2 keep working. No wire-format change, safe drop-in.

## What's in the release

- #73 — UDP handler emitted a 0-byte trailing datagram per query

## Bumped

- `dmp/__init__.py`: `__version__ = "0.7.3"`
- `setup.py`: `version="0.7.3"`
- `CHANGELOG.md`: 0.7.3 section

## Test plan

- [ ] CI green
- [ ] After merge: tag `cli-v0.7.3` and `sdk-v0.7.3`, GitHub release publishes wheel
- [ ] Run upgrade.sh on the three production nodes
- [ ] tcpdump confirms exactly one outbound packet per query post-deploy