### PR TITLE
feat(heartbeat): refresh seed list from a public URL on a slow schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Heartbeat worker can now refresh its seed-zone list from a public
+  URL on a slow schedule (default: every 6 hours, fetched lazily
+  alongside the regular harvest cycle). Operators can override the
+  source with `DMP_HEARTBEAT_PUBLIC_SEED_URLS` (comma-separated) or
+  disable entirely with `DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED=1`.
+  The default source is the curated `directory/seeds.txt` shipped
+  in this repository, so a fresh node bootstraps onto the federated
+  mesh without operator-supplied peer lists.
+- Fetched seed bodies are size-capped (64 KiB) and parsed
+  defensively: comments, blank lines, legacy `https://` entries, and
+  the node's own zone are all filtered out. A failed fetch preserves
+  the previous cache rather than wiping the harvest list, so a
+  transient outage at the seed host cannot orphan running nodes.
+  Closes #79.
+
 ## [0.7.5] — 2026-05-15 — DMPv2 plaintext envelope + identity-record versions
 
 Unblocks cross-zone first-contact delivery. Two unpinned identities

--- a/dmp/server/heartbeat_worker.py
+++ b/dmp/server/heartbeat_worker.py
@@ -33,11 +33,13 @@ primitive — see M9 design notes).
 
 from __future__ import annotations
 
+import ipaddress
 import logging
+import socket
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, Iterable, List, Optional, Set
+from typing import Callable, Dict, Iterable, List, Optional, Set
 from urllib.parse import urlsplit
 
 from dmp.core.crypto import DMPCrypto
@@ -138,6 +140,64 @@ def _parse_public_seed_body(body: bytes) -> List[str]:
     return zones
 
 
+def _is_safe_public_seed_url(url: str) -> bool:
+    """Reject URLs the worker must not fetch from.
+
+    The seed-URL list comes from an operator-controlled env var, but
+    we still gate it: ``https://`` only, hostname must resolve to a
+    routable public address. Any loopback / private / link-local /
+    multicast / reserved / unspecified address is rejected so an
+    accidentally-pointed URL can't be used to scan internal network
+    space or hit the cloud-provider metadata endpoint
+    (169.254.169.254 is link-local — already covered — but the IP
+    is famous enough to call out).
+
+    Returning ``False`` is a hard refusal: caller drops the URL for
+    this refresh cycle. It does NOT count as a transient failure, so
+    the per-URL cache is preserved unchanged.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        log.warning("public seed URL %r is not parseable; rejecting", url)
+        return False
+    if parts.scheme != "https":
+        log.warning("public seed URL %r rejected: only https:// is allowed", url)
+        return False
+    host = (parts.hostname or "").strip()
+    if not host:
+        log.warning("public seed URL %r has no hostname; rejecting", url)
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        log.warning(
+            "public seed URL %r DNS resolution failed (%s); rejecting", url, exc
+        )
+        return False
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            ip = ipaddress.ip_address(sockaddr[0])
+        except (ValueError, IndexError):
+            return False
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            log.warning(
+                "public seed URL %r resolves to non-public address %s; rejecting",
+                url,
+                ip,
+            )
+            return False
+    return True
+
+
 def _default_public_seed_fetcher(
     url: str, timeout_seconds: float, max_bytes: int
 ) -> Optional[bytes]:
@@ -150,10 +210,17 @@ def _default_public_seed_fetcher(
     read). On any failure returns ``None``; the caller treats that
     as a refresh miss and keeps the previous cache.
 
+    The URL is screened by ``_is_safe_public_seed_url`` first:
+    HTTPS-only, and the resolved hostname must be a routable public
+    address. Anything else (``http://``, loopback, private/link-local,
+    metadata endpoints) is refused without a network call.
+
     Imports ``requests`` lazily so the heartbeat module stays
     importable in environments without the HTTP client (the worker
     only needs it when ``public_seed_urls`` is non-empty).
     """
+    if not _is_safe_public_seed_url(url):
+        return None
     try:
         import requests  # type: ignore[import-not-found]
     except ImportError:
@@ -304,11 +371,13 @@ class HeartbeatWorker:
         self._cluster_peers_provider = cluster_peers_provider or (lambda: ())
         self._public_seed_fetcher = public_seed_fetcher or _default_public_seed_fetcher
         # Cache of normalized zones from the last successful public-seed
-        # refresh per URL. Failures preserve the prior cache so a
-        # transient outage doesn't drop everything we knew. List
-        # rather than set so iteration order matches URL order, which
-        # lets operators express priority via their URL list.
-        self._public_seed_zones: List[str] = []
+        # refresh, keyed by URL. Per-URL granularity matters: when
+        # one URL succeeds and another fails on the same refresh
+        # cycle, the failing URL keeps its last-known-good zones
+        # instead of being silently dropped. Order of iteration is
+        # the order of ``cfg.public_seed_urls`` so operators can
+        # express priority via their URL list.
+        self._public_seed_zones: Dict[str, List[str]] = {}
         self._public_seed_last_fetch: int = 0
 
         self._stop_event = threading.Event()
@@ -901,8 +970,12 @@ class HeartbeatWorker:
         # how often the worker ticks.
         if self._cfg.public_seed_urls:
             self._refresh_public_seeds_if_due(int(time.time()))
-            for zone in self._public_seed_zones:
-                _add(zone)
+            # Iterate per URL in config order so the priority the
+            # operator expressed in ``DMP_HEARTBEAT_PUBLIC_SEED_URLS``
+            # is preserved (first URL's zones get harvested first).
+            for url in self._cfg.public_seed_urls:
+                for zone in self._public_seed_zones.get(url, ()):
+                    _add(zone)
         # Gossip-learned: pull peer zones directly from the wires in
         # the seen-store. ``list_zones_for_harvest`` reads the
         # operator-advertised ``claim_provider_zone`` field
@@ -937,21 +1010,32 @@ class HeartbeatWorker:
         """Re-fetch ``DMP_HEARTBEAT_PUBLIC_SEED_URLS`` if the cache is stale.
 
         Rate-limited by ``public_seed_refresh_seconds``: a fast worker
-        tick doesn't translate into a fast HTTP cadence. Each URL is
-        fetched independently; per-URL fetch failures preserve the
-        prior cache contents for that URL's zones (we keep the last
-        known good list rather than dropping everything on a transient
-        outage). The merged result replaces ``self._public_seed_zones``
-        wholesale only when at least one URL fetched successfully.
+        tick doesn't translate into a fast HTTP cadence, and a
+        persistent outage at the source URL does not retry every
+        tick either — the timestamp updates regardless of outcome,
+        so a failed attempt also has to wait the full refresh window
+        before retrying.
+
+        Per-URL granularity: each URL is fetched independently, and
+        the cache slot for a URL is overwritten ONLY when that URL's
+        fetch succeeds. A partial failure (URL A succeeds, URL B
+        returns ``None``) preserves URL B's last-known-good zones
+        instead of dropping them. URLs no longer in the config are
+        evicted so cache memory stays bounded.
         """
         if not self._cfg.public_seed_urls:
             return
         last = self._public_seed_last_fetch
         if last and (now - last) < self._cfg.public_seed_refresh_seconds:
             return
-        merged: List[str] = []
-        seen: Set[str] = set()
-        any_success = False
+        # Drop slots for URLs that are no longer in the config (e.g.
+        # operator removed one) so cache memory matches current intent.
+        configured = set(self._cfg.public_seed_urls)
+        for stale in [u for u in self._public_seed_zones if u not in configured]:
+            self._public_seed_zones.pop(stale, None)
+
+        success_count = 0
+        new_zone_total = 0
         for url in self._cfg.public_seed_urls:
             try:
                 body = self._public_seed_fetcher(
@@ -964,18 +1048,30 @@ class HeartbeatWorker:
                 continue
             if body is None:
                 continue
-            any_success = True
+            zones: List[str] = []
+            seen_in_url: Set[str] = set()
             for raw_zone in _parse_public_seed_body(body):
                 zone = _zone_from_seed(raw_zone)
-                if not zone or zone in seen:
+                if not zone or zone in seen_in_url:
                     continue
-                seen.add(zone)
-                merged.append(zone)
-        if any_success:
-            self._public_seed_zones = merged
-            self._public_seed_last_fetch = now
+                seen_in_url.add(zone)
+                zones.append(zone)
+            self._public_seed_zones[url] = zones
+            success_count += 1
+            new_zone_total += len(zones)
+        # Update timestamp regardless of outcome — a failed refresh
+        # must also wait the refresh window before retrying, otherwise
+        # an outage at the source URL means we hammer it every tick.
+        self._public_seed_last_fetch = now
+        if success_count:
             log.info(
-                "refreshed public seed cache from %d URL(s); %d unique zones",
+                "refreshed public seed cache: %d/%d URL(s) ok, %d zones cached",
+                success_count,
                 len(self._cfg.public_seed_urls),
-                len(merged),
+                new_zone_total,
+            )
+        else:
+            log.warning(
+                "all %d public seed URL(s) failed this refresh; keeping prior cache",
+                len(self._cfg.public_seed_urls),
             )

--- a/dmp/server/heartbeat_worker.py
+++ b/dmp/server/heartbeat_worker.py
@@ -157,9 +157,7 @@ def _default_public_seed_fetcher(
     try:
         import requests  # type: ignore[import-not-found]
     except ImportError:
-        log.warning(
-            "requests not installed; cannot fetch public seeds from %s", url
-        )
+        log.warning("requests not installed; cannot fetch public seeds from %s", url)
         return None
     try:
         resp = requests.get(url, timeout=timeout_seconds, stream=True)
@@ -270,7 +268,9 @@ class HeartbeatWorker:
         record_writer: Optional[DNSRecordWriter] = None,
         dns_reader: Optional[DNSRecordReader] = None,
         cluster_peers_provider: Optional[Callable[[], Iterable[str]]] = None,
-        public_seed_fetcher: Optional[Callable[[str, float, int], Optional[bytes]]] = None,
+        public_seed_fetcher: Optional[
+            Callable[[str, float, int], Optional[bytes]]
+        ] = None,
     ) -> None:
         """Construct the worker.
 

--- a/dmp/server/heartbeat_worker.py
+++ b/dmp/server/heartbeat_worker.py
@@ -65,6 +65,25 @@ DEFAULT_MAX_GOSSIP_PER_RESPONSE = 20
 # resolvers and doesn't grow unbounded when the directory does.
 DEFAULT_MAX_SEEN_PUBLISH = 50
 
+# Canonical project seed list. Operators can override via
+# ``DMP_HEARTBEAT_PUBLIC_SEED_URLS`` or disable the fetch entirely
+# with ``DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED=1``.
+DEFAULT_PUBLIC_SEED_URL = (
+    "https://raw.githubusercontent.com/oscarvalenzuelab/DNSMeshProtocol"
+    "/main/directory/seeds.txt"
+)
+# 6h cadence. The directory rebuilds on every PR merge; a 6h window
+# means new operators are picked up within at most that long after
+# the merge, without hammering GitHub for every heartbeat tick.
+DEFAULT_PUBLIC_SEED_REFRESH_SECONDS = 6 * 3600
+# 5s HTTP timeout per URL. The worker tick budget is in seconds, not
+# minutes — a slow CDN can't be allowed to stall it.
+DEFAULT_PUBLIC_SEED_FETCH_TIMEOUT = 5.0
+# 64 KB response cap per URL. ``seeds.txt`` is a few hundred bytes
+# today; the cap is generous enough to absorb a healthy growth path
+# while still bounding worker memory if a hostile URL serves a flood.
+DEFAULT_PUBLIC_SEED_MAX_BYTES = 65_536
+
 # DNS owner names the worker publishes / queries under.
 HEARTBEAT_RRSET_PREFIX = "_dnsmesh-heartbeat"
 SEEN_RRSET_PREFIX = "_dnsmesh-seen"
@@ -95,6 +114,85 @@ def _zone_from_seed(seed: str) -> str:
     if ":" in s and not s.startswith("["):
         s = s.split(":", 1)[0]
     return s.lower()
+
+
+def _parse_public_seed_body(body: bytes) -> List[str]:
+    """Pull candidate zones out of a ``seeds.txt``-format response body.
+
+    Same format the public directory consumes via the pages.yml
+    aggregator: one entry per line, ``#``-prefixed lines and blank
+    lines ignored. Non-UTF-8 bytes are dropped — the format is
+    documented as ASCII-friendly DNS zone labels.
+    """
+    try:
+        text = body.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        log.warning("public seed body is not valid UTF-8; skipping")
+        return []
+    zones: List[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        zones.append(stripped)
+    return zones
+
+
+def _default_public_seed_fetcher(
+    url: str, timeout_seconds: float, max_bytes: int
+) -> Optional[bytes]:
+    """HTTP GET ``url`` and return up to ``max_bytes`` of its body.
+
+    Defensive against the obvious failure modes: HTTP timeout, network
+    errors, non-2xx responses, body larger than ``max_bytes`` (we
+    truncate at the boundary rather than failing — a hostile URL
+    serving a flood would otherwise drag the worker into an unbounded
+    read). On any failure returns ``None``; the caller treats that
+    as a refresh miss and keeps the previous cache.
+
+    Imports ``requests`` lazily so the heartbeat module stays
+    importable in environments without the HTTP client (the worker
+    only needs it when ``public_seed_urls`` is non-empty).
+    """
+    try:
+        import requests  # type: ignore[import-not-found]
+    except ImportError:
+        log.warning(
+            "requests not installed; cannot fetch public seeds from %s", url
+        )
+        return None
+    try:
+        resp = requests.get(url, timeout=timeout_seconds, stream=True)
+    except Exception as exc:  # noqa: BLE001 — network failures are best-effort
+        log.warning("public seed fetch failed for %s: %s", url, exc)
+        return None
+    try:
+        if resp.status_code != 200:
+            log.warning(
+                "public seed fetch for %s returned HTTP %d; skipping",
+                url,
+                resp.status_code,
+            )
+            return None
+        # ``iter_content`` honors the connection-level chunking and lets
+        # us bail as soon as the cap is hit, instead of buffering the
+        # entire response first.
+        buf = bytearray()
+        for chunk in resp.iter_content(chunk_size=4096):
+            if not chunk:
+                continue
+            buf.extend(chunk)
+            if len(buf) >= max_bytes:
+                # Truncate; downstream parser tolerates the partial
+                # final line (it will just be ignored if it's not a
+                # complete entry).
+                return bytes(buf[:max_bytes])
+        return bytes(buf)
+    finally:
+        try:
+            resp.close()
+        except Exception:  # noqa: BLE001
+            pass
 
 
 def heartbeat_rrset_name(zone: str) -> str:
@@ -141,6 +239,17 @@ class HeartbeatWorkerConfig:
     # M9 — DNS-native publish/discover.
     dns_zone: str = ""
     seed_zones: tuple = ()
+    # Public-seed-URL refresh (#79). When ``public_seed_urls`` is
+    # non-empty the worker fetches each URL on a refresh cadence,
+    # parses ``# comments`` + blank lines like ``directory/seeds.txt``,
+    # normalizes each entry via ``_zone_from_seed``, and merges the
+    # result into the harvest list alongside env seeds + cluster
+    # peers. Wired from ``DMP_HEARTBEAT_PUBLIC_SEED_URLS`` in node.py.
+    # Empty tuple disables the fetch entirely.
+    public_seed_urls: tuple = ()
+    public_seed_refresh_seconds: int = DEFAULT_PUBLIC_SEED_REFRESH_SECONDS
+    public_seed_fetch_timeout: float = DEFAULT_PUBLIC_SEED_FETCH_TIMEOUT
+    public_seed_max_bytes: int = DEFAULT_PUBLIC_SEED_MAX_BYTES
 
 
 class HeartbeatWorker:
@@ -161,6 +270,7 @@ class HeartbeatWorker:
         record_writer: Optional[DNSRecordWriter] = None,
         dns_reader: Optional[DNSRecordReader] = None,
         cluster_peers_provider: Optional[Callable[[], Iterable[str]]] = None,
+        public_seed_fetcher: Optional[Callable[[str, float, int], Optional[bytes]]] = None,
     ) -> None:
         """Construct the worker.
 
@@ -178,6 +288,13 @@ class HeartbeatWorker:
         that returns cluster peer endpoints (for clustered nodes
         that want to harvest each peer's zone). Each entry is
         normalized via ``_zone_from_seed``. None in solo-node mode.
+
+        ``public_seed_fetcher`` is the HTTP fetcher used to refresh
+        ``DMP_HEARTBEAT_PUBLIC_SEED_URLS``. Signature is
+        ``(url, timeout_seconds, max_bytes) -> Optional[bytes]``.
+        Returning ``None`` (or raising) is treated as a refresh
+        miss — the worker keeps the previous cache. Defaults to a
+        ``requests``-backed implementation; tests inject a fake.
         """
         self._cfg = config
         self._crypto = operator_crypto
@@ -185,6 +302,14 @@ class HeartbeatWorker:
         self._record_writer = record_writer
         self._dns_reader = dns_reader
         self._cluster_peers_provider = cluster_peers_provider or (lambda: ())
+        self._public_seed_fetcher = public_seed_fetcher or _default_public_seed_fetcher
+        # Cache of normalized zones from the last successful public-seed
+        # refresh per URL. Failures preserve the prior cache so a
+        # transient outage doesn't drop everything we knew. List
+        # rather than set so iteration order matches URL order, which
+        # lets operators express priority via their URL list.
+        self._public_seed_zones: List[str] = []
+        self._public_seed_last_fetch: int = 0
 
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -765,6 +890,19 @@ class HeartbeatWorker:
             log.exception(
                 "cluster_peers_provider raised; continuing with seeds + gossip"
             )
+        # Public-seed URLs (#79). After cluster peers (which are
+        # operator-signed via the cluster manifest, so the highest
+        # trust input), before gossip-learned peers (lowest trust:
+        # transitively learned via signature-verified heartbeats but
+        # not vetted by anyone). The refresh is rate-limited so a
+        # fast tick interval doesn't translate into a fast fetch
+        # cadence — the GitHub raw endpoint sees one request per
+        # ``public_seed_refresh_seconds`` per operator, regardless of
+        # how often the worker ticks.
+        if self._cfg.public_seed_urls:
+            self._refresh_public_seeds_if_due(int(time.time()))
+            for zone in self._public_seed_zones:
+                _add(zone)
         # Gossip-learned: pull peer zones directly from the wires in
         # the seen-store. ``list_zones_for_harvest`` reads the
         # operator-advertised ``claim_provider_zone`` field
@@ -794,3 +932,50 @@ class HeartbeatWorker:
             log.exception("SeenStore.list_zones_for_harvest raised; continuing")
 
         return out[: self._cfg.max_peers]
+
+    def _refresh_public_seeds_if_due(self, now: int) -> None:
+        """Re-fetch ``DMP_HEARTBEAT_PUBLIC_SEED_URLS`` if the cache is stale.
+
+        Rate-limited by ``public_seed_refresh_seconds``: a fast worker
+        tick doesn't translate into a fast HTTP cadence. Each URL is
+        fetched independently; per-URL fetch failures preserve the
+        prior cache contents for that URL's zones (we keep the last
+        known good list rather than dropping everything on a transient
+        outage). The merged result replaces ``self._public_seed_zones``
+        wholesale only when at least one URL fetched successfully.
+        """
+        if not self._cfg.public_seed_urls:
+            return
+        last = self._public_seed_last_fetch
+        if last and (now - last) < self._cfg.public_seed_refresh_seconds:
+            return
+        merged: List[str] = []
+        seen: Set[str] = set()
+        any_success = False
+        for url in self._cfg.public_seed_urls:
+            try:
+                body = self._public_seed_fetcher(
+                    url,
+                    self._cfg.public_seed_fetch_timeout,
+                    self._cfg.public_seed_max_bytes,
+                )
+            except Exception:
+                log.exception("public seed fetch raised for %s; ignoring", url)
+                continue
+            if body is None:
+                continue
+            any_success = True
+            for raw_zone in _parse_public_seed_body(body):
+                zone = _zone_from_seed(raw_zone)
+                if not zone or zone in seen:
+                    continue
+                seen.add(zone)
+                merged.append(zone)
+        if any_success:
+            self._public_seed_zones = merged
+            self._public_seed_last_fetch = now
+            log.info(
+                "refreshed public seed cache from %d URL(s); %d unique zones",
+                len(self._cfg.public_seed_urls),
+                len(merged),
+            )

--- a/dmp/server/node.py
+++ b/dmp/server/node.py
@@ -530,6 +530,31 @@ def _load_heartbeat_from_env(
     # cap bit is set.
     advertised_zone = publish_zone
 
+    # Public-seed URLs (#79). Default is the canonical project
+    # seeds.txt — operators get federation growth without any per-node
+    # configuration. Override with a custom list:
+    #   DMP_HEARTBEAT_PUBLIC_SEED_URLS="https://a.example/seeds.txt,https://b.example/seeds.txt"
+    # Or disable the fetch entirely:
+    #   DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED=1
+    # The trust gate is "who has merge access to the URL's source" —
+    # see #79 for the governance discussion.
+    from dmp.server.heartbeat_worker import DEFAULT_PUBLIC_SEED_URL
+
+    public_seed_disabled_raw = (
+        os.environ.get("DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED", "").strip().lower()
+    )
+    public_seed_disabled = public_seed_disabled_raw in ("1", "true", "yes", "on")
+    if public_seed_disabled:
+        public_seed_urls: tuple = ()
+    else:
+        raw_urls = os.environ.get("DMP_HEARTBEAT_PUBLIC_SEED_URLS", "").strip()
+        if raw_urls:
+            public_seed_urls = tuple(
+                u.strip() for u in raw_urls.split(",") if u.strip()
+            )
+        else:
+            public_seed_urls = (DEFAULT_PUBLIC_SEED_URL,)
+
     cfg = HeartbeatWorkerConfig(
         self_endpoint=self_endpoint,
         version=version,
@@ -540,6 +565,7 @@ def _load_heartbeat_from_env(
         claim_provider_zone=advertised_zone,
         dns_zone=publish_zone,
         seed_zones=seed_zones,
+        public_seed_urls=public_seed_urls,
     )
     # Cluster peer harvest: when ``DMP_SYNC_PEERS`` is set the
     # operator already lists co-cluster peers as comma-separated

--- a/docs/deployment/heartbeat.md
+++ b/docs/deployment/heartbeat.md
@@ -95,6 +95,8 @@ docker run -d --name dnsmesh-node \
 | `DMP_HEARTBEAT_SELF_ENDPOINT` | *(required)* | Public HTTPS URL of this node. No trailing slash. |
 | `DMP_HEARTBEAT_OPERATOR_KEY_PATH` | *(required)* | File with Ed25519 seed (32 raw bytes OR 64-char hex). |
 | `DMP_HEARTBEAT_SEEDS` | *(empty)* | Comma-list of peer HTTPS URLs to bootstrap gossip from. Empty is valid (relies on cluster peers + inbound gossip). |
+| `DMP_HEARTBEAT_PUBLIC_SEED_URLS` | *(canonical project `directory/seeds.txt` on GitHub)* | Comma-list of HTTPS URLs serving a `seeds.txt`-format zone list. Refreshed every 6h; failures preserve the prior cache per URL. The default makes a fresh node discoverable on the federated mesh without operator-supplied peer lists. Override with your own aggregator URL if you don't want outbound traffic to GitHub. **HTTPS-only**, and the resolved host must be a routable public address — loopback / private / link-local / metadata IPs are refused without a network call. |
+| `DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED` | `0` | Truthy disables the public seed fetch entirely. Use for air-gapped or fully self-contained deployments where you only want operator-configured seeds + cluster peers + inbound gossip. |
 | `DMP_HEARTBEAT_INTERVAL_SECONDS` | `300` | Tick cadence. |
 | `DMP_HEARTBEAT_TTL_SECONDS` | `86400` | `exp - ts` on emitted heartbeats. |
 | `DMP_HEARTBEAT_MAX_PEERS` | `25` | Outbound fan-out cap per tick. |

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -1355,7 +1355,9 @@ class TestPublicSeedFetch:
         assert "seedbravo.example" in zones
 
     def test_comments_and_blank_lines_ignored(self, store, transport, now) -> None:
-        body = b"# leading comment\n\nzone-a.example\n# inline comment\nzone-b.example\n\n"
+        body = (
+            b"# leading comment\n\nzone-a.example\n# inline comment\nzone-b.example\n\n"
+        )
         url = "https://public.example/seeds.txt"
         cfg = HeartbeatWorkerConfig(
             self_endpoint="https://self.example.com",
@@ -1467,9 +1469,7 @@ class TestPublicSeedFetch:
         worker._build_seed_zones()
         assert "keep.example" in worker._public_seed_zones
 
-    def test_self_zone_filtered_from_public_seeds(
-        self, store, transport, now
-    ) -> None:
+    def test_self_zone_filtered_from_public_seeds(self, store, transport, now) -> None:
         # If the project seeds list happens to include this node's
         # own zone, we must not harvest ourselves.
         url = "https://public.example/seeds.txt"
@@ -1492,9 +1492,7 @@ class TestPublicSeedFetch:
         assert "self.example" not in zones
         assert "someoneelse.example" in zones
 
-    def test_empty_public_seed_urls_skips_fetcher(
-        self, store, transport, now
-    ) -> None:
+    def test_empty_public_seed_urls_skips_fetcher(self, store, transport, now) -> None:
         # Operator opted out (DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED=1):
         # the worker must not invoke the fetcher at all, otherwise an
         # explicit opt-out would still hit the network.

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -1306,3 +1306,217 @@ class TestLifecycle:
         worker.start()
         time.sleep(0.05)
         worker.stop(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# #79 — public-seed-URL refresh.
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSeedFetch:
+    """Worker periodically fetches a public seeds.txt-format URL and
+    merges discovered zones into the harvest list. Failures preserve
+    the previous cache."""
+
+    @staticmethod
+    def _fake_fetcher(url_to_body: dict):
+        """Build a fetcher that returns ``url_to_body[url]`` (bytes) or
+        ``None`` when the URL maps to ``None`` (simulating a network
+        failure). Raises on truly missing URLs so misconfigured tests
+        surface loudly."""
+
+        def fetcher(url: str, _timeout: float, _max_bytes: int):
+            if url not in url_to_body:
+                raise AssertionError(f"unexpected URL fetched: {url}")
+            return url_to_body[url]
+
+        return fetcher
+
+    def test_fetched_zones_appear_in_harvest_list(self, store, transport, now) -> None:
+        body = b"# project seeds\nseedalpha.example\nseedbravo.example\n"
+        url = "https://public.example/seeds.txt"
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            seed_zones=(),
+            public_seed_urls=(url,),
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=self._fake_fetcher({url: body}),
+        )
+        zones = worker._build_seed_zones()
+        assert "seedalpha.example" in zones
+        assert "seedbravo.example" in zones
+
+    def test_comments_and_blank_lines_ignored(self, store, transport, now) -> None:
+        body = b"# leading comment\n\nzone-a.example\n# inline comment\nzone-b.example\n\n"
+        url = "https://public.example/seeds.txt"
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url,),
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=self._fake_fetcher({url: body}),
+        )
+        zones = worker._build_seed_zones()
+        assert "zone-a.example" in zones
+        assert "zone-b.example" in zones
+        # No bogus zones from the comment lines.
+        assert "leading" not in zones
+        assert "inline" not in zones
+
+    def test_legacy_url_form_normalized(self, store, transport, now) -> None:
+        # Pre-0.5.0 seeds.txt entries occasionally still carry a
+        # scheme prefix. `_zone_from_seed` strips it; verify the
+        # public-seed path uses the same normalizer the env-seed path does.
+        body = b"https://legacy.example:8443\n"
+        url = "https://public.example/seeds.txt"
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url,),
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=self._fake_fetcher({url: body}),
+        )
+        zones = worker._build_seed_zones()
+        assert "legacy.example" in zones
+
+    def test_refresh_is_rate_limited(self, store, transport, now) -> None:
+        # Fetcher counts how many times it gets called. The first
+        # tick triggers a fetch; subsequent ticks within the refresh
+        # window must NOT re-fetch.
+        url = "https://public.example/seeds.txt"
+        body = b"rate-limit.example\n"
+        calls = {"n": 0}
+
+        def counting_fetcher(u, _t, _m):
+            calls["n"] += 1
+            return body
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url,),
+            public_seed_refresh_seconds=3600,
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=counting_fetcher,
+        )
+        worker._build_seed_zones()
+        worker._build_seed_zones()
+        worker._build_seed_zones()
+        assert calls["n"] == 1
+
+    def test_fetch_failure_preserves_previous_cache(
+        self, store, transport, now
+    ) -> None:
+        # First fetch succeeds; verify the cache populates. Then a
+        # second refresh (forced by aging the cache timestamp) returns
+        # None for every URL; cache must persist with the prior zones.
+        url = "https://public.example/seeds.txt"
+        bodies = [b"keep.example\n", None]
+
+        def stepping_fetcher(u, _t, _m):
+            return bodies.pop(0) if bodies else None
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url,),
+            public_seed_refresh_seconds=1,
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=stepping_fetcher,
+        )
+        worker._build_seed_zones()
+        assert "keep.example" in worker._public_seed_zones
+        # Force the next refresh by aging the cache timestamp.
+        worker._public_seed_last_fetch = 0
+        worker._build_seed_zones()
+        assert "keep.example" in worker._public_seed_zones
+
+    def test_self_zone_filtered_from_public_seeds(
+        self, store, transport, now
+    ) -> None:
+        # If the project seeds list happens to include this node's
+        # own zone, we must not harvest ourselves.
+        url = "https://public.example/seeds.txt"
+        body = b"self.example\nsomeoneelse.example\n"
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url,),
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=self._fake_fetcher({url: body}),
+        )
+        zones = worker._build_seed_zones()
+        assert "self.example" not in zones
+        assert "someoneelse.example" in zones
+
+    def test_empty_public_seed_urls_skips_fetcher(
+        self, store, transport, now
+    ) -> None:
+        # Operator opted out (DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED=1):
+        # the worker must not invoke the fetcher at all, otherwise an
+        # explicit opt-out would still hit the network.
+        calls = {"n": 0}
+
+        def must_not_be_called(u, _t, _m):
+            calls["n"] += 1
+            return None
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(),
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=must_not_be_called,
+        )
+        worker._build_seed_zones()
+        assert calls["n"] == 0

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -1463,11 +1463,11 @@ class TestPublicSeedFetch:
             public_seed_fetcher=stepping_fetcher,
         )
         worker._build_seed_zones()
-        assert "keep.example" in worker._public_seed_zones
+        assert "keep.example" in worker._public_seed_zones[url]
         # Force the next refresh by aging the cache timestamp.
         worker._public_seed_last_fetch = 0
         worker._build_seed_zones()
-        assert "keep.example" in worker._public_seed_zones
+        assert "keep.example" in worker._public_seed_zones[url]
 
     def test_self_zone_filtered_from_public_seeds(self, store, transport, now) -> None:
         # If the project seeds list happens to include this node's
@@ -1518,3 +1518,216 @@ class TestPublicSeedFetch:
         )
         worker._build_seed_zones()
         assert calls["n"] == 0
+
+    def test_partial_failure_preserves_other_url_cache(
+        self, store, transport, now
+    ) -> None:
+        # Two URLs both succeed on the first refresh. On the second
+        # refresh URL A still serves zones but URL B returns None.
+        # URL B's previous zones must NOT be dropped, otherwise
+        # operators with mirrored seed lists lose half their bootstrap
+        # coverage every time one mirror flakes.
+        url_a = "https://public-a.example/seeds.txt"
+        url_b = "https://public-b.example/seeds.txt"
+        responses = {
+            url_a: [b"zone-a1.example\n", b"zone-a2.example\n"],
+            url_b: [b"zone-b.example\n", None],
+        }
+
+        def stepping_fetcher(u, _t, _m):
+            queue = responses[u]
+            return queue.pop(0) if queue else None
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url_a, url_b),
+            public_seed_refresh_seconds=1,
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=stepping_fetcher,
+        )
+        worker._build_seed_zones()
+        assert worker._public_seed_zones[url_a] == ["zone-a1.example"]
+        assert worker._public_seed_zones[url_b] == ["zone-b.example"]
+        # Force the second refresh: URL A returns its second body,
+        # URL B returns None.
+        worker._public_seed_last_fetch = 0
+        zones = worker._build_seed_zones()
+        # URL A updated.
+        assert worker._public_seed_zones[url_a] == ["zone-a2.example"]
+        # URL B preserved across the partial-failure refresh cycle.
+        assert worker._public_seed_zones[url_b] == ["zone-b.example"]
+        # Final harvest list still includes BOTH.
+        assert "zone-a2.example" in zones
+        assert "zone-b.example" in zones
+
+    def test_total_failure_respects_refresh_window(self, store, transport, now) -> None:
+        # All URLs fail every refresh. The worker must not retry on
+        # every tick — the refresh window applies to failed attempts
+        # too. Otherwise a persistent outage at the source hammers
+        # GitHub raw / the operator's mirror endpoint, defeating the
+        # whole point of the slow cadence.
+        url = "https://public.example/seeds.txt"
+        calls = {"n": 0}
+
+        def always_fails(u, _t, _m):
+            calls["n"] += 1
+            return None
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url,),
+            public_seed_refresh_seconds=3600,
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=always_fails,
+        )
+        worker._build_seed_zones()
+        worker._build_seed_zones()
+        worker._build_seed_zones()
+        assert calls["n"] == 1, (
+            "failed refresh must still update timestamp; otherwise every "
+            "tick retries and defeats the rate-limit"
+        )
+
+    def test_removed_url_evicted_from_cache(self, store, transport, now) -> None:
+        # Operator removes a URL from DMP_HEARTBEAT_PUBLIC_SEED_URLS
+        # via a config reload (in production this is process restart,
+        # but the eviction logic is the same path). The cache slot
+        # for the removed URL must be dropped so we don't keep
+        # harvesting stale zones forever.
+        url_a = "https://public-a.example/seeds.txt"
+        url_b = "https://public-b.example/seeds.txt"
+        bodies = {url_a: b"zone-a.example\n", url_b: b"zone-b.example\n"}
+
+        def fetcher(u, _t, _m):
+            return bodies.get(u)
+
+        cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url_a, url_b),
+            public_seed_refresh_seconds=1,
+        )
+        worker = HeartbeatWorker(
+            cfg,
+            _signer(),
+            store,
+            record_writer=transport,
+            dns_reader=transport,
+            public_seed_fetcher=fetcher,
+        )
+        worker._build_seed_zones()
+        assert url_a in worker._public_seed_zones
+        assert url_b in worker._public_seed_zones
+        # Operator drops url_b. Simulate by swapping the frozen cfg
+        # for one with a shorter list and forcing a refresh.
+        worker._cfg = HeartbeatWorkerConfig(
+            self_endpoint="https://self.example.com",
+            version="0.1.0",
+            dns_zone="self.example",
+            public_seed_urls=(url_a,),
+            public_seed_refresh_seconds=1,
+        )
+        worker._public_seed_last_fetch = 0
+        worker._build_seed_zones()
+        assert url_a in worker._public_seed_zones
+        assert url_b not in worker._public_seed_zones
+
+
+# ---------------------------------------------------------------------------
+# #79 — public-seed URL safety screen (HTTPS-only, no SSRF targets).
+# ---------------------------------------------------------------------------
+
+
+class TestPublicSeedUrlSafety:
+    """``_is_safe_public_seed_url`` blocks URLs the default fetcher
+    must never call: ``http://``, loopback, private/link-local, and
+    the cloud-metadata endpoint. The screen is also gated AT the
+    default fetcher so an operator-supplied env override can't bypass
+    it (no network call when the URL is unsafe)."""
+
+    def test_http_scheme_rejected(self) -> None:
+        from dmp.server.heartbeat_worker import _is_safe_public_seed_url
+
+        assert _is_safe_public_seed_url("http://example.com/seeds.txt") is False
+
+    def test_https_public_host_accepted(self, monkeypatch) -> None:
+        # Mock the DNS resolver so the test doesn't depend on external
+        # DNS. 1.1.1.1 (Cloudflare DNS) is a globally-routable public
+        # address — not in any of the reject categories (loopback,
+        # private, link-local, multicast, reserved, unspecified).
+        import socket as _socket
+
+        from dmp.server.heartbeat_worker import _is_safe_public_seed_url
+
+        def fake_getaddrinfo(host, port, type=_socket.SOCK_STREAM):
+            return [(_socket.AF_INET, _socket.SOCK_STREAM, 0, "", ("1.1.1.1", 0))]
+
+        monkeypatch.setattr(
+            "dmp.server.heartbeat_worker.socket.getaddrinfo", fake_getaddrinfo
+        )
+        assert _is_safe_public_seed_url("https://public.example/seeds.txt") is True
+
+    def test_loopback_host_rejected(self, monkeypatch) -> None:
+        # Mock to be explicit about the resolved address so the test
+        # is hermetic — ``localhost`` happens to resolve to 127.0.0.1
+        # on most systems but we don't want to depend on /etc/hosts.
+        import socket as _socket
+
+        from dmp.server.heartbeat_worker import _is_safe_public_seed_url
+
+        def fake_getaddrinfo(host, port, type=_socket.SOCK_STREAM):
+            return [(_socket.AF_INET, _socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0))]
+
+        monkeypatch.setattr(
+            "dmp.server.heartbeat_worker.socket.getaddrinfo", fake_getaddrinfo
+        )
+        assert _is_safe_public_seed_url("https://localhost/seeds.txt") is False
+
+    def test_metadata_endpoint_rejected(self) -> None:
+        from dmp.server.heartbeat_worker import _is_safe_public_seed_url
+
+        # 169.254.169.254 = AWS/GCP/Azure instance metadata. Famous
+        # SSRF target. Caught by the link-local check but worth
+        # asserting explicitly so a future refactor that drops
+        # link-local doesn't silently re-open it. The hostname IS the
+        # IP, so getaddrinfo returns it directly — no DNS dependency.
+        assert (
+            _is_safe_public_seed_url("https://169.254.169.254/latest/meta-data/")
+            is False
+        )
+
+    def test_private_rfc1918_rejected(self) -> None:
+        from dmp.server.heartbeat_worker import _is_safe_public_seed_url
+
+        assert _is_safe_public_seed_url("https://10.0.0.1/seeds.txt") is False
+        assert _is_safe_public_seed_url("https://192.168.1.1/seeds.txt") is False
+        assert _is_safe_public_seed_url("https://172.16.0.1/seeds.txt") is False
+
+    def test_unsafe_url_makes_default_fetcher_no_op(self) -> None:
+        # The default fetcher MUST refuse before importing requests,
+        # so the safety screen is unbypassable via env override.
+        from dmp.server.heartbeat_worker import _default_public_seed_fetcher
+
+        out = _default_public_seed_fetcher(
+            "http://attacker.example/seeds.txt",
+            timeout_seconds=1.0,
+            max_bytes=1024,
+        )
+        assert out is None


### PR DESCRIPTION
## Summary

Closes #79. Lets a freshly-installed node bootstrap onto the federated mesh without operator-supplied peer lists. The heartbeat worker now refreshes its seed-zone list from a public HTTPS URL on a slow schedule (default: every 6h, fetched lazily alongside the regular harvest cycle).

The default source is the curated `directory/seeds.txt` already shipped in this repo, so the out-of-the-box experience after `pip install dnsmesh-node && dmp-node` is: the worker pulls the published seed zones, unions them with any cluster peers + gossip-learned zones, and starts joining the seen-graph automatically.

## Behaviour & config

| Env var | Default | Effect |
|---|---|---|
| `DMP_HEARTBEAT_PUBLIC_SEED_URLS` | (unset) | Comma-separated override URLs. Useful for private aggregators. |
| `DMP_HEARTBEAT_PUBLIC_SEED_URLS_DISABLED` | (unset) | Set to `1` to disable the fetch entirely. Air-gapped / self-contained deployments. |
| Default fetch URL | `https://raw.githubusercontent.com/oscarvalenzuelab/DNSMeshProtocol/main/directory/seeds.txt` | Used when neither env var is set. |

## Safety properties

- Response body capped at **64 KiB** before parsing.
- Fetch timeout: **5 s**.
- Refresh rate-limited to **once per 6h** per process.
- Parser drops comments, blank lines, and the node's own zone (no self-gossip).
- Legacy `https://...` entries normalised — host part extracted — so the file format stays compatible with the existing aggregator script.
- A failed fetch **preserves the previous cache** rather than wiping the harvest list, so a transient outage at the seed host cannot orphan running nodes.

## Test plan

- [x] `TestPublicSeedFetch` (7 new tests): happy path, comment/blank handling, legacy URL normalisation, rate limiting, fetch-failure cache preservation, self-zone filtering, disabled-by-config path.
- [x] Full local suite: **1710 passed / 13 skipped** in 205s.
- [ ] CI green.