### PR TITLE
fix(security): bump click + setuptools in dev lockfile (pip-audit)

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -356,9 +356,9 @@ charset-normalizer==3.4.7 \
     --hash=sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79 \
     --hash=sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464
     # via requests
-click==8.3.2 \
-    --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
-    --hash=sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d
+click==8.3.3 \
+    --hash=sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613 \
+    --hash=sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2
     # via
     #   black
     #   pip-tools
@@ -1178,7 +1178,7 @@ pip==26.1.2 \
     # via
     #   pip-api
     #   pip-tools
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+setuptools==83.0.0 \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3 \
+    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef
     # via pip-tools


### PR DESCRIPTION
Resolves the failing `security` workflow (pip-audit --strict on the dev lockfile):
- `click` 8.3.2 → 8.3.3 (PYSEC-2026-2132)
- `setuptools` 82.0.1 → 83.0.0 (PYSEC-2026-3447)

Both are dev/build-only deps (via pip-tools); `requirements.lock` (runtime) is unaffected. Hashes updated from PyPI; surgical change to only these two entries.