### PR TITLE
fix(deps): bump idna from 3.12 to 3.15 (CVE-2026-45409)

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -328,9 +328,9 @@ dnspython==2.8.0 \
     --hash=sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af \
     --hash=sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f
     # via -r requirements.txt
-idna==3.12 \
-    --hash=sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67 \
-    --hash=sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254
+idna==3.15 \
+    --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \
+    --hash=sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc
     # via requests
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \


### PR DESCRIPTION
## Summary

- Bumps `idna` from 3.12 to 3.15 in `requirements.lock`
- Fixes CVE-2026-45409: specially crafted inputs to `idna.encode()` bypass the CVE-2024-3651 fix

## Test plan

- [ ] `pip-audit` security job passes on main after merge