### PR TITLE
fix(heartbeat): refuse HTTP redirects in public-seed fetcher to close SSRF gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   transient outage at the seed host cannot orphan running nodes.
   Closes #79.
 
+### Security
+
+- Public-seed fetcher now refuses HTTP redirects. The SSRF screen
+  added in #79 only validates the original URL; without this fix
+  a hostile public HTTPS seed host could 302 to a private / loopback
+  / link-local target and `requests` would follow it, defeating the
+  screen. Redirects now return as a fetch miss and the operator
+  must reconfigure the URL to its final destination.
+
 ## [0.7.5] — 2026-05-15 — DMPv2 plaintext envelope + identity-record versions
 
 Unblocks cross-zone first-contact delivery. Two unpinned identities

--- a/dmp/server/heartbeat_worker.py
+++ b/dmp/server/heartbeat_worker.py
@@ -227,11 +227,32 @@ def _default_public_seed_fetcher(
         log.warning("requests not installed; cannot fetch public seeds from %s", url)
         return None
     try:
-        resp = requests.get(url, timeout=timeout_seconds, stream=True)
+        # ``allow_redirects=False`` is load-bearing. The SSRF screen
+        # in ``_is_safe_public_seed_url`` only validates the ORIGINAL
+        # URL; a hostile public HTTPS seed host could otherwise return
+        # ``302 Location: http://169.254.169.254/...`` and ``requests``
+        # would follow it, defeating the screen. Force the caller to
+        # configure the canonical URL directly.
+        resp = requests.get(
+            url, timeout=timeout_seconds, stream=True, allow_redirects=False
+        )
     except Exception as exc:  # noqa: BLE001 — network failures are best-effort
         log.warning("public seed fetch failed for %s: %s", url, exc)
         return None
     try:
+        if 300 <= resp.status_code < 400:
+            # Redirects are refused (see SSRF rationale above). Treat
+            # as a fetch miss so the per-URL cache slot is preserved;
+            # the operator should reconfigure the URL to point at the
+            # final destination.
+            log.warning(
+                "public seed fetch for %s returned redirect HTTP %d "
+                "(Location: %r); SSRF screen would be bypassed — refusing",
+                url,
+                resp.status_code,
+                resp.headers.get("Location", "<missing>"),
+            )
+            return None
         if resp.status_code != 200:
             log.warning(
                 "public seed fetch for %s returned HTTP %d; skipping",

--- a/tests/test_heartbeat_worker.py
+++ b/tests/test_heartbeat_worker.py
@@ -1731,3 +1731,53 @@ class TestPublicSeedUrlSafety:
             max_bytes=1024,
         )
         assert out is None
+
+    def test_redirect_is_refused_so_ssrf_screen_holds(self, monkeypatch) -> None:
+        # The safety screen only validates the ORIGINAL URL. If
+        # ``requests.get`` followed redirects, a hostile public HTTPS
+        # seed host could 302 to ``http://169.254.169.254/...`` and
+        # bypass the screen. Confirm the fetcher disables redirects
+        # AND treats a 3xx response as a fetch miss.
+        import socket as _socket
+
+        from dmp.server.heartbeat_worker import _default_public_seed_fetcher
+
+        # Public IP for the original URL so the safety screen passes.
+        def fake_getaddrinfo(host, port, type=_socket.SOCK_STREAM):
+            return [(_socket.AF_INET, _socket.SOCK_STREAM, 0, "", ("1.1.1.1", 0))]
+
+        monkeypatch.setattr(
+            "dmp.server.heartbeat_worker.socket.getaddrinfo", fake_getaddrinfo
+        )
+
+        captured: dict = {}
+
+        class FakeResponse:
+            status_code = 302
+            headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+
+            def iter_content(self, chunk_size: int):  # pragma: no cover
+                raise AssertionError("redirect path must not read body")
+
+            def close(self) -> None:
+                pass
+
+        class FakeRequests:
+            @staticmethod
+            def get(url, **kwargs):
+                captured["url"] = url
+                captured["kwargs"] = kwargs
+                return FakeResponse()
+
+        monkeypatch.setitem(__import__("sys").modules, "requests", FakeRequests)
+
+        out = _default_public_seed_fetcher(
+            "https://public.example/seeds.txt",
+            timeout_seconds=1.0,
+            max_bytes=1024,
+        )
+        assert out is None
+        # The fetcher MUST pass ``allow_redirects=False`` — that's the
+        # whole point of this defense. A future refactor that drops
+        # the flag would silently re-open the SSRF bypass.
+        assert captured["kwargs"].get("allow_redirects") is False


### PR DESCRIPTION
## Summary

Follow-up to #115. The SSRF screen added in that PR only validates the original URL, but `requests.get` defaults to `allow_redirects=True` — so a hostile public HTTPS seed host could return `302 Location: http://169.254.169.254/...` and `requests` would follow it, defeating the whole screen.

This PR sets `allow_redirects=False` and treats any 3xx response as a fetch miss with a logged warning. The default URL (`raw.githubusercontent.com/.../directory/seeds.txt`) serves the file directly, so production behavior is unchanged.

## Test plan

- [x] `test_redirect_is_refused_so_ssrf_screen_holds`: mocks `requests` to return a 302 pointing at 169.254.169.254 and asserts the fetcher refuses without reading the body. Also asserts the `allow_redirects=False` kwarg is actually passed — that flag is load-bearing.
- [x] Full heartbeat suite passes (48 tests, +1 from #115).
- [ ] CI green.