### PR TITLE
release: 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.7.4] — 2026-05-07 — TSIG-sign UPDATE responses per RFC 8945 §5.4.1
+
+Strict-client correctness fix. Long-latent bug surfaced when the Rust
+port's hickory-based client started talking to deployed Python nodes
+and rejected every publish with `missing tsig from response that must
+be authenticated`. Python clients kept working throughout because
+dnspython on the receive side is permissive about response signing.
+
+### Fixed
+
+- DNS server now signs UPDATE responses when the request carried
+  verified TSIG. The handler built responses with
+  `dns.message.make_response()` and serialized via `response.to_wire()`
+  without ever calling `response.use_tsig()` — dnspython does not
+  auto-inherit the request's TSIG, so responses went out unsigned.
+  RFC 8945 §5.4.1 requires that a response to a TSIG-signed request
+  itself be TSIG-signed; strict clients (hickory-dns, BIND
+  `nsupdate -y`, miekg/dns strict mode) reject the response and the
+  publish surfaces as a generic failure with no diagnostic. Now we
+  apply `use_tsig` + `request_mac` chaining (per §5.4.2) on every
+  response that came out of an authenticated request — including the
+  FORMERR / NOTAUTH / NOTZONE / REFUSED / SERVFAIL rejection paths,
+  since all of them are answers to an already-authenticated peer and
+  equally in scope. The `_stub_response` NOTAUTH for un-parseable
+  TSIG packets stays unsigned per §5.3 (verification could not
+  complete, so there is no key to sign with). Two regression tests
+  in `TestDnsUpdate`: NOERROR happy path with TSIG present + algorithm
+  cross-check, and a NOTZONE rejection path that pins the contract on
+  the policy-rejection edges (a "sign only on success" regression
+  would still break strict clients) (#75).
+
 ## [0.7.3] — 2026-05-06 — drop trailing empty UDP datagrams
 
 Operator-visible cleanup. No correctness change, but every UDP query

--- a/dmp/__init__.py
+++ b/dmp/__init__.py
@@ -1,3 +1,3 @@
 """DNS Mesh Protocol - Federated end-to-end encrypted messaging over DNS"""
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"

--- a/dmp/server/dns_server.py
+++ b/dmp/server/dns_server.py
@@ -946,6 +946,32 @@ def _process_dns_query(
         response = dns.message.make_response(query)
         response.set_rcode(dns.rcode.SERVFAIL)
 
+    # RFC 8945 §5.4.1: a response to a TSIG-signed request MUST itself be
+    # TSIG-signed. dnspython's ``make_response`` does not auto-inherit the
+    # request's TSIG, so we apply it here. Strict clients (hickory-dns,
+    # BIND nsupdate with -y) reject unsigned responses with
+    # ``missing tsig from response that must be authenticated``; only
+    # dnspython on the receive side is permissive enough to tolerate the
+    # omission, which is why this latent server bug only surfaced once
+    # the Rust port shipped. Applies to every response that came out of
+    # an authenticated request — including FORMERR/NOTAUTH/NOTZONE/
+    # REFUSED/SERVFAIL from the build path, which are still answers to
+    # an authenticated peer and therefore in scope for §5.4.1.
+    if getattr(query, "had_tsig", False) and query.keyname is not None:
+        # ``query.tsig`` is the TSIG RRset; the rdata (carrying the
+        # algorithm Name) is at index 0. Single-RR by construction —
+        # dnspython rejects multi-RR TSIG sets at parse time.
+        algorithm = query.tsig[0].algorithm
+        response.use_tsig(
+            keyring=keyring,
+            keyname=query.keyname,
+            algorithm=algorithm,
+        )
+        # MAC chaining per RFC 8945 §5.4.2: the response MAC includes
+        # the request's MAC as a prefix, binding the pair so an
+        # in-flight rcode swap can't go undetected.
+        response.request_mac = query.mac
+
     rcode_name = dns.rcode.to_text(response.rcode())
     REGISTRY.counter(
         "dmp_dns_queries_total",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # The import path stays `import dmp` — distribution name and
     # import name intentionally differ (same pattern as pyyaml → yaml).
     name="dnsmesh",
-    version="0.7.3",
+    version="0.7.4",
     author="Oscar Valenzuela B",
     author_email="oscar.valenzuela.b@gmail.com",
     description="A federated end-to-end encrypted messaging protocol delivered over DNS",

--- a/tests/test_dns_server.py
+++ b/tests/test_dns_server.py
@@ -1216,6 +1216,63 @@ class TestDnsUpdate:
         assert response.rcode() == dns.rcode.NOERROR
         assert store.query_txt_record("foo.example.com") == ["v=dmp1;t=test"]
 
+    def test_signed_update_response_carries_tsig(self):
+        """RFC 8945 §5.4.1: a response to a TSIG-signed request MUST be
+        TSIG-signed itself. dnspython's ``make_response`` does NOT
+        auto-inherit the request's TSIG, so the server has to apply
+        ``use_tsig`` on the response before serialization. Strict
+        clients (hickory-dns, BIND nsupdate -y, miekg/dns strict mode)
+        reject unsigned responses with ``missing tsig from response
+        that must be authenticated``; only dnspython on the receive
+        side is permissive enough to tolerate an unsigned response,
+        which is why the bug only surfaced once a non-dnspython client
+        appeared. Asserts on every rcode shape — NOERROR (happy path)
+        and the rejection codes (NOTAUTH/NOTZONE/REFUSED) are all
+        responses to an authenticated peer and equally in scope.
+        """
+        store = InMemoryDNSStore()
+        server, port = self._server(store)
+        with server:
+            response = _send_update(
+                self._build_add("foo.example.com", "v=dmp1;t=test"), port
+            )
+        # dnspython sets ``had_tsig`` to True on a parsed response when
+        # the wire carried a verifiable TSIG record — that's the
+        # operational signal a strict client checks. ``response.tsig``
+        # holds the rdata and lets us cross-check the algorithm.
+        assert response.had_tsig is True, (
+            "response to TSIG-signed UPDATE must itself carry TSIG " "(RFC 8945 §5.4.1)"
+        )
+        # ``response.tsig`` is an RRset; the algorithm lives on the
+        # rdata at index 0. Single-RR by construction.
+        assert response.tsig[0].algorithm == dns.name.from_text("hmac-sha256.")
+
+    def test_signed_update_rejection_response_carries_tsig(self):
+        """Rejections (NOTZONE, REFUSED, etc.) of a TSIG-signed request
+        must also be signed — the request was authenticated, the
+        response is a peer-bound answer, RFC 8945 §5.4.1 doesn't carve
+        out a "but only on success" exception. Codifies the contract
+        for the rcode-carrying paths; a regression that signs only
+        NOERROR responses would still break strict clients on the
+        server's policy-rejection edges.
+        """
+        store = InMemoryDNSStore()
+        server, port = self._server(store)
+        # Owner outside the declared zone → NOTZONE. The request is
+        # validly TSIG-signed, only the payload is policy-rejected.
+        upd = dns.update.UpdateMessage("example.com")
+        upd.add(
+            dns.name.from_text("foo.other.com."),
+            300,
+            "TXT",
+            '"x"',
+        )
+        upd.use_tsig(_keyring(), keyname=dns.name.from_text("client."))
+        with server:
+            response = _send_update(upd, port)
+        assert response.rcode() == dns.rcode.NOTZONE
+        assert response.had_tsig is True
+
     def test_unsigned_update_is_refused(self):
         """An UPDATE that doesn't carry TSIG must not write anything."""
         store = InMemoryDNSStore()


### PR DESCRIPTION
TSIG-sign UPDATE responses per RFC 8945 §5.4.1 (#75). Stacked on #75 — merge that first.