### PR TITLE
chore: drop external-review tool citations from PR #98 comments

### DIFF
--- a/dmp/client/client.py
+++ b/dmp/client/client.py
@@ -281,9 +281,8 @@ class DMPClient:
         # `identity_domain` isn't configured we fall back to
         # `self.domain` — the legacy shared-mesh layout where
         # identity records live under the same zone as the mailbox.
-        # Codex review P2 (round 3): without this, identity-domain
-        # users can decrypt v2 messages but never see a verified
-        # `sender_label`.
+        # Without this, identity-domain users can decrypt v2 messages
+        # but never see a verified `sender_label`.
         self._identity_address_host = identity_domain or domain
         self.crypto = DMPCrypto.from_passphrase(passphrase, salt=kdf_salt)
         self.user_id = hashlib.sha256(self.crypto.get_public_key_bytes()).digest()
@@ -346,9 +345,9 @@ class DMPClient:
         # ``_envelope_label_cache`` maps a verified
         # ``(claimed_from, sender_spk)`` tuple to its canonical form.
         # Only positive verifications are cached; a transient DNS
-        # failure must NOT evict a previously-verified binding
-        # (codex consult 2026-05-13). Negative results are not
-        # cached so the binding can recover on later receive passes.
+        # failure must NOT evict a previously-verified binding.
+        # Negative results are not cached so the binding can recover
+        # on later receive passes.
         #
         # ``_recipient_versions_cache`` maps
         # ``(canonical_addr, pin_material)`` to the protocol versions
@@ -356,10 +355,9 @@ class DMPClient:
         # disambiguates re-pin / rotation at the same address: when a
         # contact gets re-pinned to a different key, the new (addr,
         # new_pin) tuple is a cache miss, so we re-fetch and re-apply
-        # the SPK-match guard. Codex review P2 (round 3): without
-        # this, a cached "v2 OK" from an old pin would skip the
-        # mismatch check and let the send path wrap plaintext bound
-        # for a v1-only or unrelated successor.
+        # the SPK-match guard. Without this, a cached "v2 OK" from an
+        # old pin would skip the mismatch check and let the send path
+        # wrap plaintext bound for a v1-only or unrelated successor.
         self._envelope_label_cache: Dict[Tuple[str, bytes], str] = {}
         self._recipient_versions_cache: Dict[Tuple[str, bytes], Tuple[int, ...]] = {}
 
@@ -765,10 +763,10 @@ class DMPClient:
            (covers the early-TOFU case where the caller supplied a
            disambiguator defensively but hadn't actually pinned yet).
 
-        Codex review P2: a stale zone-anchored record MUST NOT prevent
-        the lookup from reaching the matching hash-named record, and a
-        legacy X25519-only pin MUST get the same shadow protection as
-        a modern Ed25519 pin.
+        A stale zone-anchored record MUST NOT prevent the lookup from
+        reaching the matching hash-named record, and a legacy
+        X25519-only pin MUST get the same shadow protection as a modern
+        Ed25519 pin.
 
         ``hash_user_variants`` provides additional username spellings
         to use when computing the hash-name fallback. The TOFU-hash
@@ -779,7 +777,7 @@ class DMPClient:
         envelope canonicalizer always lowercases addresses, so without
         an extra variant the lookup misses the record entirely.
         Callers that know the contact's original-case username pass
-        it here. Codex review P2 (round 7).
+        it here.
         """
         hash_names = []
         seen_hash_keys: set = set()
@@ -811,7 +809,7 @@ class DMPClient:
                 # (`dnsmesh init Alice`). Comparing the stored case
                 # directly would skip a perfectly valid match and
                 # silently downgrade the send path or the verified
-                # label. Codex review P2 (round 6).
+                # label.
                 if ident.username.lower() != user:
                     continue
                 if expected_spk is not None and ident.ed25519_spk == expected_spk:
@@ -848,7 +846,6 @@ class DMPClient:
         # falling back to (1,) — meaning zone-anchored CLI contacts
         # never get DMPv2 envelopes. Strip the host suffix from
         # username when it already includes one.
-        # Codex review P2 (round 4): handle full-address contacts.
         raw_user = contact.username
         if "@" in raw_user:
             raw_user = raw_user.split("@", 1)[0]
@@ -878,7 +875,7 @@ class DMPClient:
         # Pass the original-case localpart as a hash-name variant so
         # mixed-case identities (e.g. `dnsmesh init Alice`) publishing
         # to the TOFU-hash form are still findable from the
-        # canonicalized lowercase lookup. Codex review P2 (round 7).
+        # canonicalized lowercase lookup.
         record = self._lookup_identity_record(
             user,
             host,
@@ -904,7 +901,7 @@ class DMPClient:
         #      Without this check a squatted identity at the same
         #      address could trick us into emitting v2 to a v1-only
         #      legacy contact and leak the DMPV2 prefix into their
-        #      message body. Codex review P2.
+        #      message body.
         if record is not None:
             if contact.signing_key_bytes:
                 if record.ed25519_spk != contact.signing_key_bytes:

--- a/dmp/core/envelope.py
+++ b/dmp/core/envelope.py
@@ -159,8 +159,7 @@ def decode(plaintext: bytes) -> Tuple[bytes, Optional[str]]:
       a genuine but corrupted envelope. Falling back to the full
       plaintext means a legacy v1 message whose first 256 bytes
       happen to start with ``DMPV2:`` keeps its body intact instead
-      of losing everything up to the first newline. Codex review P2
-      (round 6).
+      of losing everything up to the first newline.
     - Prefix matches, newline found, header parses as a dict →
       committed v2 envelope. Body is everything after the first
       newline. Inside the envelope the ``from`` claim is parsed and

--- a/docs/protocol/crypto.md
+++ b/docs/protocol/crypto.md
@@ -164,8 +164,7 @@ failure → `sender_label = ""` (UI falls back to SPK fingerprint).
 
 Positive bindings are cached in memory (`(canonical_from, sender_spk)
 → canonical_from`). Negative results are NOT cached — a transient
-DNS failure must not evict a previously-verified binding. Per codex
-consult 2026-05-13.
+DNS failure must not evict a previously-verified binding.
 
 ### Capability gating (no leaked wrappers)
 
@@ -186,7 +185,7 @@ in the message body.
 | versions=[1] | versions=[1,2] | v2 (wrapper)* | clean body, verified label |
 
 \* The sender's own `versions` field advertises **receive** capability;
-it does not gate **send**. Codex-validated 2026-05-13.
+it does not gate **send**.
 
 ## Forward secrecy (X3DH-style prekeys)
 

--- a/docs/protocol/vectors/_generate.py
+++ b/docs/protocol/vectors/_generate.py
@@ -1084,7 +1084,7 @@ def gen_dmpv2_envelope_cases() -> list[dict[str, Any]]:
     #    the DMPV2 prefix and contain a newline within 256 bytes.
     #    Because the header isn't well-formed JSON, decode MUST fall
     #    back to the full plaintext so the legacy sender's body
-    #    isn't truncated. Codex review P2 (round 6).
+    #    isn't truncated.
     bad_json_plaintext = b"DMPV2:{not json}\nbody-still-here"
     decoded_body, decoded_addr = envelope.decode(bad_json_plaintext)
     cases.append(

--- a/tests/test_dmpv2_integration.py
+++ b/tests/test_dmpv2_integration.py
@@ -121,7 +121,7 @@ class TestEnvelopeRoundtrip:
         not the sender's. Alice's identity record can say versions=(1,)
         — that's a statement about what she can RECEIVE — and she
         still emits v2 envelopes when sending to a v2-capable peer.
-        This is the codex-validated design: senders never need to
+        This is the designed behavior: senders never need to
         consult their own identity record to decide what to emit."""
         store = InMemoryDNSStore()
         alice, bob = _make_pair(store, alice_versions=(1,))
@@ -360,8 +360,6 @@ class TestRRSetDisambiguation:
     - ``_resolve_envelope_label`` would see the old record's SPK,
       fail to match the manifest's ``sender_spk``, and refuse to
       populate the verified label.
-
-    Codex review P2 (2026-05-13).
     """
 
     def test_resolve_envelope_label_picks_record_matching_sender_spk(self):
@@ -466,8 +464,6 @@ class TestFallbackNameSearch:
     A premature early-return at the first username-matching record
     would silently break v2 emission and label verification in any
     deployment that's gone through a republish/migration.
-
-    Codex review P2 (round 2, 2026-05-13).
     """
 
     def test_recipient_versions_falls_through_to_hash_named_record(self):
@@ -594,8 +590,6 @@ class TestIdentityDomainOverride:
     domain (where the identity record is actually published), not at
     the mailbox domain. Otherwise receivers look up the wrong address
     and never produce a verified sender_label.
-
-    Codex review P2 (round 3, 2026-05-13).
     """
 
     def test_envelope_uses_identity_domain_when_configured(self):
@@ -650,8 +644,6 @@ class TestVersionsCacheRespectsPinChange:
     a different key at the same address inherits the previous pin's
     cached v2-OK verdict — and the send path emits a wrapper to a
     recipient that the new pin says is v1-only or unrelated.
-
-    Codex review P2 (round 3, 2026-05-13).
     """
 
     def test_repinning_invalidates_versions_cache(self):
@@ -710,8 +702,6 @@ class TestFullAddressContact:
     `user@host` from the localpart, not from the already-full
     string — or canonicalization fails and v2 emission silently
     downgrades.
-
-    Codex review P2 (round 4, 2026-05-13).
     """
 
     def test_full_address_username_still_emits_v2(self):
@@ -771,8 +761,6 @@ class TestMixedCaseUsername:
     record's stored username preserves the original case for display
     + DNS, but the lookup compares case-insensitively to find the
     matching record.
-
-    Codex review P2 (round 6, 2026-05-13).
     """
 
     def test_mixed_case_record_username_matches_lowercase_envelope_lookup(self):
@@ -818,7 +806,7 @@ class TestMixedCaseHashName:
     `identity_domain`) has its record at `identity_domain("Alice",
     host)` — a different hash than `identity_domain("alice", host)`.
     The send path must look up under the ORIGINAL case to find the
-    record. Codex review P2 (round 7, 2026-05-13).
+    record.
     """
 
     def test_recipient_versions_finds_mixed_case_hash_named_record(self):
@@ -869,8 +857,6 @@ class TestLegacyPinX25519Disambiguation:
     protection a modern Ed25519 pin gets. The lookup must keep
     searching past a stale record whose X25519 key doesn't match the
     pinned encryption key.
-
-    Codex review P2 (round 4, 2026-05-13).
     """
 
     def test_legacy_pin_finds_matching_record_past_stale(self):
@@ -932,8 +918,6 @@ class TestLegacyContactDoesNotTrustSquattedVersions:
     address (advertising v2) would trick the send path into wrapping
     plaintext destined for a v1-only legacy contact, leaking the
     `DMPV2:` prefix into their message body.
-
-    Codex review P2 (round 2, 2026-05-13).
     """
 
     def test_squatted_v2_record_does_not_upgrade_legacy_contact(self):
@@ -1013,8 +997,8 @@ class TestEnvelopeCaches:
         # Cached.
         assert (addr, spk) in bob._envelope_label_cache
         # Mutate the store to break the lookup — the cache must not
-        # forget the previously-verified binding (codex consult
-        # 2026-05-13: a transient NXDOMAIN must not evict).
+        # forget the previously-verified binding (transient NXDOMAIN
+        # must not evict).
         store._records.clear()  # type: ignore[attr-defined]
         cached = bob._resolve_envelope_label(addr, spk)
         assert cached == addr

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -258,10 +258,10 @@ class TestDecode:
         assert DMPV2_PREFIX not in body
 
     def test_legacy_message_starting_with_prefix_and_newline_preserved(self):
-        """Regression for codex P2 round 6: a v1 message whose first
-        few bytes happen to be ``DMPV2:`` followed by some text and a
-        newline within 256 bytes MUST be delivered intact, not
-        truncated. The decoder requires well-formed JSON to commit."""
+        """A v1 message whose first few bytes happen to be ``DMPV2:``
+        followed by some text and a newline within 256 bytes MUST be
+        delivered intact, not truncated. The decoder requires
+        well-formed JSON to commit."""
         legacy = DMPV2_PREFIX + b"actual first line\nrest of message"
         body, sender = decode(legacy)
         assert body == legacy  # full plaintext preserved


### PR DESCRIPTION
## Summary

Pure comment + docstring cleanup. PR #98 landed with a handful of `Codex review P2 (round N)` citations scattered through code comments, docstrings, and the published wire-format docs. This PR strips those citations across the same set of files. The technical justifications behind each guard / cache / canonicalization rule stay; only the tool attribution goes.

Zero behavior change.

### Files touched

- `dmp/core/envelope.py` — 1 spot in the `decode()` docstring
- `dmp/client/client.py` — 9 spots: identity-address-host comment, version-cache comment, `_lookup_identity_record` docstring + inline comments, full-address-contact comment, hash-name-variant comment, legacy-pin defense comment
- `docs/protocol/crypto.md` — 2 spots in the DMPv2 envelope section
- `docs/protocol/vectors/_generate.py` — 1 spot in the v1-collision vector
- `tests/test_envelope.py` — 1 spot in the legacy-prefix test docstring
- `tests/test_dmpv2_integration.py` — 11 spots across class docstrings + inline comments

### Test plan

- [x] `pytest --ignore=tests/test_docker_integration.py` — 1703 pass, 6 skipped, 0 failures (same numbers as PR #98)
- [x] `black --check dmp/core/envelope.py dmp/client/client.py docs/protocol/vectors/_generate.py tests/test_envelope.py tests/test_dmpv2_integration.py` clean
- [x] `grep -nE "[Cc]odex|[Cc]laude" <pr98 files>` returns nothing